### PR TITLE
Add `build` to the list of required checks

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -78,6 +78,7 @@ branches:
       - examples (postgres 14.8)
       - examples (postgres 15.3)
       - lint
+      - build
 
     # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
     required_pull_request_reviews:


### PR DESCRIPTION
Ensure that it's possible to build binaries for all OS/arch combos before merge.