### PR TITLE
Allow to disable version schemas

### DIFF
--- a/pkg/roll/options.go
+++ b/pkg/roll/options.go
@@ -8,6 +8,9 @@ type options struct {
 
 	// optional role to set before executing migrations
 	role string
+
+	// disable pgroll version schemas creation and deletion
+	disableVersionSchemas bool
 }
 
 type Option func(*options)
@@ -23,5 +26,13 @@ func WithLockTimeoutMs(lockTimeoutMs int) Option {
 func WithRole(role string) Option {
 	return func(o *options) {
 		o.role = role
+	}
+}
+
+// WithDisableViewsManagement disables pgroll version schemas management
+// when passed, pgroll will not create or drop version schemas
+func WithDisableViewsManagement() Option {
+	return func(o *options) {
+		o.disableVersionSchemas = true
 	}
 }

--- a/pkg/roll/roll.go
+++ b/pkg/roll/roll.go
@@ -22,6 +22,9 @@ type Roll struct {
 	// schema we are acting on
 	schema string
 
+	// disable pgroll version schemas creation and deletion
+	disableVersionSchemas bool
+
 	state     *state.State
 	pgVersion PGVersion
 }
@@ -74,10 +77,11 @@ func New(ctx context.Context, pgURL, schema string, state *state.State, opts ...
 	}
 
 	return &Roll{
-		pgConn:    conn,
-		schema:    schema,
-		state:     state,
-		pgVersion: PGVersion(pgMajorVersion),
+		pgConn:                conn,
+		schema:                schema,
+		state:                 state,
+		pgVersion:             PGVersion(pgMajorVersion),
+		disableVersionSchemas: options.disableVersionSchemas,
 	}, nil
 }
 


### PR DESCRIPTION
There are situatiosn were creating schema verisons is not required. This internal flag will allow to disable creating & managing these schemas when needed.

Note: I opted to not expose this flag to the CLI as I believe it would make create more harm & confusion than not having the feature there.