### PR TITLE
Add unique & FK constraints info to the schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/xataio/pgroll
 go 1.21
 
 require (
+	github.com/google/go-cmp v0.6.0
 	github.com/lib/pq v1.10.9
 	github.com/pterm/pterm v0.12.69
 	github.com/spf13/cobra v1.7.0
@@ -11,6 +12,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.23.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.23.0
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
+	gotest.tools/v3 v3.5.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -46,6 +46,8 @@ type Table struct {
 
 	// The columns that make up the primary key
 	PrimaryKey []string `json:"primaryKey"`
+
+	ForeignKeys []ForeignKey `json:"foreignKeys"`
 }
 
 type Column struct {
@@ -57,6 +59,7 @@ type Column struct {
 
 	Default  *string `json:"default"`
 	Nullable bool    `json:"nullable"`
+	Unique   bool    `json:"unique"`
 
 	// Optional comment for the column
 	Comment string `json:"comment"`
@@ -65,6 +68,20 @@ type Column struct {
 type Index struct {
 	// Name is the name of the index in postgres
 	Name string `json:"name"`
+}
+
+type ForeignKey struct {
+	// Name is the name of the foreign key in postgres
+	Name string `json:"name"`
+
+	// The columns that the foreign key is defined on
+	Columns []string `json:"columns"`
+
+	// The table that the foreign key references
+	ReferencedTable string `json:"referencedTable"`
+
+	// The columns in the referenced table that the foreign key references
+	ReferencedColumns []string `json:"referencedColumns"`
 }
 
 func (s *Schema) GetTable(name string) *Table {

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -47,7 +47,7 @@ type Table struct {
 	// The columns that make up the primary key
 	PrimaryKey []string `json:"primaryKey"`
 
-	ForeignKeys []ForeignKey `json:"foreignKeys"`
+	ForeignKeys map[string]ForeignKey `json:"foreignKeys"`
 }
 
 type Column struct {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -174,7 +174,7 @@ BEGIN
 				  WHERE pi.indrelid = t.oid::regclass
 				),
 				'foreignKeys', (
-					SELECT json_agg(json_build_object(
+					SELECT json_object_agg(fk_details.conname, json_build_object(
 						'name', fk_details.conname,
 						'columns', fk_details.columns,
 						'referencedTable', fk_details.referencedTable,

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -147,8 +147,8 @@ func TestReadSchema(t *testing.T) {
 									Nullable: false,
 								},
 							},
-							ForeignKeys: []schema.ForeignKey{
-								{
+							ForeignKeys: map[string]schema.ForeignKey{
+								"fk_fkey": {
 									Name:              "fk_fkey",
 									Columns:           []string{"fk"},
 									ReferencedTable:   "table1",


### PR DESCRIPTION
This info is useful to better validate incoming migrations, also it reflects better the resulting schema

example output:

```
{
  "name": "public",
  "tables": {
    "table1": {
      "oid": "66508",
      "name": "table1",
      "columns": {
        "id": {
          "name": "id",
          "type": "integer",
          "unique": true,
          "comment": null,
          "default": null,
          "nullable": false
        }
      },
      "comment": null,
      "indexes": {
        "table1_pkey": {
          "name": "table1_pkey"
        }
      },
      "primaryKey": [
        "id"
      ],
      "foreignKeys": null
    },
    "table2": {
      "oid": "66513",
      "name": "table2",
      "columns": {
        "fk": {
          "name": "fk",
          "type": "integer",
          "unique": false,
          "comment": null,
          "default": null,
          "nullable": false
        }
      },
      "comment": null,
      "indexes": null,
      "primaryKey": null,
      "foreignKeys": {
        "fk_fkey": {
          "name": "fk_fkey",
          "columns": [
            "fk"
          ],
          "referencedTable": "table1",
          "referencedColumns": [
            "id"
          ]
        }
      }
    }
  }
}
```