### PR TITLE
docs: Clarify rules for quoting string literals

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -724,6 +724,7 @@ Example **add column** migrations:
 * [06_add_column_to_sql_table.json](../examples/06_add_column_to_sql_table.json)
 * [17_add_rating_column.json](../examples/17_add_rating_column.json)
 * [26_add_column_with_check_constraint.json](../examples/26_add_column_with_check_constraint.json)
+* [30_add_column_simple_up.json](../examples/30_add_column_simple_up.json)
 
 ### Alter column
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -716,6 +716,8 @@ An add column operation creates a new column on an existing table.
 }
 ```
 
+Default values are subject to the usual rules for quoting SQL expressions. In particular, string literals should be surrounded with single quotes.
+
 Example **add column** migrations:
 
 * [03_add_column.json](../examples/03_add_column.json)
@@ -923,6 +925,8 @@ where each `column` is defined as:
   }
 },
 ```
+
+Default values are subject to the usual rules for quoting SQL expressions. In particular, string literals should be surrounded with single quotes.
 
 Example **create table** migrations:
 

--- a/examples/30_add_column_simple_up.json
+++ b/examples/30_add_column_simple_up.json
@@ -1,0 +1,16 @@
+{
+  "name": "30_add_column_simple_up",
+  "operations": [
+    {
+      "add_column": {
+        "table": "people",
+        "up": "'temporary-description'",
+        "column": {
+          "name": "description",
+          "type": "varchar(255)",
+          "nullable": false
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Update the documentation to clarify how to specify default values for the add column and create table operations.