### PR TITLE
Fix tests referencing from GitHub branch protections

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -73,7 +73,7 @@ branches:
 
       # Required. The list of status checks to require in order to merge into this branch
       contexts:
-      - tests
+      - test
 
     # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
     required_pull_request_reviews:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,8 @@
-name: tests
+name: Run tests
 on: [push]
 jobs:
   test:
-    name: 'Run tests'
+    name: test
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Settings file was incorrectly referencing a non existing job