### PR TITLE
Ensure build workflow runs on PRs from forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-on: [push]
+on: [push, pull_request]
 jobs:
   test:
     name: test (postgres ${{ matrix.pgVersion }})


### PR DESCRIPTION
Previously we were only running them for branches on this repo