### PR TITLE
Feat/#175 homebrew release

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -82,7 +82,6 @@ branches:
       - examples (postgres 16.0)
       - examples (postgres latest)
       - lint
-      - build
 
     # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
     required_pull_request_reviews:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
           fi
         done
 
-  build:
+  setup:
     runs-on: ubuntu-latest
     needs: [test, lint, examples]
     env:
@@ -114,62 +114,14 @@ jobs:
       with:
         go-version: '1.21'
 
-    - name: Build pgroll (Linux amd64)
-      run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X github.com/xataio/pgroll/cmd.Version=${PGROLL_VERSION}" -o pgroll.linux.amd64
-
-    - name: Build pgroll (Linux arm64)
-      run: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "-X github.com/xataio/pgroll/cmd.Version=${PGROLL_VERSION}" -o pgroll.linux.arm64
-
-    - name: Build pgroll (MacOS amd64)
-      run: CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "-X github.com/xataio/pgroll/cmd.Version=${PGROLL_VERSION}" -o pgroll.macos.amd64
-
-    - name: Build pgroll (MacOS arm64)
-      run: CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "-X github.com/xataio/pgroll/cmd.Version=${PGROLL_VERSION}" -o pgroll.macos.arm64
-
-    - name: Build pgroll (Windows)
-      run: CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-X github.com/xataio/pgroll/cmd.Version=${PGROLL_VERSION}" -o pgroll.win.amd64
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: pgroll.linux.amd64
-        path: pgroll.linux.amd64
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: pgroll.linux.arm64
-        path: pgroll.linux.arm64
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: pgroll.macos.amd64
-        path: pgroll.macos.amd64
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: pgroll.macos.arm64
-        path: pgroll.macos.arm64
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: pgroll.win.amd64
-        path: pgroll.win.amd64
-
   release:
     runs-on: ubuntu-latest
-    needs: [build]
-    if: startsWith(github.ref, 'refs/tags/')
     steps:
-    - uses: actions/download-artifact@v3
-      with:
-        path: artifacts
-
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      with:
-        fail_on_unmatched_files: true
-        files: |
-          artifacts/pgroll.linux.amd64/pgroll.linux.amd64
-          artifacts/pgroll.linux.arm64/pgroll.linux.arm64
-          artifacts/pgroll.macos.amd64/pgroll.macos.amd64
-          artifacts/pgroll.macos.arm64/pgroll.macos.arm64
-          artifacts/pgroll.win.amd64/pgroll.win.amd64
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [test, lint, examples, license-check]
+    if: startsWith(github.ref, 'refs/tags/')
     env:
       PGROLL_VERSION: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || github.sha }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
           fi
         done
 
-  setup:
+  release:
     runs-on: ubuntu-latest
     needs: [test, lint, examples]
     env:
@@ -114,14 +114,11 @@ jobs:
       with:
         go-version: '1.21'
 
-  release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          distribution: goreleaser
-          version: latest
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v3
+      with:
+        distribution: goreleaser
+        version: latest
+        args: release --clean
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,10 +115,10 @@ jobs:
         go-version: '1.21'
 
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v3
+      uses: goreleaser/goreleaser-action@v5
       with:
         distribution: goreleaser
         version: latest
         args: release --clean
       env:
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,4 +124,4 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [test, lint, examples]
+    needs: [test, lint, examples, license-check]
     env:
       PGROLL_VERSION: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || github.sha }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ bin/license-header-checker
 # misc
 .DS_Store
 .env
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,9 +27,9 @@ brews:
     name: pgroll
     homepage: "https://www.xata.io"
     description: "Postgres zero-downtime migrations made easy"
-    tap:
+    repository:
       owner: xataio
-      name: homebrew-pgroll
+      name: pgroll
 
 archives:
   - format: binary

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,18 +22,17 @@ builds:
       - goos: windows
         goarch: arm64
 
-# brews:
-#   -
-#     name: mediumautopost
-#     homepage: "https://www.xata.io"
-#     description: "Postgres zero-downtime migrations made easy"
-#     tap:
-#       owner: xataio
-#       name: homebrew-pgroll
+brews:
+  -
+    name: pgroll
+    homepage: "https://www.xata.io"
+    description: "Postgres zero-downtime migrations made easy"
+    tap:
+      owner: xataio
+      name: homebrew-pgroll
 
 archives:
   - format: binary
-    # pgroll.win.amd64
     name_template: >-
       {{ .ProjectName }}.{{ if eq .Os "windows" }}win{{ else if eq .Os "darwin" }}macos{{ else }}{{ .Os }}{{ end }}.{{ .Arch }}
     files:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,47 @@
+project_name: pgroll
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: build_noncgo
+    binary: pgroll
+    ldflags:
+      - -X github.com/xataio/pgroll/cmd.Version={{ .Version }}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+
+# brews:
+#   -
+#     name: mediumautopost
+#     homepage: "https://www.xata.io"
+#     description: "Postgres zero-downtime migrations made easy"
+#     tap:
+#       owner: xataio
+#       name: homebrew-pgroll
+
+archives:
+  - format: binary
+    # pgroll.win.amd64
+    name_template: >-
+      {{ .ProjectName }}.{{ if eq .Os "windows" }}win{{ else if eq .Os "darwin" }}macos{{ else }}{{ .Os }}{{ end }}.{{ .Arch }}
+    files:
+      - LICENSE*
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,16 +21,15 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
-
 brews:
   -
     name: pgroll
     homepage: "https://www.xata.io"
     description: "Postgres zero-downtime migrations made easy"
+    license: "Apache-2.0"
     repository:
       owner: xataio
-      name: pgroll
-
+      name: homebrew-pgroll
 archives:
   - format: binary
     name_template: >-

--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ go install github.com/xataio/pgroll@latest
 ```
 
 Note: requires [Go 1.21](https://golang.org/doc/install) or later.
+### From package manager - Homebrew
+
+To install `pgroll` with homebrew, run the following command:
+
+```sh
+# macOS or Linux
+brew tap xataio/pgroll
+brew install pgroll
+```
 
 ## Usage
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -100,6 +100,16 @@ go install github.com/xataio/pgroll@latest
 
 Note: requires [Go 1.21](https://golang.org/doc/install) or later.
 
+### From package manager - Homebrew
+
+To install `pgroll` with homebrew, run the following command:
+
+```sh
+# macOS or Linux
+brew tap xataio/pgroll
+brew install pgroll
+```
+
 ## Tutorial
 
 This section will walk you through applying your first migrations using `pgroll`.


### PR DESCRIPTION
I needed to edit the build pipeline because using the build steps for gorelease you need to have the Pro version: https://goreleaser.com/customization/builds/#import-pre-built-binaries

Anyway I kept the same binary structure as before and the pipeline is much shorter with goreleaser now.

✅  Added Homebrew with GoReleaser
✅  Edit build pipeline and tested workflow

In order to let GoRelease push the artefacts you need to add GITHUB_TOKEN secret:
**The minimum permissions the GITHUB_TOKEN should have to run this are write:packages**