### PR TITLE
Qualify versioned schema names

### DIFF
--- a/pkg/roll/execute_test.go
+++ b/pkg/roll/execute_test.go
@@ -52,7 +52,7 @@ func TestPreviousVersionIsDroppedAfterMigrationCompletion(t *testing.T) {
       SELECT 1
       FROM pg_catalog.pg_namespace
       WHERE nspname = $1
-    )`, roll.SchemaName(schema, firstVersion)).Scan(&exists)
+    )`, roll.VersionedSchemaName(schema, firstVersion)).Scan(&exists)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Close https://github.com/xataio/pg-roll/issues/15.

Qualify versioned schema with the name of the schema they represent.

For a migration called `01_create_table` running in the `public` schema, the versioned schema is called `public_01_create_table`.