### PR TITLE
test: Change test isolation model to 'database per test'

### DIFF
--- a/pkg/testutils/db.go
+++ b/pkg/testutils/db.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package testutils
+
+import "math/rand"
+
+func randomDBName() string {
+	const length = 15
+	const charset = "abcdefghijklmnopqrstuvwxyz"
+
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))] // #nosec G404
+	}
+
+	return "testdb_" + string(b)
+}

--- a/pkg/testutils/util.go
+++ b/pkg/testutils/util.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package testutils
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"github.com/xataio/pgroll/pkg/roll"
+	"github.com/xataio/pgroll/pkg/state"
+)
+
+// The version of postgres against which the tests are run
+// if the POSTGRES_VERSION environment variable is not set.
+const defaultPostgresVersion = "15.3"
+
+// tConnStr holds the connection string to the test container created in TestMain.
+var tConnStr string
+
+// SharedTestMain starts a postgres container to be used by all tests in a package.
+// Each test then connects to the container and creates a new database.
+func SharedTestMain(m *testing.M) {
+	ctx := context.Background()
+
+	waitForLogs := wait.
+		ForLog("database system is ready to accept connections").
+		WithOccurrence(2).
+		WithStartupTimeout(5 * time.Second)
+
+	pgVersion := os.Getenv("POSTGRES_VERSION")
+	if pgVersion == "" {
+		pgVersion = defaultPostgresVersion
+	}
+
+	ctr, err := postgres.RunContainer(ctx,
+		testcontainers.WithImage("postgres:"+pgVersion),
+		testcontainers.WithWaitStrategy(waitForLogs),
+	)
+	if err != nil {
+		os.Exit(1)
+	}
+
+	tConnStr, err = ctr.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		os.Exit(1)
+	}
+
+	exitCode := m.Run()
+
+	if err := ctr.Terminate(ctx); err != nil {
+		log.Printf("Failed to terminate container: %v", err)
+	}
+
+	os.Exit(exitCode)
+}
+
+func WithStateAndConnectionToContainer(t *testing.T, fn func(*state.State, *sql.DB)) {
+	t.Helper()
+	ctx := context.Background()
+
+	tDB, err := sql.Open("postgres", tConnStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		if err := tDB.Close(); err != nil {
+			t.Fatalf("Failed to close database connection: %v", err)
+		}
+	})
+
+	dbName := randomDBName()
+
+	_, err = tDB.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE %s", pq.QuoteIdentifier(dbName)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	u, err := url.Parse(tConnStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	u.Path = "/" + dbName
+	connStr := u.String()
+
+	st, err := state.New(ctx, connStr, "pgroll")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Failed to close database connection: %v", err)
+		}
+	})
+
+	fn(st, db)
+}
+
+func WithMigratorInSchemaWithLockTimeoutAndConnectionToContainer(t *testing.T, schema string, lockTimeoutMs int, fn func(mig *roll.Roll, db *sql.DB)) {
+	t.Helper()
+	ctx := context.Background()
+
+	tDB, err := sql.Open("postgres", tConnStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		if err := tDB.Close(); err != nil {
+			t.Fatalf("Failed to close database connection: %v", err)
+		}
+	})
+
+	dbName := randomDBName()
+
+	_, err = tDB.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE %s", pq.QuoteIdentifier(dbName)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	u, err := url.Parse(tConnStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	u.Path = "/" + dbName
+	connStr := u.String()
+
+	st, err := state.New(ctx, connStr, "pgroll")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = st.Init(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mig, err := roll.New(ctx, connStr, schema, lockTimeoutMs, st)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		if err := mig.Close(); err != nil {
+			t.Fatalf("Failed to close migrator connection: %v", err)
+		}
+	})
+
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = db.ExecContext(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", schema))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Failed to close database connection: %v", err)
+		}
+	})
+
+	fn(mig, db)
+}
+
+func WithMigratorInSchemaAndConnectionToContainer(t *testing.T, schema string, fn func(mig *roll.Roll, db *sql.DB)) {
+	WithMigratorInSchemaWithLockTimeoutAndConnectionToContainer(t, schema, 500, fn)
+}
+
+func WithMigratorAndConnectionToContainer(t *testing.T, fn func(mig *roll.Roll, db *sql.DB)) {
+	WithMigratorInSchemaWithLockTimeoutAndConnectionToContainer(t, "public", 500, fn)
+}


### PR DESCRIPTION
Improve the reliability and performance of the test suite by moving the test isolation model from 'container per test' to 'database per test'.

The current test suite works well locally but is [very flaky ](https://github.com/xataio/pgroll/actions) when run on Github Actions. The cause of the flakiness is the 'container per test' isolation model, under which each testcase in each test starts its own Postgres container. This model worked well initially but as the number of tests has increased the actions runner often fails to make available the required number of containers for such a large number of parallel tests.

This PR changes the isolation model to 'database per test'. Each package creates one Postgres container and then each testcase in each test creates a database within that container. This greatly reduces the number of simultaneous containers required, making the test suite faster and more reliable.

Each job in the test matrix sees a 60-70% reduction in duration and (anecdotally) far fewer failures with no failures observed in   ~20 runs.