### PR TITLE
Fix `previous_version` function to work with non-`public` schema

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -63,7 +63,7 @@ STABLE;
 -- Get the name of the previous version of the schema, or NULL if there is none.
 CREATE OR REPLACE FUNCTION %[1]s.previous_version(schemaname NAME) RETURNS text
 AS $$
-  SELECT parent FROM %[1]s.migrations WHERE name = (SELECT %[1]s.latest_version('public')) AND schema=schemaname;
+  SELECT parent FROM %[1]s.migrations WHERE name = (SELECT %[1]s.latest_version(schemaname)) AND schema=schemaname;
 $$
 LANGUAGE SQL
 STABLE;


### PR DESCRIPTION
Fix the `previous_version` function so that it works correctly for migrations applied in schema other than`public`.

In particular, this meant that the previous version schema would not be removed on migration completion for migrations applied is schema other than `public`.

Extend the test that checks the `--schema` flag is respected with the extra coverage that would have caught this.
