### PR TITLE
Set session level `lock_timeout` for pgroll connection

### DIFF
--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -2,7 +2,9 @@
 
 package flags
 
-import "github.com/spf13/viper"
+import (
+	"github.com/spf13/viper"
+)
 
 func PostgresURL() string {
 	return viper.GetString("PG_URL")
@@ -14,4 +16,8 @@ func Schema() string {
 
 func StateSchema() string {
 	return viper.GetString("STATE_SCHEMA")
+}
+
+func LockTimeout() int {
+	return viper.GetInt("LOCK_TIMEOUT")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,10 +22,12 @@ func init() {
 	rootCmd.PersistentFlags().String("postgres-url", "postgres://postgres:postgres@localhost?sslmode=disable", "Postgres URL")
 	rootCmd.PersistentFlags().String("schema", "public", "Postgres schema to use for the migration")
 	rootCmd.PersistentFlags().String("pgroll-schema", "pgroll", "Postgres schema to use for pgroll internal state")
+	rootCmd.PersistentFlags().Int("lock-timeout", 500, "Postgres lock timeout in milliseconds for pgroll DDL operations")
 
 	viper.BindPFlag("PG_URL", rootCmd.PersistentFlags().Lookup("postgres-url"))
 	viper.BindPFlag("SCHEMA", rootCmd.PersistentFlags().Lookup("schema"))
 	viper.BindPFlag("STATE_SCHEMA", rootCmd.PersistentFlags().Lookup("pgroll-schema"))
+	viper.BindPFlag("LOCK_TIMEOUT", rootCmd.PersistentFlags().Lookup("lock-timeout"))
 }
 
 var rootCmd = &cobra.Command{
@@ -38,13 +40,14 @@ func NewRoll(ctx context.Context) (*roll.Roll, error) {
 	pgURL := flags.PostgresURL()
 	schema := flags.Schema()
 	stateSchema := flags.StateSchema()
+	lockTimeout := flags.LockTimeout()
 
 	state, err := state.New(ctx, pgURL, stateSchema)
 	if err != nil {
 		return nil, err
 	}
 
-	return roll.New(ctx, pgURL, schema, state)
+	return roll.New(ctx, pgURL, schema, lockTimeout, state)
 }
 
 // Execute executes the root command.

--- a/pkg/migrations/op_common_test.go
+++ b/pkg/migrations/op_common_test.go
@@ -141,7 +141,9 @@ func withMigratorAndConnectionToContainer(t *testing.T, fn func(mig *roll.Roll, 
 	if err != nil {
 		t.Fatal(err)
 	}
-	mig, err := roll.New(ctx, cStr, "public", st)
+
+	const lockTimeoutMs = 500
+	mig, err := roll.New(ctx, cStr, "public", lockTimeoutMs, st)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/roll/execute_test.go
+++ b/pkg/roll/execute_test.go
@@ -227,7 +227,9 @@ func withMigratorInSchemaAndConnectionToContainer(t *testing.T, schema string, f
 	if err != nil {
 		t.Fatal(err)
 	}
-	mig, err := roll.New(ctx, cStr, schema, st)
+
+	const lockTimeoutMs = 500
+	mig, err := roll.New(ctx, cStr, schema, lockTimeoutMs, st)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/roll/execute_test.go
+++ b/pkg/roll/execute_test.go
@@ -5,11 +5,13 @@ package roll_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/lib/pq"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -168,6 +170,60 @@ func TestSchemaOptionIsRespected(t *testing.T) {
 	})
 }
 
+func TestLockTimeoutIsEnforced(t *testing.T) {
+	t.Parallel()
+
+	withMigratorInSchemaWithLockTimeoutAndConnectionToContainer(t, "public", 100, func(mig *roll.Roll, db *sql.DB) {
+		ctx := context.Background()
+
+		// Start a create table migration
+		err := mig.Start(ctx, &migrations.Migration{
+			Name:       "01_create_table",
+			Operations: migrations.Operations{createTableOp("table1")},
+		})
+		if err != nil {
+			t.Fatalf("Failed to start migration: %v", err)
+		}
+
+		// Complete the create table migration
+		if err := mig.Complete(ctx); err != nil {
+			t.Fatalf("Failed to complete migration: %v", err)
+		}
+
+		// Start a transaction and take an ACCESS_EXCLUSIVE lock on the table
+		// Don't commit the transaction so that the lock is held indefinitely
+		tx, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to start transaction: %v", err)
+		}
+		t.Cleanup(func() {
+			tx.Commit()
+		})
+		if _, err := tx.ExecContext(ctx, "LOCK TABLE table1 IN ACCESS EXCLUSIVE MODE"); err != nil {
+			t.Fatalf("Failed to take ACCESS_EXCLUSIVE lock on table: %v", err)
+		}
+
+		// Attempt to run a second migration on the table while the lock is held
+		// The migration should fail due to a lock timeout error
+		err = mig.Start(ctx, &migrations.Migration{
+			Name:       "02_create_table",
+			Operations: migrations.Operations{addColumnOp("table1")},
+		})
+		if err == nil {
+			t.Fatalf("Expected migration to fail due to lock timeout")
+		}
+		if err != nil {
+			pqErr := &pq.Error{}
+			if ok := errors.As(err, &pqErr); !ok {
+				t.Fatalf("Migration failed with unexpected error: %v", err)
+			}
+			if pqErr.Code != "55P03" { // Lock not available error code
+				t.Fatalf("Migration failed with unexpected error: %v", err)
+			}
+		}
+	})
+}
+
 func createTableOp(tableName string) *migrations.OpCreateTable {
 	return &migrations.OpCreateTable{
 		Name: tableName,
@@ -186,7 +242,18 @@ func createTableOp(tableName string) *migrations.OpCreateTable {
 	}
 }
 
-func withMigratorInSchemaAndConnectionToContainer(t *testing.T, schema string, fn func(mig *roll.Roll, db *sql.DB)) {
+func addColumnOp(tableName string) *migrations.OpAddColumn {
+	return &migrations.OpAddColumn{
+		Table: tableName,
+		Column: migrations.Column{
+			Name:     "age",
+			Type:     "integer",
+			Nullable: true,
+		},
+	}
+}
+
+func withMigratorInSchemaWithLockTimeoutAndConnectionToContainer(t *testing.T, schema string, lockTimeoutMs int, fn func(mig *roll.Roll, db *sql.DB)) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -228,7 +295,6 @@ func withMigratorInSchemaAndConnectionToContainer(t *testing.T, schema string, f
 		t.Fatal(err)
 	}
 
-	const lockTimeoutMs = 500
 	mig, err := roll.New(ctx, cStr, schema, lockTimeoutMs, st)
 	if err != nil {
 		t.Fatal(err)
@@ -259,6 +325,10 @@ func withMigratorInSchemaAndConnectionToContainer(t *testing.T, schema string, f
 	fn(mig, db)
 }
 
+func withMigratorInSchemaAndConnectionToContainer(t *testing.T, schema string, fn func(mig *roll.Roll, db *sql.DB)) {
+	withMigratorInSchemaWithLockTimeoutAndConnectionToContainer(t, schema, 500, fn)
+}
+
 func withMigratorAndConnectionToContainer(t *testing.T, fn func(mig *roll.Roll, db *sql.DB)) {
-	withMigratorInSchemaAndConnectionToContainer(t, "public", fn)
+	withMigratorInSchemaWithLockTimeoutAndConnectionToContainer(t, "public", 500, fn)
 }

--- a/pkg/roll/roll.go
+++ b/pkg/roll/roll.go
@@ -21,7 +21,7 @@ type Roll struct {
 	state *state.State
 }
 
-func New(ctx context.Context, pgURL, schema string, state *state.State) (*Roll, error) {
+func New(ctx context.Context, pgURL, schema string, lockTimeoutMs int, state *state.State) (*Roll, error) {
 	dsn, err := pq.ParseURL(pgURL)
 	if err != nil {
 		dsn = pgURL
@@ -37,6 +37,11 @@ func New(ctx context.Context, pgURL, schema string, state *state.State) (*Roll, 
 	_, err = conn.ExecContext(ctx, "SET LOCAL pgroll.internal to 'TRUE'")
 	if err != nil {
 		return nil, fmt.Errorf("unable to set pgroll.internal to true: %w", err)
+	}
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("SET lock_timeout to '%dms'", lockTimeoutMs))
+	if err != nil {
+		return nil, fmt.Errorf("unable to set lock_timeout: %w", err)
 	}
 
 	return &Roll{


### PR DESCRIPTION
Set the session `lock_timeout` for the connection used by `pgroll` to run DDL operations.

The need to set `lock_timeout` for DDL operations to achieve zero downtime migrations is well documented [[1](https://xata.io/blog/postgres-schema-changes-pita#locking-gotchas)], [[2](https://medium.com/paypal-tech/postgresql-at-scale-database-schema-changes-without-downtime-20d3749ed680#00dc)]. 

When a DDL transaction attempts to take an `ACCESS EXCLUSIVE` lock on a table while another transaction holds a conflicting lock (such as a long-running `SELECT` query's `ACCESS SHARE` lock),  other queries will queue up behind the DDL transaction until it is able to obtain the exclusive lock thus locking out reads from the table and causing downtime. By setting a `lock_timeout` the DDL transaction will abort if it is unable to acquire the lock before the timeout, freeing any other queries that were queued behind it.

The approach taken here is to set the `lock_timeout` at the session level. This assumes that `pgroll` has a direct connection to the Postgres instance rather than going through a connection pooler like PGBouncer. PGBouncer's statement or transaction mode may swap out the connection between transactions/statements meaning that the lock timeout may not be applied correctly. See [[3](https://jpcamara.com/2023/04/12/pgbouncer-is-useful.html)] for a more detailed discussion of PGBouncer's behaviour here.

The new `--lock-timeout` flag (and `PGROLL_LOCK_TIMEOUT` env var) is used to control the timeout duration.

Fixes https://github.com/xataio/pgroll/issues/65