### PR TITLE
Reduce lock contention by backfilling new columns in batches

### DIFF
--- a/pkg/migrations/backfill.go
+++ b/pkg/migrations/backfill.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/lib/pq"
+	"github.com/xataio/pgroll/pkg/schema"
+)
+
+// Backfill updates all rows in the given table, in batches, using the
+// following algorithm:
+// 1. Get the primary key column for the table.
+// 2. Get the first batch of rows from the table, ordered by the primary key.
+// 3. Update each row in the batch, setting the value of the primary key column to itself.
+// 4. Repeat steps 2 and 3 until no more rows are returned.
+func backfill(ctx context.Context, conn *sql.DB, table *schema.Table) error {
+	// Get the primary key column for the table
+	pks := table.GetPrimaryKey()
+	if len(pks) != 1 {
+		return errors.New("table must have a single primary key column")
+	}
+	pk := pks[0]
+
+	// Create a batcher for the table.
+	b := batcher{
+		table:     table,
+		pkColumn:  pk,
+		lastPK:    nil,
+		batchSize: 1000,
+	}
+
+	// Update each batch of rows
+	for {
+		if err := b.updateBatch(ctx, conn); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				break
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+type batcher struct {
+	table     *schema.Table
+	pkColumn  *schema.Column
+	lastPK    interface{}
+	batchSize int
+}
+
+// updateBatch updates the next batch of rows in the table.
+func (b *batcher) updateBatch(ctx context.Context, conn *sql.DB) error {
+	// Start the transaction for this batch
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	// Build the query to update the next batch of rows
+	query := b.buildQuery()
+
+	// Execute the query to update the next batch of rows and update the last PK
+	// value for the next batch
+	err = tx.QueryRowContext(ctx, query).Scan(&b.lastPK)
+	if err != nil {
+		return err
+	}
+
+	// Commit the transaction for this batch
+	return tx.Commit()
+}
+
+// buildQuery builds the query used to update the next batch of rows.
+func (b *batcher) buildQuery() string {
+	whereClause := ""
+	if b.lastPK != nil {
+		whereClause = fmt.Sprintf("WHERE %s > %v", pq.QuoteIdentifier(b.pkColumn.Name), b.lastPK)
+	}
+
+	return fmt.Sprintf(`
+    WITH batch AS (
+      SELECT %[1]s FROM %[2]s %[4]s ORDER BY %[1]s LIMIT %[3]d FOR UPDATE
+    ), update AS (
+      UPDATE %[2]s SET %[1]s=%[2]s.%[1]s FROM batch WHERE %[2]s.%[1]s = batch.%[1]s RETURNING %[2]s.%[1]s
+    )
+    SELECT LAST_VALUE(%[1]s) OVER() FROM update
+    `,
+		pq.QuoteIdentifier(b.pkColumn.Name),
+		pq.QuoteIdentifier(b.table.Name),
+		b.batchSize,
+		whereClause)
+}

--- a/pkg/migrations/errors.go
+++ b/pkg/migrations/errors.go
@@ -138,3 +138,12 @@ type MultipleAlterColumnChangesError struct {
 func (e MultipleAlterColumnChangesError) Error() string {
 	return fmt.Sprintf("alter column operations require exactly one change, found %d", e.Changes)
 }
+
+type InvalidPrimaryKeyError struct {
+	Table  string
+	Fields int
+}
+
+func (e InvalidPrimaryKeyError) Error() string {
+	return fmt.Sprintf("primary key on table %q must be defined on exactly one column, found %d", e.Table, e.Fields)
+}

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -53,7 +53,7 @@ func (o *OpAddColumn) Start(ctx context.Context, conn *sql.DB, stateSchema strin
 		if err != nil {
 			return fmt.Errorf("failed to create trigger: %w", err)
 		}
-		if err := backFill(ctx, conn, o.Table, TemporaryName(o.Column.Name)); err != nil {
+		if err := backfill(ctx, conn, table); err != nil {
 			return fmt.Errorf("failed to backfill column: %w", err)
 		}
 	}

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -220,18 +220,6 @@ func (o *OpAddColumn) addCheckConstraint(ctx context.Context, conn *sql.DB) erro
 	return err
 }
 
-func backFill(ctx context.Context, conn *sql.DB, table, column string) error {
-	// touch rows without changing them in order to have the trigger fire
-	// and set the value using the `up` SQL.
-	// TODO: this should be done in batches in case of large tables.
-	_, err := conn.ExecContext(ctx, fmt.Sprintf("UPDATE %s SET %s = %s",
-		pq.QuoteIdentifier(table),
-		pq.QuoteIdentifier(column),
-		pq.QuoteIdentifier(column)))
-
-	return err
-}
-
 func NotNullConstraintName(columnName string) string {
 	return "_pgroll_add_column_check_" + columnName
 }

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -163,6 +163,12 @@ func (o *OpAddColumn) Validate(ctx context.Context, s *schema.Schema) error {
 		}
 	}
 
+	// Ensure that the column has a primary key defined on exactly one column.
+	pk := table.GetPrimaryKey()
+	if len(pk) != 1 {
+		return InvalidPrimaryKeyError{Table: o.Table, Fields: len(pk)}
+	}
+
 	if !o.Column.Nullable && o.Column.Default == nil && o.Up == nil {
 		return FieldRequiredError{Name: "up"}
 	}

--- a/pkg/migrations/op_add_column_test.go
+++ b/pkg/migrations/op_add_column_test.go
@@ -560,6 +560,34 @@ func TestAddColumnValidation(t *testing.T) {
 			},
 			wantStartErr: migrations.FieldRequiredError{Name: "up"},
 		},
+		{
+			name: "table must have a primary key on exactly one column",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpRawSQL{
+							Up:   "CREATE TABLE orders(id integer, order_id integer, name text, primary key (id, order_id))",
+							Down: "DROP TABLE orders",
+						},
+					},
+				},
+				{
+					Name: "02_add_column",
+					Operations: migrations.Operations{
+						&migrations.OpAddColumn{
+							Table: "orders",
+							Up:    ptr("UPPER(name)"),
+							Column: migrations.Column{
+								Name: "description",
+								Type: "text",
+							},
+						},
+					},
+				},
+			},
+			wantStartErr: migrations.InvalidPrimaryKeyError{Table: "orders", Fields: 2},
+		},
 	})
 }
 

