### PR TITLE
Change signature of `migrations.ReadMigrationFile`

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -31,7 +32,13 @@ func startCmd() *cobra.Command {
 			}
 			defer m.Close()
 
-			migration, err := migrations.ReadMigrationFile(args[0])
+			file, err := os.Open(args[0])
+			if err != nil {
+				return fmt.Errorf("opening migration file: %w", err)
+			}
+			defer file.Close()
+
+			migration, err := migrations.ReadMigration(file)
 			if err != nil {
 				return fmt.Errorf("reading migration file: %w", err)
 			}

--- a/pkg/migrations/op_common.go
+++ b/pkg/migrations/op_common.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 )
 
 type OpName string
@@ -37,16 +36,8 @@ func TemporaryName(name string) string {
 	return "_pgroll_new_" + name
 }
 
-func ReadMigrationFile(file string) (*Migration, error) {
-	// read operations from file
-	jsonFile, err := os.Open(file)
-	if err != nil {
-		return nil, err
-	}
-	defer jsonFile.Close()
-
-	// read our opened xmlFile as a byte array.
-	byteValue, err := io.ReadAll(jsonFile)
+func ReadMigration(r io.Reader) (*Migration, error) {
+	byteValue, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Read migrations from from an abitrary `io.Reader` rather than a filename.

The CLI is concerned with files, but the module API should work with a `Reader`.