### PR TITLE
Add a way to set postgres role when executing migrations

### DIFF
--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -21,3 +21,7 @@ func StateSchema() string {
 func LockTimeout() int {
 	return viper.GetInt("LOCK_TIMEOUT")
 }
+
+func Role() string {
+	return viper.GetString("ROLE")
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -537,7 +537,7 @@ The `pgroll` CLI has the following top-level flags:
 * `--schema`: The Postgres schema in which migrations will be run (default `"public"`).
 * `--pgroll-schema`: The Postgres schema in which `pgroll` will store its internal state (default: `"pgroll"`).
 * `--lock-timeout`: The Postgres `lock_timeout` value to use for all `pgroll` DDL operations, specified in milliseconds (default `500`).
-* --role: The Postgres role to use for all `pgroll` DDL operations (default: `""`, which doesn't set any role).
+* `--role``: The Postgres role to use for all `pgroll` DDL operations (default: `""`, which doesn't set any role).
 
 Each of these flags can also be set via an environment variable:
 * `PGROLL_PG_URL`

--- a/docs/README.md
+++ b/docs/README.md
@@ -537,12 +537,14 @@ The `pgroll` CLI has the following top-level flags:
 * `--schema`: The Postgres schema in which migrations will be run (default `"public"`).
 * `--pgroll-schema`: The Postgres schema in which `pgroll` will store its internal state (default: `"pgroll"`).
 * `--lock-timeout`: The Postgres `lock_timeout` value to use for all `pgroll` DDL operations, specified in milliseconds (default `500`).
+* --role: The Postgres role to use for all `pgroll` DDL operations (default: `""`, which doesn't set any role).
 
 Each of these flags can also be set via an environment variable:
 * `PGROLL_PG_URL`
 * `PGROLL_SCHEMA`
 * `PGROLL_STATE_SCHEMA`
 * `PGROLL_LOCK_TIMEOUT`
+* `PGROLL_ROLE`
 
 The CLI flag takes precedence if a flag is set via both an environment variable and a CLI flag.
 

--- a/pkg/roll/execute_test.go
+++ b/pkg/roll/execute_test.go
@@ -253,7 +253,7 @@ func TestSchemaOptionIsRespected(t *testing.T) {
 func TestLockTimeoutIsEnforced(t *testing.T) {
 	t.Parallel()
 
-	testutils.WithMigratorInSchemaConnectionToContainerWithOptions(t, "public", []roll.Option{roll.WithLockTimeoutMs(100)}, func(mig *roll.Roll, db *sql.DB) {
+	testutils.WithMigratorInSchemaAndConnectionToContainerWithOptions(t, "public", []roll.Option{roll.WithLockTimeoutMs(100)}, func(mig *roll.Roll, db *sql.DB) {
 		ctx := context.Background()
 
 		// Start a create table migration
@@ -461,7 +461,7 @@ func TestStatusMethodReturnsCorrectStatus(t *testing.T) {
 func TestRoleIsRespected(t *testing.T) {
 	t.Parallel()
 
-	testutils.WithMigratorInSchemaConnectionToContainerWithOptions(t, "public", []roll.Option{roll.WithRole("pgroll")}, func(mig *roll.Roll, db *sql.DB) {
+	testutils.WithMigratorInSchemaAndConnectionToContainerWithOptions(t, "public", []roll.Option{roll.WithRole("pgroll")}, func(mig *roll.Roll, db *sql.DB) {
 		ctx := context.Background()
 
 		// Start a create table migration

--- a/pkg/roll/options.go
+++ b/pkg/roll/options.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package roll
 
 type options struct {

--- a/pkg/roll/options.go
+++ b/pkg/roll/options.go
@@ -1,0 +1,25 @@
+package roll
+
+type options struct {
+	// lock timeout in milliseconds for pgroll DDL operations
+	lockTimeoutMs int
+
+	// optional role to set before executing migrations
+	role string
+}
+
+type Option func(*options)
+
+// WithLockTimeoutMs sets the lock timeout in milliseconds for pgroll DDL operations
+func WithLockTimeoutMs(lockTimeoutMs int) Option {
+	return func(o *options) {
+		o.lockTimeoutMs = lockTimeoutMs
+	}
+}
+
+// WithRole sets the role to set before executing migrations
+func WithRole(role string) Option {
+	return func(o *options) {
+		o.role = role
+	}
+}

--- a/pkg/testutils/util.go
+++ b/pkg/testutils/util.go
@@ -60,7 +60,7 @@ func SharedTestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	// create handy role for tets
+	// create handy role for tests
 	_, err = db.ExecContext(ctx, "CREATE ROLE pgroll")
 	if err != nil {
 		os.Exit(1)

--- a/pkg/testutils/util.go
+++ b/pkg/testutils/util.go
@@ -153,7 +153,7 @@ func WithMigratorInSchemaWithLockTimeoutAndConnectionToContainer(t *testing.T, s
 		t.Fatal(err)
 	}
 
-	mig, err := roll.New(ctx, connStr, schema, lockTimeoutMs, st)
+	mig, err := roll.New(ctx, connStr, schema, st, roll.WithLockTimeoutMs(lockTimeoutMs))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/testutils/util.go
+++ b/pkg/testutils/util.go
@@ -113,7 +113,7 @@ func WithStateAndConnectionToContainer(t *testing.T, fn func(*state.State, *sql.
 	fn(st, db)
 }
 
-func WithMigratorInSchemaWithLockTimeoutAndConnectionToContainer(t *testing.T, schema string, lockTimeoutMs int, fn func(mig *roll.Roll, db *sql.DB)) {
+func WithMigratorInSchemaConnectionToContainerWithOptions(t *testing.T, schema string, opts []roll.Option, fn func(mig *roll.Roll, db *sql.DB)) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -143,33 +143,7 @@ func WithMigratorInSchemaWithLockTimeoutAndConnectionToContainer(t *testing.T, s
 	u.Path = "/" + dbName
 	connStr := u.String()
 
-	st, err := state.New(ctx, connStr, "pgroll")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = st.Init(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	mig, err := roll.New(ctx, connStr, schema, st, roll.WithLockTimeoutMs(lockTimeoutMs))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Cleanup(func() {
-		if err := mig.Close(); err != nil {
-			t.Fatalf("Failed to close migrator connection: %v", err)
-		}
-	})
-
 	db, err := sql.Open("postgres", connStr)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = db.ExecContext(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", schema))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -180,13 +154,55 @@ func WithMigratorInSchemaWithLockTimeoutAndConnectionToContainer(t *testing.T, s
 		}
 	})
 
+	// handy role for tets
+	_, err = db.ExecContext(ctx, "CREATE ROLE pgroll")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := state.New(ctx, connStr, "pgroll")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = st.Init(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mig, err := roll.New(ctx, connStr, schema, st, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		if err := mig.Close(); err != nil {
+			t.Fatalf("Failed to close migrator connection: %v", err)
+		}
+	})
+
+	_, err = db.ExecContext(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", schema))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = db.ExecContext(ctx, fmt.Sprintf("GRANT ALL PRIVILEGES ON SCHEMA %s TO pgroll", schema))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = db.ExecContext(ctx, fmt.Sprintf("GRANT ALL PRIVILEGES ON DATABASE %s TO pgroll", dbName))
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	fn(mig, db)
 }
 
 func WithMigratorInSchemaAndConnectionToContainer(t *testing.T, schema string, fn func(mig *roll.Roll, db *sql.DB)) {
-	WithMigratorInSchemaWithLockTimeoutAndConnectionToContainer(t, schema, 500, fn)
+	WithMigratorInSchemaConnectionToContainerWithOptions(t, schema, []roll.Option{roll.WithLockTimeoutMs(500)}, fn)
 }
 
 func WithMigratorAndConnectionToContainer(t *testing.T, fn func(mig *roll.Roll, db *sql.DB)) {
-	WithMigratorInSchemaWithLockTimeoutAndConnectionToContainer(t, "public", 500, fn)
+	WithMigratorInSchemaConnectionToContainerWithOptions(t, "public", []roll.Option{roll.WithLockTimeoutMs(500)}, fn)
 }

--- a/pkg/testutils/util.go
+++ b/pkg/testutils/util.go
@@ -124,7 +124,7 @@ func WithStateAndConnectionToContainer(t *testing.T, fn func(*state.State, *sql.
 	fn(st, db)
 }
 
-func WithMigratorInSchemaConnectionToContainerWithOptions(t *testing.T, schema string, opts []roll.Option, fn func(mig *roll.Roll, db *sql.DB)) {
+func WithMigratorInSchemaAndConnectionToContainerWithOptions(t *testing.T, schema string, opts []roll.Option, fn func(mig *roll.Roll, db *sql.DB)) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -205,9 +205,9 @@ func WithMigratorInSchemaConnectionToContainerWithOptions(t *testing.T, schema s
 }
 
 func WithMigratorInSchemaAndConnectionToContainer(t *testing.T, schema string, fn func(mig *roll.Roll, db *sql.DB)) {
-	WithMigratorInSchemaConnectionToContainerWithOptions(t, schema, []roll.Option{roll.WithLockTimeoutMs(500)}, fn)
+	WithMigratorInSchemaAndConnectionToContainerWithOptions(t, schema, []roll.Option{roll.WithLockTimeoutMs(500)}, fn)
 }
 
 func WithMigratorAndConnectionToContainer(t *testing.T, fn func(mig *roll.Roll, db *sql.DB)) {
-	WithMigratorInSchemaConnectionToContainerWithOptions(t, "public", []roll.Option{roll.WithLockTimeoutMs(500)}, fn)
+	WithMigratorInSchemaAndConnectionToContainerWithOptions(t, "public", []roll.Option{roll.WithLockTimeoutMs(500)}, fn)
 }

--- a/pkg/testutils/util.go
+++ b/pkg/testutils/util.go
@@ -55,6 +55,17 @@ func SharedTestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
+	db, err := sql.Open("postgres", tConnStr)
+	if err != nil {
+		os.Exit(1)
+	}
+
+	// create handy role for tets
+	_, err = db.ExecContext(ctx, "CREATE ROLE pgroll")
+	if err != nil {
+		os.Exit(1)
+	}
+
 	exitCode := m.Run()
 
 	if err := ctr.Terminate(ctx); err != nil {
@@ -153,12 +164,6 @@ func WithMigratorInSchemaConnectionToContainerWithOptions(t *testing.T, schema s
 			t.Fatalf("Failed to close database connection: %v", err)
 		}
 	})
-
-	// handy role for tets
-	_, err = db.ExecContext(ctx, "CREATE ROLE pgroll")
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	st, err := state.New(ctx, connStr, "pgroll")
 	if err != nil {


### PR DESCRIPTION
In same cases we want to set a specific role when executing migrations, so the ownerhsip of the created/updated objects is different from the pgroll user (storing pgroll state). This change allows to set a role that will be set in the connection executing migrations.