### PR TITLE
Add `--version` (`-v`) flag to the root command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: [test, lint, examples]
+    env:
+      PGROLL_VERSION: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || github.sha }}
     steps:
     - uses: actions/checkout@v3
 
@@ -113,19 +115,19 @@ jobs:
         go-version: '1.21'
 
     - name: Build pgroll (Linux amd64)
-      run: GOOS=linux GOARCH=amd64 go build -o pgroll.linux.amd64
+      run: GOOS=linux GOARCH=amd64 go build -ldflags "-X github.com/xataio/pgroll/cmd.Version=${PGROLL_VERSION}" -o pgroll.linux.amd64
 
     - name: Build pgroll (Linux arm64)
-      run: GOOS=linux GOARCH=arm64 go build -o pgroll.linux.arm64
+      run: GOOS=linux GOARCH=arm64 go build -ldflags "-X github.com/xataio/pgroll/cmd.Version=${PGROLL_VERSION}" -o pgroll.linux.arm64
 
     - name: Build pgroll (MacOS amd64)
-      run: GOOS=darwin GOARCH=amd64 go build -o pgroll.macos.amd64
+      run: GOOS=darwin GOARCH=amd64 go build -ldflags "-X github.com/xataio/pgroll/cmd.Version=${PGROLL_VERSION}" -o pgroll.macos.amd64
 
     - name: Build pgroll (MacOS arm64)
-      run: GOOS=darwin GOARCH=arm64 go build -o pgroll.macos.arm64
+      run: GOOS=darwin GOARCH=arm64 go build -ldflags "-X github.com/xataio/pgroll/cmd.Version=${PGROLL_VERSION}" -o pgroll.macos.arm64
 
     - name: Build pgroll (Windows)
-      run: GOOS=windows GOARCH=amd64 go build -o pgroll.win.amd64
+      run: GOOS=windows GOARCH=amd64 go build -ldflags "-X github.com/xataio/pgroll/cmd.Version=${PGROLL_VERSION}" -o pgroll.win.amd64
 
     - uses: actions/upload-artifact@v3
       with:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,9 @@ var (
 
 	// StateSchema is the Postgres schema where pgroll will store its state
 	StateSchema string
+
+	// Version is the pgroll version
+	Version = "development"
 )
 
 func init() {
@@ -30,6 +33,7 @@ func init() {
 var rootCmd = &cobra.Command{
 	Use:          "pgroll",
 	SilenceUsage: true,
+	Version:      Version,
 }
 
 func NewRoll(ctx context.Context) (*roll.Roll, error) {


### PR DESCRIPTION
Add `--version` (`-v`) flag to the root command.

`pgroll --version` shows:

* `"development"` for local builds
*  the git SHA of the build for non-tagged builds in CI
*  the tag name for tagged builds in CI (eg `v0.2.0`)

Fixes https://github.com/xataio/pgroll/issues/134