### PR TITLE
Add CI check for up-to-date type generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,24 @@ jobs:
           fi
         done
 
+  type-generation:
+    name: type generation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Generate types
+        run: |
+          make generate
+
+      - name: Ensure generated types are up-to-date
+        run: |
+          if ! git diff --quiet; then
+            echo "generated types are out of date!"
+            echo "run 'make generate' to regenerate type definitions"
+            exit 1
+          fi
+
   license-check:
     name: license check
     runs-on: ubuntu-latest
@@ -106,7 +124,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [test, lint, examples, license-check]
+    needs: [test, lint, examples, license-check, type-generation]
     if: startsWith(github.ref, 'refs/tags/')
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
         done
 
   license-check:
-    name: License check
+    name: license check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -192,8 +192,12 @@ type PgRollMigration struct {
 	Name string `json:"name"`
 
 	// Operations corresponds to the JSON schema field "operations".
-	Operations []interface{} `json:"operations"`
+	Operations PgRollOperations `json:"operations"`
 }
+
+type PgRollOperation interface{}
+
+type PgRollOperations []interface{}
 
 // Replica identity definition
 type ReplicaIdentity struct {


### PR DESCRIPTION
Add a CI check to ensure that the `types.go` file generated from `schema.json` is up-to-date.

Types are generated from the `schema.json` file but there was no check in place to ensure that the two were consistent.

This PR runs `make generate` to correct an inconsistency between the definitions and the generated types and adds the check so that we can't repeat this mistake.

An example failed run where the types are out of date is [here](https://github.com/xataio/pgroll/actions/runs/7475710605/job/20344427261).