### PR TITLE
Add `build` and `release` jobs to the workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,3 +91,74 @@ jobs:
             go run . start --complete $file;
           fi
         done
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [test, lint, examples]
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.21'
+
+    - name: Build pg-roll (Linux amd64)
+      run: GOOS=linux GOARCH=amd64 go build -o pg-roll.linux.amd64
+
+    - name: Build pg-roll (Linux arm64)
+      run: GOOS=linux GOARCH=arm64 go build -o pg-roll.linux.arm64
+
+    - name: Build pg-roll (MacOS amd64)
+      run: GOOS=darwin GOARCH=amd64 go build -o pg-roll.macos.amd64
+
+    - name: Build pg-roll (MacOS arm64)
+      run: GOOS=darwin GOARCH=arm64 go build -o pg-roll.macos.arm64
+
+    - name: Build pg-roll (Windows)
+      run: GOOS=windows GOARCH=amd64 go build -o pg-roll.win.amd64
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: pg-roll.linux.amd64
+        path: pg-roll.linux.amd64
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: pg-roll.linux.arm64
+        path: pg-roll.linux.arm64
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: pg-roll.macos.amd64
+        path: pg-roll.macos.amd64
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: pg-roll.macos.arm64
+        path: pg-roll.macos.arm64
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: pg-roll.win.amd64
+        path: pg-roll.win.amd64
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        path: artifacts
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        fail_on_unmatched_files: true
+        files: |
+          artifacts/pg-roll.linux.amd64/pg-roll.linux.amd64
+          artifacts/pg-roll.linux.arm64/pg-roll.linux.arm64
+          artifacts/pg-roll.macos.amd64/pg-roll.macos.amd64
+          artifacts/pg-roll.macos.arm64/pg-roll.macos.arm64
+          artifacts/pg-roll.win.amd64/pg-roll.win.amd64


### PR DESCRIPTION
Create a new release for each tag pushed to the repository.

Build versions of `pg-roll` for most OS/arch combinations and use them as artifacts for the release.

The build job runs on every push and the release job is gated on pushes to `refs/tags`.