### PR TITLE
Use org-level `GIT_TOKEN` for brew tap update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,6 +139,11 @@ jobs:
         version: latest
         args: release --clean
       env:
+        # We use two github tokens here:
+        # * The actions-bound `GITHUB_TOKEN` with permissions to write packages.
+        # * The org level `GIT_TOKEN` to be able to publish the brew tap file.
+        # See: https://goreleaser.com/errors/resource-not-accessible-by-integration/
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAP_GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
         GITHUB_USERNAME: ${{ github.repository_owner }}
         DOCKER_USERNAME: ghcr.io/${{ github.repository_owner }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,6 +31,7 @@ brews:
     description: "Postgres zero-downtime migrations made easy"
     license: "Apache-2.0"
     repository:
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
       owner: "{{ .Env.GITHUB_USERNAME }}"
       name: homebrew-pgroll
 


### PR DESCRIPTION
As described in the GoReleaser docs: https://goreleaser.com/errors/resource-not-accessible-by-integration/