### PR TITLE
Update golangci-lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         # Require: The version of golangci-lint to use.
         # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
         # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-        version: v1.53
+        version: v1.54.2
 
         # Optional: golangci-lint command line arguments.
         #

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.21'
+
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-goVersion: &goVersion "1.20"
+goVersion: &goVersion "1.21"
 
 run:
   go: *goVersion


### PR DESCRIPTION
Update to the latest version of `golangci-lint`.

Also add an explicit `setup-go` step to the workflow before the `golangci-lint` step. Without this, `golangci-lint` seems to pick up the wrong Go version installed on the runners (see the list [here](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#go)), causing it to fail when running against #139 