### PR TITLE
Take `up`, `down` as `string` in set `NOT NULL` op

### DIFF
--- a/pkg/migrations/op_set_notnull_test.go
+++ b/pkg/migrations/op_set_notnull_test.go
@@ -51,7 +51,7 @@ func TestSetNotNull(t *testing.T) {
 						&migrations.OpSetNotNull{
 							Table:  "reviews",
 							Column: "review",
-							Up:     ptr("(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)"),
+							Up:     "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
 						},
 					},
 				},
@@ -192,8 +192,8 @@ func TestSetNotNull(t *testing.T) {
 						&migrations.OpSetNotNull{
 							Table:  "reviews",
 							Column: "review",
-							Up:     ptr("(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)"),
-							Down:   ptr("review || ' (from new column)'"),
+							Up:     "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
+							Down:   "review || ' (from new column)'",
 						},
 					},
 				},
@@ -266,7 +266,7 @@ func TestSetNotNullValidation(t *testing.T) {
 						&migrations.OpSetNotNull{
 							Table:  "reviews",
 							Column: "review",
-							Down:   ptr("review"),
+							Down:   "review",
 						},
 					},
 				},
@@ -283,8 +283,8 @@ func TestSetNotNullValidation(t *testing.T) {
 						&migrations.OpSetNotNull{
 							Table:  "doesntexist",
 							Column: "review",
-							Up:     ptr("(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)"),
-							Down:   ptr("review"),
+							Up:     "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
+							Down:   "review",
 						},
 					},
 				},
@@ -301,8 +301,8 @@ func TestSetNotNullValidation(t *testing.T) {
 						&migrations.OpSetNotNull{
 							Table:  "reviews",
 							Column: "doesntexist",
-							Up:     ptr("(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)"),
-							Down:   ptr("review"),
+							Up:     "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
+							Down:   "review",
 						},
 					},
 				},
@@ -348,8 +348,8 @@ func TestSetNotNullValidation(t *testing.T) {
 						&migrations.OpSetNotNull{
 							Table:  "reviews",
 							Column: "review",
-							Up:     ptr("(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)"),
-							Down:   ptr("review"),
+							Up:     "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
+							Down:   "review",
 						},
 					},
 				},


### PR DESCRIPTION
For consistency with other 'alter column' style operations and to make it easier to combine such operations into one, make the set `NOT NULL` operation take `up` and `down` as `string` rather than `*string`.