### PR TITLE
Add a `rollback` command to the CLI

### DIFF
--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"pg-roll/pkg/migrations"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var rollbackCmd = &cobra.Command{
+	Use:   "rollback <file>",
+	Short: "Roll back an ongoing migration",
+	Long:  "Roll back an ongoing migration. This will revert the changes made by the migration.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fileName := args[0]
+
+		m, err := migrations.New(cmd.Context(), PGURL)
+		if err != nil {
+			return err
+		}
+		defer m.Close()
+
+		ops, err := migrations.ReadMigrationFile(args[0])
+		if err != nil {
+			return fmt.Errorf("reading migration file: %w", err)
+		}
+
+		version := strings.TrimSuffix(filepath.Base(fileName), filepath.Ext(fileName))
+
+		err = m.Rollback(cmd.Context(), version, ops)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Migration rolled back. Changes made by %q have been reverted.\n", version)
+		return nil
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ func Execute() error {
 	// register subcommands
 	rootCmd.AddCommand(startCmd)
 	rootCmd.AddCommand(completeCmd)
+	rootCmd.AddCommand(rollbackCmd)
 	rootCmd.AddCommand(analyzeCmd)
 
 	return rootCmd.Execute()


### PR DESCRIPTION
Add a `rollback` command to the CLI.

Use the rollback functionality added to the `migrations` package in #5 to perform the rollback.

Example:

```bash
go run . start examples/01_create_tables.json 
go run . rollback examples/01_create_tables.json 
```
The schema for the `01_create_table` version is removed from the database along with the underlying tables.

⚠️ We currently don't have a way to ensure that only uncompleted migrations can be rolled back. Once we have some state in the db recording with migrations have been applied, we can revisit this command to ensure completed migrations can't be rolled back ⚠️ 