### PR TITLE
Pin Go to 1.20.5 to work around testcontainers/Go breakage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.20.5'
 
     - name: Run tests
       run: go test ./...
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.20.5'
         cache: false
 
     - name: golangci-lint


### PR DESCRIPTION
Pin Go to version `1.20.5` to fix [testcontainer](https://golang.testcontainers.org/) tests.

Go `1.20.6` introduced changes in `Host` header parsing ([issue](https://github.com/golang/go/issues/61431)) which breaks `testcontainers-go` ([issue](https://github.com/testcontainers/testcontainers-go/issues/1359)).

Our tests started failing consistently yesterday due to this issue ([example run](https://github.com/xataio/pg-roll/actions/runs/5612153506)).

The suggested workaround until this is resolved upstream is to pin to `1.20.5`.