### PR TITLE
Add section to README about RLS in Postgres 14

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
     * [Multiple schema versions](#multiple-schema-versions)
     * [Client applications](#client-applications)
 * [Installation](#installation)
+* [Supported Postgres versions](#supported-postgres-versions)
 * [Tutorial](#tutorial)
 * [Command line reference](#command-line-reference)
     * [init](#init)
@@ -110,6 +111,12 @@ To install `pgroll` with homebrew, run the following command:
 brew tap xataio/pgroll
 brew install pgroll
 ```
+
+## Supported Postgres versions
+
+`pgroll` supports Postgres versions >= 14.
+
+:warning: In Postgres 14, row level security policies on tables are not respected by `pgroll`'s versioned views. This is because `pgroll` is unable to create the views with the `(security_invoker = true)` option, as the ability to do so was added in Postgres 15. If you use RLS in Postgres 14 `pgroll` is likely a poor choice of migration tool. All other `pgroll` features are fully supported across all supported Postgres versions.
 
 ## Tutorial
 


### PR DESCRIPTION
Add a section covering the limitations of `pgroll` and row level security policies in Postgres 14.

[[Direct link](https://github.com/xataio/pgroll/blob/document-rls/docs/README.md#supported-postgres-versions)]

Relates to https://github.com/xataio/pgroll/issues/179