### PR TITLE
Fix `go install` command in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Binaries are available for Linux, macOS & Windows, check our [Releases](https://
 To install `pgroll` from source, run the following command:
 
 ```sh
-go install github.com/xataio/pgroll
+go install github.com/xataio/pgroll@latest
 ```
 
 Note: requires [Go 1.21](https://golang.org/doc/install) or later.


### PR DESCRIPTION
The intention is that this command be run outside a module to install the binary and will require a version suffix in that case.