### PR TITLE
Store primary keys in `pgroll` internal schema

### DIFF
--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -43,6 +43,9 @@ type Table struct {
 
 	// Indexes is a map of the indexes defined on the table
 	Indexes map[string]Index `json:"indexes"`
+
+	// The columns that make up the primary key
+	PrimaryKey []string `json:"primaryKey"`
 }
 
 type Column struct {
@@ -110,6 +113,13 @@ func (t *Table) GetColumn(name string) *Column {
 		return nil
 	}
 	return &c
+}
+
+func (t *Table) GetPrimaryKey() (columns []*Column) {
+	for _, name := range t.PrimaryKey {
+		columns = append(columns, t.GetColumn(name))
+	}
+	return columns
 }
 
 func (t *Table) AddColumn(name string, c Column) {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -120,14 +120,15 @@ BEGIN
 							attr.attnum
 					) c
 				),
-        'primaryKey', (
-          SELECT json_agg(kcu.column_name) AS primary_key_columns
-          FROM information_schema.table_constraints AS tc 
-          JOIN information_schema.key_column_usage AS kcu 
-          ON tc.constraint_name = kcu.constraint_name
-          WHERE tc.table_name = 'users' 
-          AND tc.constraint_type = 'PRIMARY KEY'
-        ),
+				'primaryKey', (
+				  SELECT json_agg(kcu.column_name) AS primary_key_columns
+				  FROM information_schema.table_constraints AS tc 
+				  JOIN information_schema.key_column_usage AS kcu 
+				  ON tc.constraint_name = kcu.constraint_name
+				  WHERE tc.table_name = t.relname
+				  AND tc.table_schema = schemaname
+				  AND tc.constraint_type = 'PRIMARY KEY'
+				),
 				'indexes', (
 				  SELECT json_object_agg(pi.indexrelid::regclass, json_build_object(
 				    'name', pi.indexrelid::regclass

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -120,6 +120,14 @@ BEGIN
 							attr.attnum
 					) c
 				),
+        'primaryKey', (
+          SELECT json_agg(kcu.column_name) AS primary_key_columns
+          FROM information_schema.table_constraints AS tc 
+          JOIN information_schema.key_column_usage AS kcu 
+          ON tc.constraint_name = kcu.constraint_name
+          WHERE tc.table_name = 'users' 
+          AND tc.constraint_type = 'PRIMARY KEY'
+        ),
 				'indexes', (
 				  SELECT json_object_agg(pi.indexrelid::regclass, json_build_object(
 				    'name', pi.indexrelid::regclass


### PR DESCRIPTION
Add a `primaryKey` field to each table in the internal schema store to record the column(s) that make up a table's primary key.

This will be used when backfilling rows (https://github.com/xataio/pgroll/issues/127)

An example schema now looks like:

```json
{
  "name": "public",
  "tables": {
    "users": {
      "oid": "16412",
      "name": "users",
      "columns": {
        "id": {
          "name": "id",
          "type": "integer",
          "comment": null,
          "default": "nextval('users_id_seq'::regclass)",
          "nullable": false
        },
        "name": {
          "name": "name",
          "type": "text",
          "comment": null,
          "default": null,
          "nullable": true
        }
      },
      "comment": null,
      "indexes": {
        "users_pkey": {
          "name": "users_pkey"
        }
      },
      "primaryKey": [
        "id"
      ]
    }
  }
}
```
Where the `primaryKey` field is the new field.