### PR TITLE
Update default pg version to use in tests

### DIFF
--- a/pkg/migrations/op_common_test.go
+++ b/pkg/migrations/op_common_test.go
@@ -22,7 +22,7 @@ import (
 
 // The version of postgres against which the tests are run
 // if the POSTGRES_VERSION environment variable is not set.
-const defaultPostgresVersion = "15.3"
+const defaultPostgresVersion = "16.0"
 
 type TestCase struct {
 	name          string

--- a/pkg/roll/execute_test.go
+++ b/pkg/roll/execute_test.go
@@ -20,7 +20,7 @@ const (
 	schema = "public"
 	// The version of postgres against which the tests are run
 	// if the POSTGRES_VERSION environment variable is not set.
-	defaultPostgresVersion = "15.3"
+	defaultPostgresVersion = "16.0"
 )
 
 func TestSchemaIsCreatedfterMigrationStart(t *testing.T) {


### PR DESCRIPTION
Follow up on this comment: https://github.com/xataio/pg-roll/pull/114#pullrequestreview-1637454998

This means that running `go test` locally will use Postgres 16.