### PR TITLE
Sort keys before constructing `INSERT` statement in `MustInsert`

### DIFF
--- a/pkg/migrations/op_common_test.go
+++ b/pkg/migrations/op_common_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 
 	"pg-roll/pkg/migrations"
 	"pg-roll/pkg/roll"
@@ -213,19 +214,22 @@ func MustInsert(t *testing.T, db *sql.DB, schema, version, table string, record 
 	t.Helper()
 	versionSchema := roll.VersionedSchemaName(schema, version)
 
+	cols := maps.Keys(record)
+	slices.Sort(cols)
+
 	recordStr := "("
-	for i, k := range maps.Keys(record) {
+	for i, c := range cols {
 		if i > 0 {
 			recordStr += ", "
 		}
-		recordStr += k
+		recordStr += c
 	}
 	recordStr += ") VALUES ("
-	for i, v := range maps.Values(record) {
+	for i, c := range cols {
 		if i > 0 {
 			recordStr += ", "
 		}
-		recordStr += fmt.Sprintf("'%s'", v)
+		recordStr += fmt.Sprintf("'%s'", record[c])
 	}
 	recordStr += ")"
 


### PR DESCRIPTION
Sort the keys in the record map before constructing the `INSERT` statement, to ensure a consistent ordering of the column names and values in the `INSERT` statement.

For example inserting records into a `users` table could sometimes generate these two `INSERT` statements depending how the map was iterated:

```
INSERT INTO public_02_add_column.users (name, age) VALUES ('21', 'Bob')
INSERT INTO public_02_add_column.users (name, age) VALUES ('Bob', '21')
```

the first of which will fail (assuming the `age` field as type `integer`).

This was causing flaky tests when inserting values into multiple columns.