### PR TITLE
Add `SECURITY DEFINER` to internal functions

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -51,6 +51,7 @@ CREATE OR REPLACE FUNCTION %[1]s.is_active_migration_period(schemaname NAME) RET
 
 -- Get the latest version name (this is the one with child migrations)
 CREATE OR REPLACE FUNCTION %[1]s.latest_version(schemaname NAME) RETURNS text
+SECURITY DEFINER
 AS $$ 
   SELECT p.name FROM %[1]s.migrations p 
   WHERE NOT EXISTS (

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -172,7 +172,7 @@ BEGIN
 
 	ELSIF tg_event = 'ddl_command_end' THEN
 		-- Guess the schema from ddl commands, ignore migrations that touch several schemas
-		IF (SELECT COUNT(DISTINCT schema_name) FROM pg_catalog.pg_event_trigger_ddl_commands() WHERE schema_name IS NOT NULL) > 1 THEN
+		IF (SELECT pg_catalog.count(DISTINCT schema_name) FROM pg_catalog.pg_event_trigger_ddl_commands() WHERE schema_name IS NOT NULL) > 1 THEN
 			RAISE NOTICE 'pgroll: ignoring migration that changes several schemas';
 			RETURN;
 		END IF;

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -52,6 +52,7 @@ CREATE OR REPLACE FUNCTION %[1]s.is_active_migration_period(schemaname NAME) RET
 -- Get the latest version name (this is the one with child migrations)
 CREATE OR REPLACE FUNCTION %[1]s.latest_version(schemaname NAME) RETURNS text
 SECURITY DEFINER
+SET search_path = %[1]s, pg_catalog
 AS $$ 
   SELECT p.name FROM %[1]s.migrations p 
   WHERE NOT EXISTS (
@@ -155,27 +156,28 @@ $$;
 
 CREATE OR REPLACE FUNCTION %[1]s.raw_migration() RETURNS event_trigger
 LANGUAGE plpgsql 
-SECURITY DEFINER AS $$
+SECURITY DEFINER
+SET search_path = %[1]s, pg_catalog AS $$
 DECLARE
 	schemaname TEXT;
 BEGIN
 	-- Ignore migrations done by pgroll
-	IF (current_setting('pgroll.internal', 'TRUE') <> 'TRUE') THEN
+	IF (pg_catalog.current_setting('pgroll.internal', 'TRUE') <> 'TRUE') THEN
 		RETURN;
 	END IF;
 
 	IF tg_event = 'sql_drop' THEN
 		-- Guess the schema from drop commands
-		SELECT schema_name INTO schemaname FROM pg_event_trigger_dropped_objects() WHERE schema_name IS NOT NULL;
+		SELECT schema_name INTO schemaname FROM pg_catalog.pg_event_trigger_dropped_objects() WHERE schema_name IS NOT NULL;
 
 	ELSIF tg_event = 'ddl_command_end' THEN
 		-- Guess the schema from ddl commands, ignore migrations that touch several schemas
-		IF (SELECT COUNT(DISTINCT schema_name) FROM pg_event_trigger_ddl_commands() WHERE schema_name IS NOT NULL) > 1 THEN
+		IF (SELECT COUNT(DISTINCT schema_name) FROM pg_catalog.pg_event_trigger_ddl_commands() WHERE schema_name IS NOT NULL) > 1 THEN
 			RAISE NOTICE 'pgroll: ignoring migration that changes several schemas';
 			RETURN;
 		END IF;
 
-		SELECT schema_name INTO schemaname FROM pg_event_trigger_ddl_commands() WHERE schema_name IS NOT NULL;
+		SELECT schema_name INTO schemaname FROM pg_catalog.pg_event_trigger_ddl_commands() WHERE schema_name IS NOT NULL;
 	END IF;
 
 	IF schemaname IS NULL THEN
@@ -194,7 +196,7 @@ BEGIN
 	VALUES (
 		schemaname,
 		format('sql_%%s', substr(md5(random()::text), 0, 15)),
-		json_build_object('sql', json_build_object('up', current_query())),
+		pg_catalog.json_build_object('sql', pg_catalog.json_build_object('up', pg_catalog.current_query())),
 		%[1]s.read_schema(schemaname),
 		true,
 		%[1]s.latest_version(schemaname)

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -153,7 +153,8 @@ END;
 $$;
 
 CREATE OR REPLACE FUNCTION %[1]s.raw_migration() RETURNS event_trigger
-LANGUAGE plpgsql AS $$
+LANGUAGE plpgsql 
+SECURITY DEFINER AS $$
 DECLARE
 	schemaname TEXT;
 BEGIN

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -52,7 +52,7 @@ CREATE OR REPLACE FUNCTION %[1]s.is_active_migration_period(schemaname NAME) RET
 -- Get the latest version name (this is the one with child migrations)
 CREATE OR REPLACE FUNCTION %[1]s.latest_version(schemaname NAME) RETURNS text
 SECURITY DEFINER
-SET search_path = %[1]s, pg_catalog
+SET search_path = %[1]s, pg_catalog, pg_temp
 AS $$ 
   SELECT p.name FROM %[1]s.migrations p 
   WHERE NOT EXISTS (
@@ -157,7 +157,7 @@ $$;
 CREATE OR REPLACE FUNCTION %[1]s.raw_migration() RETURNS event_trigger
 LANGUAGE plpgsql 
 SECURITY DEFINER
-SET search_path = %[1]s, pg_catalog AS $$
+SET search_path = %[1]s, pg_catalog, pg_temp AS $$
 DECLARE
 	schemaname TEXT;
 BEGIN
@@ -195,7 +195,7 @@ BEGIN
 	INSERT INTO %[1]s.migrations (schema, name, migration, resulting_schema, done, parent)
 	VALUES (
 		schemaname,
-		format('sql_%%s', substr(md5(random()::text), 0, 15)),
+		pg_catalog.format('sql_%%s',pg_catalog.substr(md5(random()::text), 0, 15)),
 		pg_catalog.json_build_object('sql', pg_catalog.json_build_object('up', pg_catalog.current_query())),
 		%[1]s.read_schema(schemaname),
 		true,

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -195,7 +195,7 @@ BEGIN
 	INSERT INTO %[1]s.migrations (schema, name, migration, resulting_schema, done, parent)
 	VALUES (
 		schemaname,
-		pg_catalog.format('sql_%%s',pg_catalog.substr(md5(random()::text), 0, 15)),
+		pg_catalog.format('sql_%%s',pg_catalog.substr(pg_catalog.md5(pg_catalog.random()::text), 0, 15)),
 		pg_catalog.json_build_object('sql', pg_catalog.json_build_object('up', pg_catalog.current_query())),
 		%[1]s.read_schema(schemaname),
 		true,


### PR DESCRIPTION
We want to work on the security model for the `pgroll` schema, allowing admins to remove access while maintaining functionality intact. Because of this, some functions must still be marked as executable for any user doing migrations directly with postgres.

This PR adds `SECURITY DEFINER` to these functions