### PR TITLE
Remove `setup-go` step from `lint` job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,12 +26,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.21'
-        cache: false
-
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:


### PR DESCRIPTION
Disabling the cache during the `setup-go` step was probably done to avoid errors from the `golangci-lint` step https://github.com/golangci/golangci-lint-action/issues/807, https://github.com/golangci/golangci-lint-action/issues/244), but the `setup-go` step isn't actually needed before running `golangci-lint`.