### PR TITLE
Show the status for the correct schema

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -30,7 +30,7 @@ var statusCmd = &cobra.Command{
 		}
 		defer state.Close()
 
-		statusLine, err := statusForSchema(ctx, state, flags.StateSchema())
+		statusLine, err := statusForSchema(ctx, state, flags.Schema())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fix the `pgroll status` command so that it shows the status for the correct schema (ie the one set by the `--schema` flag, or `"public"` by default).

Prior to this the command would show the status for the `--pgroll-schema` (`"pgroll"`  by default).

This appears to have been broken since #152.