### PR TITLE
Ping after creating connection

### DIFF
--- a/pkg/roll/roll.go
+++ b/pkg/roll/roll.go
@@ -39,6 +39,10 @@ func New(ctx context.Context, pgURL, schema string, lockTimeoutMs int, state *st
 		return nil, err
 	}
 
+	if err := conn.PingContext(ctx); err != nil {
+		return nil, err
+	}
+
 	_, err = conn.ExecContext(ctx, "SET LOCAL pgroll.internal to 'TRUE'")
 	if err != nil {
 		return nil, fmt.Errorf("unable to set pgroll.internal to true: %w", err)

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -225,6 +225,10 @@ func New(ctx context.Context, pgURL, stateSchema string) (*State, error) {
 		return nil, err
 	}
 
+	if err := conn.PingContext(ctx); err != nil {
+		return nil, err
+	}
+
 	_, err = conn.ExecContext(ctx, "SET LOCAL pgroll.internal to 'TRUE'")
 	if err != nil {
 		return nil, fmt.Errorf("unable to set pgroll.internal to true: %w", err)


### PR DESCRIPTION
Ping the database after establishing a connection for better error messages.

Without this change, an error establishing a connection would be prefixed with the message from the next failure.

**before**:
```
Error: unable to set pgroll.internal to true: dial tcp [::1]:7432: connect: connection refused
```

**after**:
```
Error: dial tcp [::1]:7432: connect: connection refused 
```

Fixes https://github.com/xataio/pgroll/issues/133
