### PR TITLE
Improve 'alter column' operation error messages

### DIFF
--- a/pkg/migrations/errors.go
+++ b/pkg/migrations/errors.go
@@ -112,8 +112,10 @@ func (e NoDownSQLAllowedError) Error() string {
 	return "down SQL is not allowed for this operation"
 }
 
-type MultipleAlterColumnChangesError struct{}
+type MultipleAlterColumnChangesError struct {
+	Changes int
+}
 
 func (e MultipleAlterColumnChangesError) Error() string {
-	return "alter column operations require exactly one change"
+	return fmt.Sprintf("alter column operations require exactly one change, found %d", e.Changes)
 }

--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -43,8 +43,8 @@ func (o *OpAlterColumn) Rollback(ctx context.Context, conn *sql.DB) error {
 
 func (o *OpAlterColumn) Validate(ctx context.Context, s *schema.Schema) error {
 	// Ensure that the operation describes only one change to the column
-	if !o.oneChange() {
-		return MultipleAlterColumnChangesError{}
+	if cnt := o.numChanges(); cnt != 1 {
+		return MultipleAlterColumnChangesError{Changes: cnt}
 	}
 
 	// Validate that the table and column exist
@@ -125,10 +125,9 @@ func (o *OpAlterColumn) innerOperation() Operation {
 	return nil
 }
 
-// oneChange ensures that the 'alter column' operation attempts to make
-// only one kind of change. For example, it should not attempt to rename a
-// column and change its type at the same time.
-func (o *OpAlterColumn) oneChange() bool {
+// numChanges returns the number of kinds of change that one 'alter column'
+// operation represents.
+func (o *OpAlterColumn) numChanges() int {
 	fieldsSet := 0
 
 	if o.Name != "" {
@@ -147,5 +146,5 @@ func (o *OpAlterColumn) oneChange() bool {
 		fieldsSet++
 	}
 
-	return fieldsSet == 1
+	return fieldsSet
 }

--- a/pkg/migrations/op_alter_column_test.go
+++ b/pkg/migrations/op_alter_column_test.go
@@ -132,7 +132,7 @@ func TestAlterColumnValidation(t *testing.T) {
 					},
 				},
 			},
-			wantStartErr: migrations.MultipleAlterColumnChangesError{},
+			wantStartErr: migrations.MultipleAlterColumnChangesError{Changes: 0},
 		},
 		{
 			name: "only one change at at time",
@@ -150,7 +150,7 @@ func TestAlterColumnValidation(t *testing.T) {
 					},
 				},
 			},
-			wantStartErr: migrations.MultipleAlterColumnChangesError{},
+			wantStartErr: migrations.MultipleAlterColumnChangesError{Changes: 2},
 		},
 	})
 }


### PR DESCRIPTION
When an 'alter column' represents multiple (or zero) changes, include the number of changes in the error message.