### PR TITLE
Implement `Rollback` for adding columns with `NOT NULL` and no `DEFAULT`

### DIFF
--- a/pkg/migrations/op_add_column_test.go
+++ b/pkg/migrations/op_add_column_test.go
@@ -242,6 +242,9 @@ func TestAddNotNullColumnWithNoDefault(t *testing.T) {
 			})
 		},
 		afterRollback: func(t *testing.T, db *sql.DB) {
+			// the check constraint has been dropped.
+			constraintname := migrations.NotNullConstraintName("description")
+			ConstraintMustNotExist(t, db, "public", "products", constraintname)
 		},
 		afterComplete: func(t *testing.T, db *sql.DB) {
 		},

--- a/pkg/migrations/op_common_test.go
+++ b/pkg/migrations/op_common_test.go
@@ -233,6 +233,32 @@ func TriggerMustExist(t *testing.T, db *sql.DB, schema, table, trigger string) {
 	}
 }
 
+func ConstraintMustNotExist(t *testing.T, db *sql.DB, schema, table, constraint string) {
+	t.Helper()
+	if constraintExists(t, db, schema, table, constraint) {
+		t.Fatalf("Expected constraint to not exist")
+	}
+}
+
+func constraintExists(t *testing.T, db *sql.DB, schema, table, constraint string) bool {
+	t.Helper()
+
+	var exists bool
+	err := db.QueryRow(`
+    SELECT EXISTS (
+      SELECT 1
+      FROM pg_catalog.pg_constraint
+      WHERE conrelid = $1::regclass
+      AND conname = $2
+    )`,
+		fmt.Sprintf("%s.%s", schema, table), constraint).Scan(&exists)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return exists
+}
+
 func triggerExists(t *testing.T, db *sql.DB, schema, table, trigger string) bool {
 	t.Helper()
 


### PR DESCRIPTION
Implement `Rollback` for **add column** operations that add a `NOT NULL` column without a `DEFAULT`.

Support for starting such an operation was added in https://github.com/xataio/pg-roll/pull/37. See that PR for a description of the steps involved.

In order to roll back, there is nothing to be done as the rollback for the **add column** operation already removes the new column, which also removes any constraints defined on the column.

This PR adds an `afterRollback` hook to the tests to verify that the constraint has been dropped.

