### PR TITLE
Mark releases as draft

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,15 +21,19 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
+
+release:
+  draft: true
+
 brews:
-  -
-    name: pgroll
+  - name: pgroll
     homepage: "https://www.xata.io"
     description: "Postgres zero-downtime migrations made easy"
     license: "Apache-2.0"
     repository:
       owner: xataio
       name: homebrew-pgroll
+
 archives:
   - format: binary
     name_template: >-


### PR DESCRIPTION
Until we are happy with the goreleaser based release flow.

This means the release will have to be manually published before being generally visible.