### PR TITLE
fix(#132): consistent naming for nullable columns in migration files

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -234,13 +234,13 @@ Here is the `pgroll` migration that will perform the migration to make the `desc
 
 ```json
 {
-  "name": "02_user_description_not_null",
+  "name": "02_user_description_nullable",
   "operations": [
     {
       "alter_column": {
         "table": "users",
         "column": "description",
-        "not_null": true,
+        "nullable": true,
         "up": "(SELECT CASE WHEN description IS NULL THEN 'description for ' || name ELSE description END)",
         "down": "description"
       }
@@ -249,10 +249,10 @@ Here is the `pgroll` migration that will perform the migration to make the `desc
 }
 ```
 
-Save this migration as `sql/02_user_description_not_null.json` and start the migration:
+Save this migration as `sql/02_user_description_nullable.json` and start the migration:
 
 ```
-pgroll start 02_user_description_not_null.json
+pgroll start 02_user_description_nullable.json
 ```
 
 After some progress updates you should see a message saying that the migration has been started successfully.
@@ -280,7 +280,7 @@ You should see something like this:
 | 10  | user_10  | description for user_10 | description for user_10  |
 ```
 
-`pgroll` has added a `_pgroll_new_description` field to the table and populated the field for all rows using the `up` SQL from the `02_user_description_not_null.json` file:
+`pgroll` has added a `_pgroll_new_description` field to the table and populated the field for all rows using the `up` SQL from the `02_user_description_nullable.json` file:
 
 ```json
 "up": "(SELECT CASE WHEN description IS NULL THEN 'description for ' || name ELSE description END)",
@@ -334,11 +334,11 @@ You should see something like this:
 | pgroll                              | postgres          |
 | public                              | pg_database_owner |
 | public_01_create_users_table        | postgres          |
-| public_02_user_description_not_null | postgres          |
+| public_02_user_description_nullable | postgres          |
 +-------------------------------------+-------------------+
 ```
 
-We have two schemas: one corresponding to the old schema, `public_01_create_users_table`, and one for the migration we just started, `public_02_user_description_not_null`. Each schema contains one view on the `users` table. Let's look at the view in the first schema:
+We have two schemas: one corresponding to the old schema, `public_01_create_users_table`, and one for the migration we just started, `public_02_user_description_nullable`. Each schema contains one view on the `users` table. Let's look at the view in the first schema:
 
 ```
 \d+ public_01_create_users_table.users
@@ -356,7 +356,7 @@ The output should contain something like this:
 and for the second view:
 
 ```
-\d+ public_02_user_description_not_null.users
+\d+ public_02_user_description_nullable.users
 ```
 
 The output should contain something like this:
@@ -370,7 +370,7 @@ The output should contain something like this:
 
 The second view exposes the same three columns as the first, but its `description` field is mapped to the `_pgroll_new_description` field in the underlying table. 
 
-By choosing to access the `users` table through either the `public_01_create_users_table.users` or `public_02_user_description_not_null.users` view, applications have a choice of which version of the schema they want to see; either the old version without the `NOT NULL` constraint on the `description` field or the new version with the constraint.
+By choosing to access the `users` table through either the `public_01_create_users_table.users` or `public_02_user_description_nullable.users` view, applications have a choice of which version of the schema they want to see; either the old version without the `NOT NULL` constraint on the `description` field or the new version with the constraint.
 
 When we looked at the schema of the `users` table, we saw that `pgroll` has created two triggers:
 
@@ -419,7 +419,7 @@ The trigger should have copied the data that was just written into the old `desc
 Let's check. Set the search path to the new version of the schema:
 
 ```sql
-SET search_path = 'public_02_user_description_not_null'
+SET search_path = 'public_02_user_description_nullable'
 ```
 
 and find the users we just inserted:
@@ -463,11 +463,11 @@ shows something like:
 +-------------------------------------+-------------------+
 | pgroll                              | postgres          |
 | public                              | pg_database_owner |
-| public_02_user_description_not_null | postgres          |
+| public_02_user_description_nullable | postgres          |
 +-------------------------------------+-------------------+
 ```
 
-Only the new version schema `public_02_user_description_not_null` remains in the database.
+Only the new version schema `public_02_user_description_nullable` remains in the database.
 
 Let's look at the schema of the `users` table to see what's changed there:
 
@@ -812,7 +812,7 @@ Add not null operations add a `NOT NULL` constraint to a column.
   "alter_column": {
     "table": "table name",
     "column": "column name",
-    "not_null": true,
+    "nullable": true,
     "up": "SQL expression",
     "down": "SQL expression"
   }
@@ -821,7 +821,7 @@ Add not null operations add a `NOT NULL` constraint to a column.
 
 Example **add not null** migrations:
 
-* [16_set_not_null.json](../examples/16_set_not_null.json)
+* [16_set_nullable.json](../examples/16_set_nullable.json)
 
 #### Add unique constraint
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -240,7 +240,7 @@ Here is the `pgroll` migration that will perform the migration to make the `desc
       "alter_column": {
         "table": "users",
         "column": "description",
-        "nullable": true,
+        "nullable": false,
         "up": "(SELECT CASE WHEN description IS NULL THEN 'description for ' || name ELSE description END)",
         "down": "description"
       }
@@ -812,7 +812,7 @@ Add not null operations add a `NOT NULL` constraint to a column.
   "alter_column": {
     "table": "table name",
     "column": "column name",
-    "nullable": true,
+    "nullable": false,
     "up": "SQL expression",
     "down": "SQL expression"
   }

--- a/docs/README.md
+++ b/docs/README.md
@@ -328,14 +328,14 @@ For now, let's look at the schemas in the database:
 You should see something like this:
 
 ```
-+-------------------------------------+-------------------+
-| Name                                | Owner             |
-+-------------------------------------+-------------------+
-| pgroll                              | postgres          |
-| public                              | pg_database_owner |
-| public_01_create_users_table        | postgres          |
++-----------------------------------------+-------------------+
+| Name                                    | Owner             |
++-----------------------------------------+-------------------+
+| pgroll                                  | postgres          |
+| public                                  | pg_database_owner |
+| public_01_create_users_table            | postgres          |
 | public_02_user_description_set_nullable | postgres          |
-+-------------------------------------+-------------------+
++-----------------------------------------+-------------------+
 ```
 
 We have two schemas: one corresponding to the old schema, `public_01_create_users_table`, and one for the migration we just started, `public_02_user_description_set_nullable`. Each schema contains one view on the `users` table. Let's look at the view in the first schema:
@@ -458,13 +458,13 @@ After the migration has completed, the old version of the schema is no longer pr
 shows something like:
 
 ```
-+-------------------------------------+-------------------+
-| Name                                | Owner             |
-+-------------------------------------+-------------------+
-| pgroll                              | postgres          |
-| public                              | pg_database_owner |
++-----------------------------------------+-------------------+
+| Name                                    | Owner             |
++-----------------------------------------+-------------------+
+| pgroll                                  | postgres          |
+| public                                  | pg_database_owner |
 | public_02_user_description_set_nullable | postgres          |
-+-------------------------------------+-------------------+
++-----------------------------------------+-------------------+
 ```
 
 Only the new version schema `public_02_user_description_set_nullable` remains in the database.

--- a/docs/README.md
+++ b/docs/README.md
@@ -234,7 +234,7 @@ Here is the `pgroll` migration that will perform the migration to make the `desc
 
 ```json
 {
-  "name": "02_user_description_nullable",
+  "name": "02_user_description_set_nullable",
   "operations": [
     {
       "alter_column": {
@@ -249,10 +249,10 @@ Here is the `pgroll` migration that will perform the migration to make the `desc
 }
 ```
 
-Save this migration as `sql/02_user_description_nullable.json` and start the migration:
+Save this migration as `sql/02_user_description_set_nullable.json` and start the migration:
 
 ```
-pgroll start 02_user_description_nullable.json
+pgroll start 02_user_description_set_nullable.json
 ```
 
 After some progress updates you should see a message saying that the migration has been started successfully.
@@ -280,7 +280,7 @@ You should see something like this:
 | 10  | user_10  | description for user_10 | description for user_10  |
 ```
 
-`pgroll` has added a `_pgroll_new_description` field to the table and populated the field for all rows using the `up` SQL from the `02_user_description_nullable.json` file:
+`pgroll` has added a `_pgroll_new_description` field to the table and populated the field for all rows using the `up` SQL from the `02_user_description_set_nullable.json` file:
 
 ```json
 "up": "(SELECT CASE WHEN description IS NULL THEN 'description for ' || name ELSE description END)",
@@ -334,11 +334,11 @@ You should see something like this:
 | pgroll                              | postgres          |
 | public                              | pg_database_owner |
 | public_01_create_users_table        | postgres          |
-| public_02_user_description_nullable | postgres          |
+| public_02_user_description_set_nullable | postgres          |
 +-------------------------------------+-------------------+
 ```
 
-We have two schemas: one corresponding to the old schema, `public_01_create_users_table`, and one for the migration we just started, `public_02_user_description_nullable`. Each schema contains one view on the `users` table. Let's look at the view in the first schema:
+We have two schemas: one corresponding to the old schema, `public_01_create_users_table`, and one for the migration we just started, `public_02_user_description_set_nullable`. Each schema contains one view on the `users` table. Let's look at the view in the first schema:
 
 ```
 \d+ public_01_create_users_table.users
@@ -356,7 +356,7 @@ The output should contain something like this:
 and for the second view:
 
 ```
-\d+ public_02_user_description_nullable.users
+\d+ public_02_user_description_set_nullable.users
 ```
 
 The output should contain something like this:
@@ -370,7 +370,7 @@ The output should contain something like this:
 
 The second view exposes the same three columns as the first, but its `description` field is mapped to the `_pgroll_new_description` field in the underlying table. 
 
-By choosing to access the `users` table through either the `public_01_create_users_table.users` or `public_02_user_description_nullable.users` view, applications have a choice of which version of the schema they want to see; either the old version without the `NOT NULL` constraint on the `description` field or the new version with the constraint.
+By choosing to access the `users` table through either the `public_01_create_users_table.users` or `public_02_user_description_set_nullable.users` view, applications have a choice of which version of the schema they want to see; either the old version without the `NOT NULL` constraint on the `description` field or the new version with the constraint.
 
 When we looked at the schema of the `users` table, we saw that `pgroll` has created two triggers:
 
@@ -419,7 +419,7 @@ The trigger should have copied the data that was just written into the old `desc
 Let's check. Set the search path to the new version of the schema:
 
 ```sql
-SET search_path = 'public_02_user_description_nullable'
+SET search_path = 'public_02_user_description_set_nullable'
 ```
 
 and find the users we just inserted:
@@ -463,11 +463,11 @@ shows something like:
 +-------------------------------------+-------------------+
 | pgroll                              | postgres          |
 | public                              | pg_database_owner |
-| public_02_user_description_nullable | postgres          |
+| public_02_user_description_set_nullable | postgres          |
 +-------------------------------------+-------------------+
 ```
 
-Only the new version schema `public_02_user_description_nullable` remains in the database.
+Only the new version schema `public_02_user_description_set_nullable` remains in the database.
 
 Let's look at the schema of the `users` table to see what's changed there:
 

--- a/examples/16_set_nullable.json
+++ b/examples/16_set_nullable.json
@@ -1,11 +1,11 @@
 {
-  "name": "16_set_not_null",
+  "name": "16_set_nullable",
   "operations": [
     {
       "alter_column": {
         "table": "reviews",
         "column": "review",
-        "not_null": true,
+        "nullable": true,
         "up": "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
         "down": "review"
       }

--- a/examples/16_set_nullable.json
+++ b/examples/16_set_nullable.json
@@ -5,7 +5,7 @@
       "alter_column": {
         "table": "reviews",
         "column": "review",
-        "nullable": true,
+        "nullable": false,
         "up": "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
         "down": "review"
       }

--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -76,7 +76,7 @@ func (o *OpAlterColumn) Validate(ctx context.Context, s *schema.Schema) error {
 		}
 
 	case *OpSetNotNull:
-		if o.Nullable != nil && !*o.Nullable {
+		if o.Nullable != nil && *o.Nullable {
 			return fmt.Errorf("removing NOT NULL constraints is not supported")
 		}
 	}

--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -17,7 +17,7 @@ type OpAlterColumn struct {
 	Type       string               `json:"type"`
 	Check      *CheckConstraint     `json:"check"`
 	References *ForeignKeyReference `json:"references"`
-	NotNull    *bool                `json:"not_null"`
+	Nullable   *bool                `json:"nullable"`
 	Unique     *UniqueConstraint    `json:"unique"`
 	Up         string               `json:"up"`
 	Down       string               `json:"down"`
@@ -76,7 +76,7 @@ func (o *OpAlterColumn) Validate(ctx context.Context, s *schema.Schema) error {
 		}
 
 	case *OpSetNotNull:
-		if o.NotNull != nil && !*o.NotNull {
+		if o.Nullable != nil && !*o.Nullable {
 			return fmt.Errorf("removing NOT NULL constraints is not supported")
 		}
 	}
@@ -121,7 +121,7 @@ func (o *OpAlterColumn) innerOperation() Operation {
 			Down:       o.Down,
 		}
 
-	case o.NotNull != nil:
+	case o.Nullable != nil:
 		return &OpSetNotNull{
 			Table:  o.Table,
 			Column: o.Column,
@@ -158,7 +158,7 @@ func (o *OpAlterColumn) numChanges() int {
 	if o.References != nil {
 		fieldsSet++
 	}
-	if o.NotNull != nil {
+	if o.Nullable != nil {
 		fieldsSet++
 	}
 	if o.Unique != nil {

--- a/pkg/migrations/op_set_notnull_test.go
+++ b/pkg/migrations/op_set_notnull_test.go
@@ -15,7 +15,7 @@ func TestSetNotNull(t *testing.T) {
 
 	ExecuteTests(t, TestCases{
 		{
-			name: "set not null with default down sql",
+			name: "set nullable with default down sql",
 			migrations: []migrations.Migration{
 				{
 					Name: "01_add_table",
@@ -48,12 +48,12 @@ func TestSetNotNull(t *testing.T) {
 					},
 				},
 				{
-					Name: "02_set_not_null",
+					Name: "02_set_nullable",
 					Operations: migrations.Operations{
 						&migrations.OpAlterColumn{
 							Table:    "reviews",
 							Column:   "review",
-							Nullable: ptr(true),
+							Nullable: ptr(false),
 							Up:       "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
 						},
 					},
@@ -64,13 +64,13 @@ func TestSetNotNull(t *testing.T) {
 				ColumnMustExist(t, db, "public", "reviews", migrations.TemporaryName("review"))
 
 				// Inserting a NULL into the new `review` column should fail
-				MustNotInsert(t, db, "public", "02_set_not_null", "reviews", map[string]string{
+				MustNotInsert(t, db, "public", "02_set_nullable", "reviews", map[string]string{
 					"username": "alice",
 					"product":  "apple",
 				})
 
 				// Inserting a non-NULL value into the new `review` column should succeed
-				MustInsert(t, db, "public", "02_set_not_null", "reviews", map[string]string{
+				MustInsert(t, db, "public", "02_set_nullable", "reviews", map[string]string{
 					"username": "alice",
 					"product":  "apple",
 					"review":   "amazing",
@@ -91,7 +91,7 @@ func TestSetNotNull(t *testing.T) {
 
 				// The NULL value inserted into the old `review` column has been written into
 				// the new `review` column using the `up` SQL.
-				rows = MustSelect(t, db, "public", "02_set_not_null", "reviews")
+				rows = MustSelect(t, db, "public", "02_set_nullable", "reviews")
 				assert.Equal(t, []map[string]any{
 					{"id": 2, "username": "alice", "product": "apple", "review": "amazing"},
 					{"id": 3, "username": "bob", "product": "banana", "review": "banana is good"},
@@ -106,7 +106,7 @@ func TestSetNotNull(t *testing.T) {
 
 				// The non-NULL value inserted into the old `review` column has been copied
 				// unchanged into the new `review` column.
-				rows = MustSelect(t, db, "public", "02_set_not_null", "reviews")
+				rows = MustSelect(t, db, "public", "02_set_nullable", "reviews")
 				assert.Equal(t, []map[string]any{
 					{"id": 2, "username": "alice", "product": "apple", "review": "amazing"},
 					{"id": 3, "username": "bob", "product": "banana", "review": "banana is good"},
@@ -132,7 +132,7 @@ func TestSetNotNull(t *testing.T) {
 				ColumnMustNotExist(t, db, "public", "reviews", migrations.TemporaryName("review"))
 
 				// Selecting from the `reviews` view should succeed.
-				rows := MustSelect(t, db, "public", "02_set_not_null", "reviews")
+				rows := MustSelect(t, db, "public", "02_set_nullable", "reviews")
 				assert.Equal(t, []map[string]any{
 					{"id": 2, "username": "alice", "product": "apple", "review": "amazing"},
 					{"id": 3, "username": "bob", "product": "banana", "review": "banana is good"},
@@ -140,7 +140,7 @@ func TestSetNotNull(t *testing.T) {
 				}, rows)
 
 				// Writing NULL reviews into the `review` column should fail.
-				MustNotInsert(t, db, "public", "02_set_not_null", "reviews", map[string]string{
+				MustNotInsert(t, db, "public", "02_set_nullable", "reviews", map[string]string{
 					"username": "daisy",
 					"product":  "durian",
 				})
@@ -157,7 +157,7 @@ func TestSetNotNull(t *testing.T) {
 			},
 		},
 		{
-			name: "set not null with user-supplied down sql",
+			name: "set nullable with user-supplied down sql",
 			migrations: []migrations.Migration{
 				{
 					Name: "01_add_table",
@@ -190,12 +190,12 @@ func TestSetNotNull(t *testing.T) {
 					},
 				},
 				{
-					Name: "02_set_not_null",
+					Name: "02_set_nullable",
 					Operations: migrations.Operations{
 						&migrations.OpAlterColumn{
 							Table:    "reviews",
 							Column:   "review",
-							Nullable: ptr(true),
+							Nullable: ptr(false),
 							Up:       "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
 							Down:     "review || ' (from new column)'",
 						},
@@ -204,7 +204,7 @@ func TestSetNotNull(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB) {
 				// Inserting a non-NULL value into the new `review` column should succeed
-				MustInsert(t, db, "public", "02_set_not_null", "reviews", map[string]string{
+				MustInsert(t, db, "public", "02_set_nullable", "reviews", map[string]string{
 					"username": "alice",
 					"product":  "apple",
 					"review":   "amazing",
@@ -265,12 +265,12 @@ func TestSetNotNullValidation(t *testing.T) {
 			migrations: []migrations.Migration{
 				createTableMigration,
 				{
-					Name: "02_set_not_null",
+					Name: "02_set_nullable",
 					Operations: migrations.Operations{
 						&migrations.OpAlterColumn{
 							Table:    "reviews",
 							Column:   "review",
-							Nullable: ptr(true),
+							Nullable: ptr(false),
 							Down:     "review",
 						},
 					},
@@ -312,12 +312,12 @@ func TestSetNotNullValidation(t *testing.T) {
 					},
 				},
 				{
-					Name: "02_set_not_null",
+					Name: "02_set_nullable",
 					Operations: migrations.Operations{
 						&migrations.OpAlterColumn{
 							Table:    "reviews",
 							Column:   "review",
-							Nullable: ptr(true),
+							Nullable: ptr(false),
 							Up:       "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
 							Down:     "review",
 						},

--- a/pkg/migrations/op_set_notnull_test.go
+++ b/pkg/migrations/op_set_notnull_test.go
@@ -51,10 +51,10 @@ func TestSetNotNull(t *testing.T) {
 					Name: "02_set_not_null",
 					Operations: migrations.Operations{
 						&migrations.OpAlterColumn{
-							Table:   "reviews",
-							Column:  "review",
-							NotNull: ptr(true),
-							Up:      "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
+							Table:    "reviews",
+							Column:   "review",
+							Nullable: ptr(true),
+							Up:       "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
 						},
 					},
 				},
@@ -193,11 +193,11 @@ func TestSetNotNull(t *testing.T) {
 					Name: "02_set_not_null",
 					Operations: migrations.Operations{
 						&migrations.OpAlterColumn{
-							Table:   "reviews",
-							Column:  "review",
-							NotNull: ptr(true),
-							Up:      "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
-							Down:    "review || ' (from new column)'",
+							Table:    "reviews",
+							Column:   "review",
+							Nullable: ptr(true),
+							Up:       "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
+							Down:     "review || ' (from new column)'",
 						},
 					},
 				},
@@ -268,10 +268,10 @@ func TestSetNotNullValidation(t *testing.T) {
 					Name: "02_set_not_null",
 					Operations: migrations.Operations{
 						&migrations.OpAlterColumn{
-							Table:   "reviews",
-							Column:  "review",
-							NotNull: ptr(true),
-							Down:    "review",
+							Table:    "reviews",
+							Column:   "review",
+							Nullable: ptr(true),
+							Down:     "review",
 						},
 					},
 				},
@@ -315,11 +315,11 @@ func TestSetNotNullValidation(t *testing.T) {
 					Name: "02_set_not_null",
 					Operations: migrations.Operations{
 						&migrations.OpAlterColumn{
-							Table:   "reviews",
-							Column:  "review",
-							NotNull: ptr(true),
-							Up:      "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
-							Down:    "review",
+							Table:    "reviews",
+							Column:   "review",
+							Nullable: ptr(true),
+							Up:       "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
+							Down:     "review",
 						},
 					},
 				},


### PR DESCRIPTION
Realated Issue: #132

This PR includes **BREAKING CHANGES**, existing migrations that add a not null constraint using the `not_null` property will not work anymore. The migration strategy would be to rename those `not_null` fields in `alter_column` operations to `nullable`.