### PR TITLE
Use autogen GitHub token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 on: [push, pull_request]
+permissions:
+  contents: write
+  packages: write
 jobs:
   test:
     name: test (postgres ${{ matrix.pgVersion }})
@@ -122,7 +125,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
-        password: ${{ secrets.GIT_TOKEN }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Go
       uses: actions/setup-go@v4
@@ -136,6 +139,6 @@ jobs:
         version: latest
         args: release --clean
       env:
-        GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_USERNAME: ${{ github.repository_owner }}
         DOCKER_USERNAME: ghcr.io/${{ github.repository_owner }}


### PR DESCRIPTION
* Change the `GITHUB_TOKEN` used by the `Build` workflow to the default one.
* Add the necessary scopes to the token to allow it to create releases and push images to GHCR.