### PR TITLE
Make `(Must|MustNot)Insert` helper functions

### DIFF
--- a/pkg/migrations/op_common_test.go
+++ b/pkg/migrations/op_common_test.go
@@ -423,12 +423,16 @@ func columnExists(t *testing.T, db *sql.DB, schema, table, column string) bool {
 }
 
 func MustInsert(t *testing.T, db *sql.DB, schema, version, table string, record map[string]string) {
+	t.Helper()
+
 	if err := insert(t, db, schema, version, table, record); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func MustNotInsert(t *testing.T, db *sql.DB, schema, version, table string, record map[string]string) {
+	t.Helper()
+
 	if err := insert(t, db, schema, version, table, record); err == nil {
 		t.Fatal("Expected INSERT to fail")
 	}


### PR DESCRIPTION
Failures here should be presented as failures in the caller.