### PR TITLE
Move `set_not_null` operation into `alter_column`

### DIFF
--- a/examples/16_set_not_null.json
+++ b/examples/16_set_not_null.json
@@ -2,9 +2,10 @@
   "name": "16_set_not_null",
   "operations": [
     {
-      "set_not_null": {
+      "alter_column": {
         "table": "reviews",
         "column": "review",
+        "not_null": true,
         "up": "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
         "down": "review"
       }

--- a/pkg/migrations/op_common.go
+++ b/pkg/migrations/op_common.go
@@ -110,9 +110,6 @@ func (v *Operations) UnmarshalJSON(data []byte) error {
 		case OpNameSetUnique:
 			item = &OpSetUnique{}
 
-		case OpNameSetNotNull:
-			item = &OpSetNotNull{}
-
 		case OpRawSQLName:
 			item = &OpRawSQL{}
 
@@ -186,9 +183,6 @@ func OperationName(op Operation) OpName {
 
 	case *OpSetUnique:
 		return OpNameSetUnique
-
-	case *OpSetNotNull:
-		return OpNameSetNotNull
 
 	case *OpRawSQL:
 		return OpRawSQLName

--- a/pkg/migrations/op_set_notnull_test.go
+++ b/pkg/migrations/op_set_notnull_test.go
@@ -48,10 +48,11 @@ func TestSetNotNull(t *testing.T) {
 				{
 					Name: "02_set_not_null",
 					Operations: migrations.Operations{
-						&migrations.OpSetNotNull{
-							Table:  "reviews",
-							Column: "review",
-							Up:     "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
+						&migrations.OpAlterColumn{
+							Table:   "reviews",
+							Column:  "review",
+							NotNull: ptr(true),
+							Up:      "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
 						},
 					},
 				},
@@ -189,11 +190,12 @@ func TestSetNotNull(t *testing.T) {
 				{
 					Name: "02_set_not_null",
 					Operations: migrations.Operations{
-						&migrations.OpSetNotNull{
-							Table:  "reviews",
-							Column: "review",
-							Up:     "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
-							Down:   "review || ' (from new column)'",
+						&migrations.OpAlterColumn{
+							Table:   "reviews",
+							Column:  "review",
+							NotNull: ptr(true),
+							Up:      "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
+							Down:    "review || ' (from new column)'",
 						},
 					},
 				},
@@ -263,10 +265,11 @@ func TestSetNotNullValidation(t *testing.T) {
 				{
 					Name: "02_set_not_null",
 					Operations: migrations.Operations{
-						&migrations.OpSetNotNull{
-							Table:  "reviews",
-							Column: "review",
-							Down:   "review",
+						&migrations.OpAlterColumn{
+							Table:   "reviews",
+							Column:  "review",
+							NotNull: ptr(true),
+							Down:    "review",
 						},
 					},
 				},
@@ -280,11 +283,12 @@ func TestSetNotNullValidation(t *testing.T) {
 				{
 					Name: "02_set_not_null",
 					Operations: migrations.Operations{
-						&migrations.OpSetNotNull{
-							Table:  "doesntexist",
-							Column: "review",
-							Up:     "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
-							Down:   "review",
+						&migrations.OpAlterColumn{
+							Table:   "doesntexist",
+							Column:  "review",
+							NotNull: ptr(true),
+							Up:      "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
+							Down:    "review",
 						},
 					},
 				},
@@ -298,11 +302,12 @@ func TestSetNotNullValidation(t *testing.T) {
 				{
 					Name: "02_set_not_null",
 					Operations: migrations.Operations{
-						&migrations.OpSetNotNull{
-							Table:  "reviews",
-							Column: "doesntexist",
-							Up:     "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
-							Down:   "review",
+						&migrations.OpAlterColumn{
+							Table:   "reviews",
+							Column:  "doesntexist",
+							NotNull: ptr(true),
+							Up:      "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
+							Down:    "review",
 						},
 					},
 				},
@@ -345,11 +350,12 @@ func TestSetNotNullValidation(t *testing.T) {
 				{
 					Name: "02_set_not_null",
 					Operations: migrations.Operations{
-						&migrations.OpSetNotNull{
-							Table:  "reviews",
-							Column: "review",
-							Up:     "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
-							Down:   "review",
+						&migrations.OpAlterColumn{
+							Table:   "reviews",
+							Column:  "review",
+							NotNull: ptr(true),
+							Up:      "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
+							Down:    "review",
 						},
 					},
 				},


### PR DESCRIPTION
Build on #91 and #92 and move the `set_not_null` operation into the `alter_column` operation.

The pattern is the same as for the operations already moved:

* Update the example migration to use the new operation type
* Remove serialization and deserialization logic for the individual operation.
* Make the `alter_column` operation construct the right type of 'inner operation'.
* Update tests for the foreign key and check constraint ops to use the `alter_column` operation.

A migration to set a column `NOT NULL` now looks like:

```json
{
  "name": "16_set_not_null",
  "operations": [
    {
      "alter_column": {
        "table": "reviews",
        "column": "review",
        "not_null": true,
        "up": "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
        "down": "review"
      }
    }
  ]
}
```

The `not_null` field is currently only allowed to be set `true`, as removing this kind of constraint is currently unsupported.