### PR TITLE
Remove unnecessary env section from release job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,8 +105,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, lint, examples, license-check]
     if: startsWith(github.ref, 'refs/tags/')
-    env:
-      PGROLL_VERSION: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || github.sha }}
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
goreleaser's template already populates a .Version field so we don't need this (it was unused since the switch to goreleaser).