--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -58,6 +58,12 @@ func (o *OpAlterColumn) Validate(ctx context.Context, s *schema.Schema) error {
 		return ColumnDoesNotExistError{Table: o.Table, Name: o.Column}
 	}
 
+	// Ensure that the column has a primary key defined on exactly one column.
+	pk := table.GetPrimaryKey()
+	if len(pk) != 1 {
+		return InvalidPrimaryKeyError{Table: o.Table, Fields: len(pk)}
+	}
+
 	// Apply any special validation rules for the inner operation
 	op := o.innerOperation()
 	switch op.(type) {

--- a/pkg/migrations/op_alter_column_test.go
+++ b/pkg/migrations/op_alter_column_test.go
@@ -154,5 +154,30 @@ func TestAlterColumnValidation(t *testing.T) {
 			},
 			wantStartErr: migrations.MultipleAlterColumnChangesError{Changes: 2},
 		},
+		{
+			name: "table must have a primary key on exactly one column",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpRawSQL{
+							Up:   "CREATE TABLE orders(id integer, order_id integer, quantity integer, primary key (id, order_id))",
+							Down: "DROP TABLE orders",
+						},
+					},
+				},
+				{
+					Name: "02_alter_column",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:  "orders",
+							Column: "quantity",
+							Name:   "renamed_quantity",
+						},
+					},
+				},
+			},
+			wantStartErr: migrations.InvalidPrimaryKeyError{Table: "orders", Fields: 2},
+		},
 	})
 }

--- a/pkg/migrations/op_change_type.go
+++ b/pkg/migrations/op_change_type.go
@@ -46,7 +46,7 @@ func (o *OpChangeType) Start(ctx context.Context, conn *sql.DB, stateSchema stri
 	}
 
 	// Backfill the new column with values from the old column.
-	if err := backFill(ctx, conn, o.Table, TemporaryName(o.Column)); err != nil {
+	if err := backfill(ctx, conn, table); err != nil {
 		return fmt.Errorf("failed to backfill column: %w", err)
 	}
 

--- a/pkg/migrations/op_drop_constraint.go
+++ b/pkg/migrations/op_drop_constraint.go
@@ -46,7 +46,7 @@ func (o *OpDropConstraint) Start(ctx context.Context, conn *sql.DB, stateSchema 
 	}
 
 	// Backfill the new column with values from the old column.
-	if err := backFill(ctx, conn, o.Table, TemporaryName(o.Column)); err != nil {
+	if err := backfill(ctx, conn, table); err != nil {
 		return fmt.Errorf("failed to backfill column: %w", err)
 	}
 

--- a/pkg/migrations/op_set_check.go
+++ b/pkg/migrations/op_set_check.go
@@ -52,7 +52,7 @@ func (o *OpSetCheckConstraint) Start(ctx context.Context, conn *sql.DB, stateSch
 	}
 
 	// Backfill the new column with values from the old column.
-	if err := backFill(ctx, conn, o.Table, TemporaryName(o.Column)); err != nil {
+	if err := backfill(ctx, conn, table); err != nil {
 		return fmt.Errorf("failed to backfill column: %w", err)
 	}
 

--- a/pkg/migrations/op_set_fk.go
+++ b/pkg/migrations/op_set_fk.go
@@ -51,7 +51,7 @@ func (o *OpSetForeignKey) Start(ctx context.Context, conn *sql.DB, stateSchema s
 	}
 
 	// Backfill the new column with values from the old column.
-	if err := backFill(ctx, conn, o.Table, TemporaryName(o.Column)); err != nil {
+	if err := backfill(ctx, conn, table); err != nil {
 		return fmt.Errorf("failed to backfill column: %w", err)
 	}
 

--- a/pkg/migrations/op_set_notnull.go
+++ b/pkg/migrations/op_set_notnull.go
@@ -50,7 +50,7 @@ func (o *OpSetNotNull) Start(ctx context.Context, conn *sql.DB, stateSchema stri
 	}
 
 	// Backfill the new column with values from the old column.
-	if err := backFill(ctx, conn, o.Table, TemporaryName(o.Column)); err != nil {
+	if err := backfill(ctx, conn, table); err != nil {
 		return fmt.Errorf("failed to backfill column: %w", err)
 	}
 

--- a/pkg/migrations/op_set_unique.go
+++ b/pkg/migrations/op_set_unique.go
@@ -51,7 +51,7 @@ func (o *OpSetUnique) Start(ctx context.Context, conn *sql.DB, stateSchema strin
 	}
 
 	// Backfill the new column with values from the old column.
-	if err := backFill(ctx, conn, o.Table, TemporaryName(o.Column)); err != nil {
+	if err := backfill(ctx, conn, table); err != nil {
 		return fmt.Errorf("failed to backfill column: %w", err)
 	}
 


### PR DESCRIPTION
The previous approach to backfilling new columns with values from existing columns applied one `UPDATE` statement to the whole table, taking row locks on the entire table in one long-running transaction.

This PR changes backfills to work in batches, copying 1000 records at a time, each in separate short transaction. This reduces contention for row locks and ensures that long-running backfills don't lock out other updates to the same table for the duration of the backfill.

Fixes #127 