### PR TITLE
Fix primary keys retrieval query

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -128,7 +128,6 @@ BEGIN
 					WHERE
 						indrelid = t.oid AND
 						nspname = schemaname AND
-						t.relnamespace = ns.oid AND
 						pg_attribute.attrelid = t.oid AND
 						pg_attribute.attnum = any(pg_index.indkey)
 						AND indisprimary

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -126,7 +126,6 @@ BEGIN
 					SELECT json_agg(pg_attribute.attname) AS primary_key_columns
 					FROM pg_index, pg_attribute
 					WHERE
-						t.oid = t.oid::regclass AND
 						indrelid = t.oid AND
 						nspname = schemaname AND
 						t.relnamespace = ns.oid AND
@@ -139,7 +138,6 @@ BEGIN
 				    'name', pi.indexrelid::regclass
 				  ))
 				  FROM pg_index pi 
-				  INNER JOIN pg_class pgc ON pi.indexrelid = pgc.oid
 				  WHERE pi.indrelid = t.oid::regclass
 				)
 			)) FROM pg_class AS t

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -124,13 +124,13 @@ BEGIN
 				),
 				'primaryKey', (
 					SELECT json_agg(pg_attribute.attname) AS primary_key_columns
-					FROM pg_index, pg_class, pg_attribute, pg_namespace
+					FROM pg_index, pg_attribute
 					WHERE
-						pg_class.oid = t.oid::regclass AND
-						indrelid = pg_class.oid AND
+						t.oid = t.oid::regclass AND
+						indrelid = t.oid AND
 						nspname = schemaname AND
-						pg_class.relnamespace = pg_namespace.oid AND
-						pg_attribute.attrelid = pg_class.oid AND
+						t.relnamespace = ns.oid AND
+						pg_attribute.attrelid = t.oid AND
 						pg_attribute.attnum = any(pg_index.indkey)
 						AND indisprimary
 				),

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -123,13 +123,16 @@ BEGIN
 					) c
 				),
 				'primaryKey', (
-				  SELECT json_agg(kcu.column_name) AS primary_key_columns
-				  FROM information_schema.table_constraints AS tc 
-				  JOIN information_schema.key_column_usage AS kcu 
-				  ON tc.constraint_name = kcu.constraint_name
-				  WHERE tc.table_name = t.relname
-				  AND tc.table_schema = schemaname
-				  AND tc.constraint_type = 'PRIMARY KEY'
+					SELECT json_agg(pg_attribute.attname) AS primary_key_columns
+					FROM pg_index, pg_class, pg_attribute, pg_namespace
+					WHERE
+						pg_class.oid = t.oid::regclass AND
+						indrelid = pg_class.oid AND
+						nspname = schemaname AND
+						pg_class.relnamespace = pg_namespace.oid AND
+						pg_attribute.attrelid = pg_class.oid AND
+						pg_attribute.attnum = any(pg_index.indkey)
+						AND indisprimary
 				),
 				'indexes', (
 				  SELECT json_object_agg(pi.indexrelid::regclass, json_build_object(


### PR DESCRIPTION
The previous query had some issues when used under clusters with many schema objects, this one improves query performance