### PR TITLE
Rename workflow from `build` to `test`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Test
 on: [push]
 jobs:
   test:


### PR DESCRIPTION
The workflow doesn't build anything; just runs tests, examples and does linting.

There will be a separate 'publish' workflow that does builds and creates releases.