### PR TITLE
More README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ When no more client applications are using the old schema version, the migration
 
 - [Installation](#installation)
 - [Usage](#usage)
+- [Documentation](#documentation)
 - [Contributing](#contributing)
 - [License](#license)
 - [Support](#support)
@@ -148,9 +149,9 @@ At any point during a migration, it can be rolled back to the previous version. 
 pgroll --postgres-url postgres://user:password@host:port/dbname rollback
 ```
 
-### Advanced Usage
+## Documentation
 
-For more advanced usage and detailed options, refer to the [Documentation](docs/README.md).
+For more advanced usage, a tutorial, and detailed options refer to the full [Documentation](docs/README.md).
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,20 @@ If an application doesn't set the `search_path` for the connection, the `search_
 
 ## Installation
 
+### Binaries
+
+Binaries are available for Linux, macOS & Windows on our [Releases](https://github.com/xataio/pgroll/releases) page.
+
+### From source
+
+To install `pgroll` from source, run the following command:
+
+```sh
+go install github.com/xataio/pgroll@latest
+```
+
+Note: requires [Go 1.21](https://golang.org/doc/install) or later.
+
 ## Tutorial
 
 This section will walk you through applying your first migrations using `pgroll`.


### PR DESCRIPTION
* Fill in the missing `Installation` section in the `docs/README.md`
* Make the link in the main `README.md` to the `docs/README.md` more prominent by adding a section header.

[[Direct link to README.md](https://github.com/xataio/pgroll/blob/more-readme-updates/README.md)]
[[Direct link to docs/README.md](https://github.com/xataio/pgroll/blob/more-readme-updates/docs/README.md)]