### PR TITLE
Add a `--complete` flag to to the `start` command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,11 +42,8 @@ func NewRoll(ctx context.Context) (*roll.Roll, error) {
 
 // Execute executes the root command.
 func Execute() error {
-	// add flags to subcommands
-	startCmd.Flags().BoolVarP(&startOpts.complete, "complete", "c", false, "complete the migration immediately")
-
 	// register subcommands
-	rootCmd.AddCommand(startCmd)
+	rootCmd.AddCommand(startCmd())
 	rootCmd.AddCommand(completeCmd)
 	rootCmd.AddCommand(rollbackCmd)
 	rootCmd.AddCommand(analyzeCmd)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -10,42 +10,46 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var startOpts struct {
-	complete bool
-}
+func startCmd() *cobra.Command {
+	var complete bool
 
-var startCmd = &cobra.Command{
-	Use:   "start <file>",
-	Short: "Start a migration for the operations present in the given file",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		fileName := args[0]
+	startCmd := &cobra.Command{
+		Use:   "start <file>",
+		Short: "Start a migration for the operations present in the given file",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fileName := args[0]
 
-		m, err := NewRoll(cmd.Context())
-		if err != nil {
-			return err
-		}
-		defer m.Close()
-
-		migration, err := migrations.ReadMigrationFile(args[0])
-		if err != nil {
-			return fmt.Errorf("reading migration file: %w", err)
-		}
-
-		version := strings.TrimSuffix(filepath.Base(fileName), filepath.Ext(fileName))
-
-		err = m.Start(cmd.Context(), migration)
-		if err != nil {
-			return err
-		}
-
-		if startOpts.complete {
-			if err = m.Complete(cmd.Context()); err != nil {
+			m, err := NewRoll(cmd.Context())
+			if err != nil {
 				return err
 			}
-		}
+			defer m.Close()
 
-		fmt.Printf("Migration successful!, new version of the schema available under postgres '%s' schema\n", version)
-		return nil
-	},
+			migration, err := migrations.ReadMigrationFile(args[0])
+			if err != nil {
+				return fmt.Errorf("reading migration file: %w", err)
+			}
+
+			version := strings.TrimSuffix(filepath.Base(fileName), filepath.Ext(fileName))
+
+			err = m.Start(cmd.Context(), migration)
+			if err != nil {
+				return err
+			}
+
+			if complete {
+				if err = m.Complete(cmd.Context()); err != nil {
+					return err
+				}
+			}
+
+			fmt.Printf("Migration successful!, new version of the schema available under postgres '%s' schema\n", version)
+			return nil
+		},
+	}
+
+	startCmd.Flags().BoolVarP(&complete, "complete", "c", false, "Mark the migration as complete")
+
+	return startCmd
 }


### PR DESCRIPTION
If set, complete the migration immediately after starting it.

For example:

```bash
go run start examples/02_create_another_table.json --complete
```

Completes the migration immediately, without the user having to run `complete`.