### PR TITLE
Add support for creating tables and columns with comments

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -698,6 +698,7 @@ An add column operation creates a new column on an existing table.
     "column": {
       "name": "name of column",
       "type": "postgres type",
+      "comment": "postgres comment for the column",
       "nullable": true|false,
       "unique": true|false,
       "pk": true|false,
@@ -911,6 +912,7 @@ where each `column` is defined as:
 {
   "name": "column name",
   "type": "postgres type",
+  "comment": "postgres comment for the column",
   "nullable": true|false,
   "unique": true|false,
   "pk": true|false,

--- a/examples/12_create_employees_table.json
+++ b/examples/12_create_employees_table.json
@@ -4,6 +4,7 @@
     {
       "create_table": {
         "name": "employees",
+        "comment": "This is a comment for the employees table",
         "columns": [
           {
             "name": "id",
@@ -12,7 +13,8 @@
           },
           {
             "name": "role",
-            "type": "varchar(255)"
+            "type": "varchar(255)",
+            "comment": "This is a comment for the role column"
           }
         ]
       }

--- a/examples/30_add_column_simple_up.json
+++ b/examples/30_add_column_simple_up.json
@@ -8,7 +8,8 @@
         "column": {
           "name": "description",
           "type": "varchar(255)",
-          "nullable": false
+          "nullable": false,
+          "comment": "This is a comment for the description column"
         }
       }
     }

--- a/pkg/migrations/comment.go
+++ b/pkg/migrations/comment.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/lib/pq"
+)
+
+func addCommentToColumn(ctx context.Context, conn *sql.DB, tableName, columnName, comment string) error {
+	_, err := conn.ExecContext(ctx, fmt.Sprintf(`COMMENT ON COLUMN %s.%s IS %s`,
+		pq.QuoteIdentifier(tableName),
+		pq.QuoteIdentifier(columnName),
+		pq.QuoteLiteral(comment)))
+
+	return err
+}
+
+func addCommentToTable(ctx context.Context, conn *sql.DB, tableName, comment string) error {
+	_, err := conn.ExecContext(ctx, fmt.Sprintf(`COMMENT ON TABLE %s IS %s`,
+		pq.QuoteIdentifier(tableName),
+		pq.QuoteLiteral(comment)))
+
+	return err
+}

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -21,6 +21,12 @@ func (o *OpAddColumn) Start(ctx context.Context, conn *sql.DB, stateSchema strin
 		return fmt.Errorf("failed to start add column operation: %w", err)
 	}
 
+	if o.Column.Comment != nil {
+		if err := addCommentToColumn(ctx, conn, o.Table, TemporaryName(o.Column.Name), *o.Column.Comment); err != nil {
+			return fmt.Errorf("failed to add comment to column: %w", err)
+		}
+	}
+
 	if !o.Column.Nullable && o.Column.Default == nil {
 		if err := addNotNullConstraint(ctx, conn, o.Table, o.Column.Name, TemporaryName(o.Column.Name)); err != nil {
 			return fmt.Errorf("failed to add not null constraint: %w", err)

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -22,6 +22,22 @@ func (o *OpCreateTable) Start(ctx context.Context, conn *sql.DB, stateSchema str
 		return err
 	}
 
+	// Add comments to any columns that have them
+	for _, col := range o.Columns {
+		if col.Comment != nil {
+			if err := addCommentToColumn(ctx, conn, tempName, col.Name, *col.Comment); err != nil {
+				return fmt.Errorf("failed to add comment to column: %w", err)
+			}
+		}
+	}
+
+	// Add comment to the table itself
+	if o.Comment != nil {
+		if err := addCommentToTable(ctx, conn, tempName, *o.Comment); err != nil {
+			return fmt.Errorf("failed to add comment to table: %w", err)
+		}
+	}
+
 	columns := make(map[string]schema.Column, len(o.Columns))
 	for _, col := range o.Columns {
 		columns[col.Name] = schema.Column{

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -17,6 +17,9 @@ type Column struct {
 	// Check constraint for the column
 	Check *CheckConstraint `json:"check,omitempty"`
 
+	// Postgres comment for the column
+	Comment *string `json:"comment,omitempty"`
+
 	// Default value for the column
 	Default *string `json:"default,omitempty"`
 
@@ -112,6 +115,9 @@ type OpCreateIndex struct {
 type OpCreateTable struct {
 	// Columns corresponds to the JSON schema field "columns".
 	Columns []Column `json:"columns"`
+
+	// Postgres comment for the table
+	Comment *string `json:"comment,omitempty"`
 
 	// Name of the table
 	Name string `json:"name"`

--- a/schema.json
+++ b/schema.json
@@ -56,6 +56,10 @@
         "unique": {
           "description": "Indicates if the column values must be unique",
           "type": "boolean"
+        },
+        "comment": {
+          "description": "Postgres comment for the column",
+          "type": "string"
         }
       },
       "required": ["name", "nullable", "pk", "type", "unique"],
@@ -185,6 +189,10 @@
         },
         "name": {
           "description": "Name of the table",
+          "type": "string"
+        },
+        "comment": {
+          "description": "Postgres comment for the table",
           "type": "string"
         }
       },


### PR DESCRIPTION
Update the **create table** and **add column** operations so that they support adding [Postgres comments](https://www.postgresql.org/docs/current/sql-comment.html):

* **create table**: comments can be added to the table itself and to each of its columns.
* **add column**: a comment can be added to the column.

A **create table** migration that includes a comment on the table itself and on one of its columns looks like this:

```json
{
  "name": "12_create_employees_table",
  "operations": [
    {
      "create_table": {
        "name": "employees",
        "comment": "This is a comment for the employees table",
        "columns": [
          {
            "name": "id",
            "type": "serial",
            "pk": true
          },
          {
            "name": "role",
            "type": "varchar(255)",
            "comment": "This is a comment for the role column"
          }
        ]
      }
    }
  ]
}
```

and an **add column** migration that includes a comment looks like this:

```json
{
  "name": "30_add_column_simple_up",
  "operations": [
    {
      "add_column": {
        "table": "people",
        "up": "'temporary-description'",
        "column": {
          "name": "description",
          "type": "varchar(255)",
          "nullable": false,
          "comment": "This is a comment for the description column"
        }
      }
    }
  ]
}
```

This allows new tables and columns to be created with comments.

Deletion and modification of comments should still be performed with a raw SQL migration. Until we see a use case that requires versioned modification/removal of comments, these operations are best performed directly on the base table with raw SQL.
