### PR TITLE
Improve test failure messages

### DIFF
--- a/pkg/migrations/op_common_test.go
+++ b/pkg/migrations/op_common_test.go
@@ -169,42 +169,42 @@ func withMigratorAndConnectionToContainer(t *testing.T, fn func(mig *roll.Roll, 
 func ViewMustExist(t *testing.T, db *sql.DB, schema, version, view string) {
 	t.Helper()
 	if !viewExists(t, db, schema, version, view) {
-		t.Fatalf("Expected view to exist")
+		t.Fatalf("Expected view %q to exist", view)
 	}
 }
 
 func ViewMustNotExist(t *testing.T, db *sql.DB, schema, version, view string) {
 	t.Helper()
 	if viewExists(t, db, schema, version, view) {
-		t.Fatalf("Expected view to not exist")
+		t.Fatalf("Expected view %q to not exist", view)
 	}
 }
 
 func TableMustExist(t *testing.T, db *sql.DB, schema, table string) {
 	t.Helper()
 	if !tableExists(t, db, schema, table) {
-		t.Fatalf("Expected table to exist")
+		t.Fatalf("Expected table %q to exist", table)
 	}
 }
 
 func TableMustNotExist(t *testing.T, db *sql.DB, schema, table string) {
 	t.Helper()
 	if tableExists(t, db, schema, table) {
-		t.Fatalf("Expected table to not exist")
+		t.Fatalf("Expected table %q to not exist", table)
 	}
 }
 
 func ColumnMustExist(t *testing.T, db *sql.DB, schema, table, column string) {
 	t.Helper()
 	if !columnExists(t, db, schema, table, column) {
-		t.Fatalf("Expected column to exist")
+		t.Fatalf("Expected column %q to exist", column)
 	}
 }
 
 func ColumnMustNotExist(t *testing.T, db *sql.DB, schema, table, column string) {
 	t.Helper()
 	if columnExists(t, db, schema, table, column) {
-		t.Fatalf("Expected column to not exist")
+		t.Fatalf("Expected column %q to not exist", column)
 	}
 }
 
@@ -215,52 +215,52 @@ func TableMustHaveColumnCount(t *testing.T, db *sql.DB, schema, table string, n 
 	}
 }
 
-func FunctionMustExist(t *testing.T, db *sql.DB, schema, functionName string) {
+func FunctionMustExist(t *testing.T, db *sql.DB, schema, function string) {
 	t.Helper()
-	if !functionExists(t, db, schema, functionName) {
-		t.Fatalf("Expected function to exist")
+	if !functionExists(t, db, schema, function) {
+		t.Fatalf("Expected function %q to exist", function)
 	}
 }
 
-func FunctionMustNotExist(t *testing.T, db *sql.DB, schema, functionName string) {
+func FunctionMustNotExist(t *testing.T, db *sql.DB, schema, function string) {
 	t.Helper()
-	if functionExists(t, db, schema, functionName) {
-		t.Fatalf("Expected function to not exist")
+	if functionExists(t, db, schema, function) {
+		t.Fatalf("Expected function %q to not exist", function)
 	}
 }
 
 func TriggerMustNotExist(t *testing.T, db *sql.DB, schema, table, trigger string) {
 	t.Helper()
 	if triggerExists(t, db, schema, table, trigger) {
-		t.Fatalf("Expected trigger to not exist")
+		t.Fatalf("Expected trigger %q to not exist", trigger)
 	}
 }
 
 func TriggerMustExist(t *testing.T, db *sql.DB, schema, table, trigger string) {
 	t.Helper()
 	if !triggerExists(t, db, schema, table, trigger) {
-		t.Fatalf("Expected trigger to exist")
+		t.Fatalf("Expected trigger %q to exist", trigger)
 	}
 }
 
 func ConstraintMustNotExist(t *testing.T, db *sql.DB, schema, table, constraint string) {
 	t.Helper()
 	if constraintExists(t, db, schema, table, constraint) {
-		t.Fatalf("Expected constraint to not exist")
+		t.Fatalf("Expected constraint %q to not exist", constraint)
 	}
 }
 
 func IndexMustExist(t *testing.T, db *sql.DB, schema, table, index string) {
 	t.Helper()
 	if !indexExists(t, db, schema, table, index) {
-		t.Fatalf("Expected index to exist")
+		t.Fatalf("Expected index %q to exist", index)
 	}
 }
 
 func IndexMustNotExist(t *testing.T, db *sql.DB, schema, table, index string) {
 	t.Helper()
 	if indexExists(t, db, schema, table, index) {
-		t.Fatalf("Expected index to not exist")
+		t.Fatalf("Expected index %q to not exist", index)
 	}
 }
 


### PR DESCRIPTION
Include the name of the database object that was expected to exist/not exist in test failure messages.