### PR TITLE
Add json lint step to the pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,5 +44,8 @@ jobs:
     - name: Ensure JSON examples are formatted
       run: |
         for file in ./examples/*.json; do
-          diff <(cat $file | jq) <(cat $file)
+          if ! diff <(cat $file | jq) <(cat $file); then
+            echo "$file is not formatted: run 'cat $file | jq' to fix";
+            exit 1;
+          fi
         done


### PR DESCRIPTION
Add a step to the `lint` job in the build workflow to check that all the example `.json` migration files are consistently formatted.

The step fails as of this PR. It will pass when rebased on to https://github.com/xataio/pg-roll/pull/21.