### PR TITLE
Delete trigger and trigger function on add column operation rollback

### DIFF
--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -61,7 +61,7 @@ func (o *OpAddColumn) Rollback(ctx context.Context, conn *sql.DB) error {
 	}
 
 	_, err = conn.ExecContext(ctx, fmt.Sprintf("DROP FUNCTION IF EXISTS %s CASCADE",
-		pq.QuoteIdentifier(triggerFunctionName(o))))
+		pq.QuoteIdentifier(TriggerFunctionName(o.Table, o.Column.Name))))
 	return err
 }
 
@@ -97,8 +97,6 @@ func addColumn(ctx context.Context, conn *sql.DB, o OpAddColumn, t *schema.Table
 }
 
 func createTrigger(ctx context.Context, conn *sql.DB, o *OpAddColumn, schemaName, stateSchema string, s *schema.Schema) error {
-	triggerName := triggerFunctionName
-
 	// Generate the SQL declarations for the trigger function
 	// This results in declarations like:
 	//   col1 table.col1%TYPE := NEW.col1;
@@ -135,7 +133,7 @@ func createTrigger(ctx context.Context, conn *sql.DB, o *OpAddColumn, schemaName
 
       RETURN NEW;
     END; $$`,
-		pq.QuoteIdentifier(triggerFunctionName(o)),
+		pq.QuoteIdentifier(TriggerFunctionName(o.Table, o.Column.Name)),
 		pq.QuoteIdentifier(TemporaryName(o.Column.Name)),
 		*o.Up,
 		sqlDeclarations(s),
@@ -152,9 +150,9 @@ func createTrigger(ctx context.Context, conn *sql.DB, o *OpAddColumn, schemaName
     ON %[2]s
     FOR EACH ROW
     EXECUTE PROCEDURE %[3]s();`,
-		pq.QuoteIdentifier(triggerName(o)),
+		pq.QuoteIdentifier(TriggerName(o.Table, o.Column.Name)),
 		pq.QuoteIdentifier(o.Table),
-		pq.QuoteIdentifier(triggerFunctionName(o)))
+		pq.QuoteIdentifier(TriggerFunctionName(o.Table, o.Column.Name)))
 
 	_, err = conn.ExecContext(ctx, trigger)
 	if err != nil {
@@ -164,6 +162,10 @@ func createTrigger(ctx context.Context, conn *sql.DB, o *OpAddColumn, schemaName
 	return nil
 }
 
-func triggerFunctionName(o *OpAddColumn) string {
-	return "_pgroll_add_column_" + o.Table + "_" + o.Column.Name
+func TriggerFunctionName(tableName, columnName string) string {
+	return "_pgroll_add_column_" + tableName + "_" + columnName
+}
+
+func TriggerName(tableName, columnName string) string {
+	return TriggerFunctionName(tableName, columnName)
 }

--- a/pkg/migrations/op_add_column_test.go
+++ b/pkg/migrations/op_add_column_test.go
@@ -169,7 +169,13 @@ func TestAddColumnWithUpSql(t *testing.T) {
 			}, res)
 		},
 		afterRollback: func(t *testing.T, db *sql.DB) {
-			// TODO check that the trigger created by the start operation has been removed
+			// The trigger function has been dropped.
+			triggerFnName := migrations.TriggerFunctionName("products", "description")
+			FunctionMustNotExist(t, db, "public", triggerFnName)
+
+			// The trigger has been dropped.
+			triggerName := migrations.TriggerName("products", "description")
+			TriggerMustNotExist(t, db, "public", "products", triggerName)
 		},
 		afterComplete: func(t *testing.T, db *sql.DB) {
 		},


### PR DESCRIPTION
Support for `up` SQL in  **add column** operations was added in #34 

When such an **add column** operation runs, a trigger (and therefore a trigger function) is created to implement running `up` SQL on insertions to the old schema.

This PR ensures that the trigger and function are dropped when the migration is rolled back:

* Extract two functions so that the rollback operations can name the function to be dropped.
* Add necessary assertion functions to the common test infra.
* Add an `afterRollback` hook to the existing test for `up` SQL.