### PR TITLE
Move logic for the `status` command into the `state` and `migrations` packages

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -13,12 +13,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type statusLine struct {
-	Schema  string
-	Version string
-	Status  string
-}
-
 var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show pgroll status",
@@ -30,12 +24,12 @@ var statusCmd = &cobra.Command{
 		}
 		defer state.Close()
 
-		statusLine, err := statusForSchema(ctx, state, flags.Schema())
+		status, err := statusForSchema(ctx, state, flags.Schema())
 		if err != nil {
 			return err
 		}
 
-		statusJSON, err := json.MarshalIndent(statusLine, "", "  ")
+		statusJSON, err := json.MarshalIndent(status, "", "  ")
 		if err != nil {
 			return err
 		}
@@ -45,7 +39,7 @@ var statusCmd = &cobra.Command{
 	},
 }
 
-func statusForSchema(ctx context.Context, st *state.State, schema string) (*statusLine, error) {
+func statusForSchema(ctx context.Context, st *state.State, schema string) (*state.Status, error) {
 	latestVersion, err := st.LatestVersion(ctx, schema)
 	if err != nil {
 		return nil, err
@@ -68,7 +62,7 @@ func statusForSchema(ctx context.Context, st *state.State, schema string) (*stat
 		status = "Complete"
 	}
 
-	return &statusLine{
+	return &state.Status{
 		Schema:  schema,
 		Version: *latestVersion,
 		Status:  status,

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -3,7 +3,6 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 
@@ -24,7 +23,7 @@ var statusCmd = &cobra.Command{
 		}
 		defer state.Close()
 
-		status, err := statusForSchema(ctx, state, flags.Schema())
+		status, err := state.Status(ctx, flags.Schema())
 		if err != nil {
 			return err
 		}
@@ -37,34 +36,4 @@ var statusCmd = &cobra.Command{
 		fmt.Println(string(statusJSON))
 		return nil
 	},
-}
-
-func statusForSchema(ctx context.Context, st *state.State, schema string) (*state.Status, error) {
-	latestVersion, err := st.LatestVersion(ctx, schema)
-	if err != nil {
-		return nil, err
-	}
-	if latestVersion == nil {
-		latestVersion = new(string)
-	}
-
-	isActive, err := st.IsActiveMigrationPeriod(ctx, schema)
-	if err != nil {
-		return nil, err
-	}
-
-	var status string
-	if *latestVersion == "" {
-		status = "No migrations"
-	} else if isActive {
-		status = "In Progress"
-	} else {
-		status = "Complete"
-	}
-
-	return &state.Status{
-		Schema:  schema,
-		Version: *latestVersion,
-		Status:  status,
-	}, nil
 }

--- a/pkg/roll/roll.go
+++ b/pkg/roll/roll.go
@@ -75,6 +75,10 @@ func (m *Roll) PGVersion() PGVersion {
 	return m.pgVersion
 }
 
+func (m *Roll) Status(ctx context.Context, schema string) (*state.Status, error) {
+	return m.state.Status(ctx, schema)
+}
+
 func (m *Roll) Close() error {
 	err := m.state.Close()
 	if err != nil {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -349,13 +349,13 @@ func (s *State) Status(ctx context.Context, schema string) (*Status, error) {
 		return nil, err
 	}
 
-	var status string
+	var status MigrationStatus
 	if *latestVersion == "" {
-		status = "No migrations"
+		status = NoneMigrationStatus
 	} else if isActive {
-		status = "In Progress"
+		status = InProgressMigrationStatus
 	} else {
-		status = "Complete"
+		status = CompleteMigrationStatus
 	}
 
 	return &Status{

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -334,6 +334,37 @@ func (s *State) PreviousVersion(ctx context.Context, schema string) (*string, er
 	return parent, nil
 }
 
+// Status returns the current migration status of the specified schema
+func (s *State) Status(ctx context.Context, schema string) (*Status, error) {
+	latestVersion, err := s.LatestVersion(ctx, schema)
+	if err != nil {
+		return nil, err
+	}
+	if latestVersion == nil {
+		latestVersion = new(string)
+	}
+
+	isActive, err := s.IsActiveMigrationPeriod(ctx, schema)
+	if err != nil {
+		return nil, err
+	}
+
+	var status string
+	if *latestVersion == "" {
+		status = "No migrations"
+	} else if isActive {
+		status = "In Progress"
+	} else {
+		status = "Complete"
+	}
+
+	return &Status{
+		Schema:  schema,
+		Version: *latestVersion,
+		Status:  status,
+	}, nil
+}
+
 // ReadSchema reads & returns the current schema from postgres
 func ReadSchema(ctx context.Context, conn *sql.DB, stateSchema, schemaname string) (*schema.Schema, error) {
 	var res schema.Schema

--- a/pkg/state/status.go
+++ b/pkg/state/status.go
@@ -2,6 +2,14 @@
 
 package state
 
+type MigrationStatus string
+
+const (
+	NoneMigrationStatus       MigrationStatus = "No migrations"
+	InProgressMigrationStatus MigrationStatus = "In progress"
+	CompleteMigrationStatus   MigrationStatus = "Complete"
+)
+
 // Status describes the current migration status of a database schema.
 type Status struct {
 	// The schema name.
@@ -11,5 +19,5 @@ type Status struct {
 	Version string `json:"version"`
 
 	// The status of the most recent migration.
-	Status string `json:"status"`
+	Status MigrationStatus `json:"status"`
 }

--- a/pkg/state/status.go
+++ b/pkg/state/status.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+// Status describes the current migration status of a database schema.
+type Status struct {
+	// The schema name.
+	Schema string `json:"schema"`
+
+	// The name of the latest version schema.
+	Version string `json:"version"`
+
+	// The status of the most recent migration.
+	Status string `json:"status"`
+}


### PR DESCRIPTION
Move the logic for the `pgroll status` command out of the CLI and into the `migrations` and `state` package and add tests for it.

This makes it possible to consume migration status information from packages using `pgroll` as a module.