### PR TITLE
Quote table name in `OpSetReplicaIdentity`

### DIFF
--- a/pkg/migrations/op_set_replica_identity.go
+++ b/pkg/migrations/op_set_replica_identity.go
@@ -33,7 +33,9 @@ func (o *OpSetReplicaIdentity) Start(ctx context.Context, conn *sql.DB, stateSch
 	}
 
 	// set the replica identity on the underlying table
-	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s REPLICA IDENTITY %s", o.Table, identitySQL))
+	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s REPLICA IDENTITY %s",
+		pq.QuoteIdentifier(o.Table),
+		identitySQL))
 	return err
 }
 


### PR DESCRIPTION
Fix table name quoting in the `OpSetReplicaIdentity` operation. 

This was causing the operation to fail on tables with case-sensitive names.