### PR TITLE
Add reference documentation for more operations

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -597,6 +597,25 @@ Example **create table** migrations:
 * [25_add_table_with_check_constraint.json](../examples/25_add_table_with_check_constraint.json)
 
 ### Drop column
+
+A drop column operation drops a column from an existing table.
+
+**drop column** operations have this structure:
+
+```json
+{
+  "drop_column": {
+    "table": "name of table",
+    "column": "name of column to drop",
+    "down": "SQL expression"
+  }
+}
+```
+
+Example **drop column** migrations:
+
+* [09_drop_column.json](../examples/09_drop_column.json)
+
 ### Drop constraint
 ### Drop index
 ### Drop table

--- a/docs/README.md
+++ b/docs/README.md
@@ -679,6 +679,26 @@ Example **drop table** migrations:
 * [07_drop_table.json](../examples/07_drop_table.json)
 
 ### Raw SQL
+
+A raw SQL operation runs arbitrary SQL against the database. This is intended as an 'escape hatch' to allow a migration to perform operations that are otherwise not supported by `pgroll`.
+
+:warning: `pgroll` is unable to guarantee that raw SQL migrations are safe and will not result in application downtime. :warning:
+
+**sql** operations have this structure:
+
+```json
+{
+  "sql": {
+    "up": "SQL expression",
+    "down": "SQL expression"
+  }
+}
+```
+
+Example **raw SQL** migrations:
+
+* [05_sql.json](../examples/05_sql.json)
+
 ### Alter column
 
 #### Rename column

--- a/docs/README.md
+++ b/docs/README.md
@@ -469,7 +469,7 @@ See the [examples](../examples) directory for examples of each kind of operation
 
 `pgroll` supports the following migration operations:
 
-* [Add column](add-column)
+* [Add column](#add-column)
 * [Alter column](#alter-column)
 * [Create index](#create-index)
 * [Create table](#create-table)
@@ -488,6 +488,44 @@ See the [examples](../examples) directory for examples of each kind of operation
     * [Add unique constraint](#set-unique)
 
 ### Add column
+
+An add column operation creates a new column on an existing table.
+
+**add column** operations have this structure:
+
+```json
+{
+  "add_column": {
+    "table": "name of table to which the column should be added",
+    "up": "SQL expression",
+    "column": {
+      "name": "name of column",
+      "type": "postgres type",
+      "nullable": true|false,
+      "unique": true|false,
+      "pk": true|false,
+      "default": "default value for the column",
+      "check": {
+        "name": "name of check constraint",
+        "constraint": "constraint expression"
+      },
+      "references": {
+        "name": "name of foreign key constraint",
+        "table": "name of referenced table",
+        "column": "name of referenced column"
+      } 
+    }
+  }
+}
+```
+
+Example **add column** migrations:
+
+* [03_add_column.json](../examples/03_add_column.json)
+* [06_add_column_to_sql_table.json](../examples/06_add_column_to_sql_table.json)
+* [17_add_rating_column.json](../examples/17_add_rating_column.json)
+* [26_add_column_with_check_constraint.json](../examples/26_add_column_with_check_constraint.json)
+
 ### Alter column
 ### Create index
 ### Create table

--- a/docs/README.md
+++ b/docs/README.md
@@ -643,6 +643,23 @@ Example **drop constraint** migrations:
 * [24_drop_foreign_key_constraint.json](../examples/24_drop_foreign_key_constraint.json)
 
 ### Drop index
+
+A drop index operation drops an index from a table.
+
+**drop index** operations have this structure:
+
+```json
+{
+  "drop_index": {
+    "name": "name of index to drop"
+  }
+}
+```
+
+Example **drop index** migrations:
+
+* [11_drop_index.json](../examples/11_drop_index.json)
+
 ### Drop table
 ### Raw SQL
 ### Alter column

--- a/docs/README.md
+++ b/docs/README.md
@@ -699,6 +699,25 @@ Example **raw SQL** migrations:
 
 * [05_sql.json](../examples/05_sql.json)
 
+### Rename table
+
+A rename table operation renames a table.
+
+**rename table** operations have this structure:
+
+```json
+{
+  "rename_table": {
+    "from": "old column name",
+    "to": "new column name"
+  }
+}
+```
+
+Example **rename table** migrations:
+
+* [04_rename_table.json](../examples/04_rename_table.json)
+
 ### Alter column
 
 #### Rename column

--- a/docs/README.md
+++ b/docs/README.md
@@ -661,6 +661,23 @@ Example **drop index** migrations:
 * [11_drop_index.json](../examples/11_drop_index.json)
 
 ### Drop table
+
+A drop table operation drops a table.
+
+**drop table** operations have this structure:
+
+```json
+{
+  "drop_table": {
+    "name": "name of table to drop"
+  }
+}
+```
+
+Example **drop table** migrations:
+
+* [07_drop_table.json](../examples/07_drop_table.json)
+
 ### Raw SQL
 ### Alter column
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -528,6 +528,25 @@ Example **add column** migrations:
 
 ### Alter column
 ### Create index
+
+A create index operation creates a new btree index on a set of columns.
+
+**create index** operations have this structure:
+
+```json
+{
+  "create_index": {
+    "table": "name of table on which to define the index",
+    "name": "index name",
+    "columns": [ "names of columns on which to define the index" ]
+  }
+}
+```
+
+Example **create index** migrations:
+
+* [10_create_index.json](../examples/10_create_index.json)
+
 ### Create table
 
 A create table migration creates a new table in the database.

--- a/docs/README.md
+++ b/docs/README.md
@@ -549,9 +549,9 @@ Example **create index** migrations:
 
 ### Create table
 
-A create table migration creates a new table in the database.
+A create table operation creates a new table in the database.
 
-**create table** migrations have this structure:
+**create table** operations have this structure:
 
 ```json
 {

--- a/docs/README.md
+++ b/docs/README.md
@@ -617,6 +617,31 @@ Example **drop column** migrations:
 * [09_drop_column.json](../examples/09_drop_column.json)
 
 ### Drop constraint
+
+A drop constraint operation drops a constraint from an existing table.
+
+Only `CHECK`, `FOREIGN KEY`, and `UNIQUE` constraints can be dropped.
+
+**drop constraint** operations have this structure:
+
+```json
+{
+  "drop_constraint": {
+    "table": "name of table",
+    "column": "name of column on which constraint is defined",
+    "name": "name of constraint to drop",
+    "up": "SQL expression",
+    "down": "SQL expression"
+  }
+}
+```
+
+Example **drop constraint** migrations:
+
+* [27_drop_unique_constraint.json](../examples/27_drop_unique_constraint.json)
+* [23_drop_check_constraint.json](../examples/23_drop_check_constraint.json)
+* [24_drop_foreign_key_constraint.json](../examples/24_drop_foreign_key_constraint.json)
+
 ### Drop index
 ### Drop table
 ### Raw SQL


### PR DESCRIPTION
Following on from https://github.com/xataio/pgroll/pull/146, add reference documentation for all other operations except for `alter_column` which will come in a later PR.

[[Direct link](https://github.com/xataio/pgroll/blob/doc/document-more-operations/docs/README.md#operations-reference)]