### PR TITLE
Preserve column properties on add `FOREIGN KEY` constraint operation

### DIFF
--- a/pkg/migrations/op_set_check.go
+++ b/pkg/migrations/op_set_check.go
@@ -27,7 +27,8 @@ func (o *OpSetCheckConstraint) Start(ctx context.Context, conn *sql.DB, stateSch
 	column := table.GetColumn(o.Column)
 
 	// Create a copy of the column on the underlying table.
-	if err := duplicateColumn(ctx, conn, table, *column); err != nil {
+	d := NewColumnDuplicator(conn, table, column)
+	if err := d.Duplicate(ctx); err != nil {
 		return fmt.Errorf("failed to duplicate column: %w", err)
 	}
 
@@ -112,11 +113,9 @@ func (o *OpSetCheckConstraint) Complete(ctx context.Context, conn *sql.DB, s *sc
 	}
 
 	// Rename the new column to the old column name
-	_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s RENAME COLUMN %s TO %s",
-		pq.QuoteIdentifier(o.Table),
-		pq.QuoteIdentifier(TemporaryName(o.Column)),
-		pq.QuoteIdentifier(o.Column)))
-	if err != nil {
+	table := s.GetTable(o.Table)
+	column := table.GetColumn(o.Column)
+	if err := RenameDuplicatedColumn(ctx, conn, table, column); err != nil {
 		return err
 	}
 

--- a/pkg/migrations/op_set_check_test.go
+++ b/pkg/migrations/op_set_check_test.go
@@ -13,129 +13,198 @@ import (
 func TestSetCheckConstraint(t *testing.T) {
 	t.Parallel()
 
-	ExecuteTests(t, TestCases{{
-		name: "add check constraint",
-		migrations: []migrations.Migration{
-			{
-				Name: "01_add_table",
-				Operations: migrations.Operations{
-					&migrations.OpCreateTable{
-						Name: "posts",
-						Columns: []migrations.Column{
-							{
-								Name: "id",
-								Type: "serial",
-								Pk:   true,
-							},
-							{
-								Name: "title",
-								Type: "text",
+	ExecuteTests(t, TestCases{
+		{
+			name: "add check constraint",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "posts",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name: "title",
+									Type: "text",
+								},
 							},
 						},
 					},
 				},
-			},
-			{
-				Name: "02_add_check_constraint",
-				Operations: migrations.Operations{
-					&migrations.OpAlterColumn{
-						Table:  "posts",
-						Column: "title",
-						Check: &migrations.CheckConstraint{
-							Name:       "check_title_length",
-							Constraint: "length(title) > 3",
+				{
+					Name: "02_add_check_constraint",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:  "posts",
+							Column: "title",
+							Check: &migrations.CheckConstraint{
+								Name:       "check_title_length",
+								Constraint: "length(title) > 3",
+							},
+							Up:   "(SELECT CASE WHEN length(title) <= 3 THEN LPAD(title, 4, '-') ELSE title END)",
+							Down: "title",
 						},
-						Up:   "(SELECT CASE WHEN length(title) <= 3 THEN LPAD(title, 4, '-') ELSE title END)",
-						Down: "title",
 					},
 				},
 			},
+			afterStart: func(t *testing.T, db *sql.DB) {
+				// The new (temporary) `title` column should exist on the underlying table.
+				ColumnMustExist(t, db, "public", "posts", migrations.TemporaryName("title"))
+
+				// Inserting a row that meets the check constraint into the old view works.
+				MustInsert(t, db, "public", "01_add_table", "posts", map[string]string{
+					"title": "post by alice",
+				})
+
+				// Inserting a row that does not meet the check constraint into the old view also works.
+				MustInsert(t, db, "public", "01_add_table", "posts", map[string]string{
+					"title": "b",
+				})
+
+				// Both rows have been backfilled into the new view; the short title has
+				// been rewritten using `up` SQL to meet the length constraint.
+				rows := MustSelect(t, db, "public", "02_add_check_constraint", "posts")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "title": "post by alice"},
+					{"id": 2, "title": "---b"},
+				}, rows)
+
+				// Inserting a row that meets the check constraint into the new view works.
+				MustInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+					"title": "post by carl",
+				})
+
+				// Inserting a row that does not meet the check constraint into the new view fails.
+				MustNotInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+					"title": "d",
+				})
+
+				// The row that was inserted into the new view has been backfilled into the old view.
+				rows = MustSelect(t, db, "public", "01_add_table", "posts")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "title": "post by alice"},
+					{"id": 2, "title": "b"},
+					{"id": 3, "title": "post by carl"},
+				}, rows)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB) {
+				// The new (temporary) `title` column should not exist on the underlying table.
+				ColumnMustNotExist(t, db, "public", "posts", migrations.TemporaryName("title"))
+
+				// The up function no longer exists.
+				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", "title"))
+				// The down function no longer exists.
+				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", migrations.TemporaryName("title")))
+
+				// The up trigger no longer exists.
+				TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", "title"))
+				// The down trigger no longer exists.
+				TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", migrations.TemporaryName("title")))
+			},
+			afterComplete: func(t *testing.T, db *sql.DB) {
+				// Inserting a row that meets the check constraint into the new view works.
+				MustInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+					"title": "post by dana",
+				})
+
+				// Inserting a row that does not meet the check constraint into the new view fails.
+				MustNotInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+					"title": "e",
+				})
+
+				// The data in the new `posts` view is as expected.
+				rows := MustSelect(t, db, "public", "02_add_check_constraint", "posts")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "title": "post by alice"},
+					{"id": 2, "title": "---b"},
+					{"id": 3, "title": "post by carl"},
+					{"id": 5, "title": "post by dana"},
+				}, rows)
+
+				// The up function no longer exists.
+				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", "title"))
+				// The down function no longer exists.
+				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", migrations.TemporaryName("title")))
+
+				// The up trigger no longer exists.
+				TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", "title"))
+				// The down trigger no longer exists.
+				TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", migrations.TemporaryName("title")))
+			},
 		},
-		afterStart: func(t *testing.T, db *sql.DB) {
-			// The new (temporary) `title` column should exist on the underlying table.
-			ColumnMustExist(t, db, "public", "posts", migrations.TemporaryName("title"))
+		{
+			name: "column defaults are preserved when adding a check constraint",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "posts",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name:    "title",
+									Type:    "text",
+									Default: ptr("'untitled'"),
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_add_check_constraint",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:  "posts",
+							Column: "title",
+							Check: &migrations.CheckConstraint{
+								Name:       "check_title_length",
+								Constraint: "length(title) > 3",
+							},
+							Up:   "(SELECT CASE WHEN length(title) <= 3 THEN LPAD(title, 4, '-') ELSE title END)",
+							Down: "title",
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB) {
+				// A row can be inserted into the new version of the table.
+				MustInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+					"id": "1",
+				})
 
-			// Inserting a row that meets the check constraint into the old view works.
-			MustInsert(t, db, "public", "01_add_table", "posts", map[string]string{
-				"title": "post by alice",
-			})
+				// The newly inserted row respects the default value of the column.
+				rows := MustSelect(t, db, "public", "02_add_check_constraint", "posts")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "title": "untitled"},
+				}, rows)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB) {
+			},
+			afterComplete: func(t *testing.T, db *sql.DB) {
+				// A row can be inserted into the new version of the table.
+				MustInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+					"id": "2",
+				})
 
-			// Inserting a row that does not meet the check constraint into the old view also works.
-			MustInsert(t, db, "public", "01_add_table", "posts", map[string]string{
-				"title": "b",
-			})
-
-			// Both rows have been backfilled into the new view; the short title has
-			// been rewritten using `up` SQL to meet the length constraint.
-			rows := MustSelect(t, db, "public", "02_add_check_constraint", "posts")
-			assert.Equal(t, []map[string]any{
-				{"id": 1, "title": "post by alice"},
-				{"id": 2, "title": "---b"},
-			}, rows)
-
-			// Inserting a row that meets the check constraint into the new view works.
-			MustInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
-				"title": "post by carl",
-			})
-
-			// Inserting a row that does not meet the check constraint into the new view fails.
-			MustNotInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
-				"title": "d",
-			})
-
-			// The row that was inserted into the new view has been backfilled into the old view.
-			rows = MustSelect(t, db, "public", "01_add_table", "posts")
-			assert.Equal(t, []map[string]any{
-				{"id": 1, "title": "post by alice"},
-				{"id": 2, "title": "b"},
-				{"id": 3, "title": "post by carl"},
-			}, rows)
+				// The newly inserted row respects the default value of the column.
+				rows := MustSelect(t, db, "public", "02_add_check_constraint", "posts")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "title": "untitled"},
+					{"id": 2, "title": "untitled"},
+				}, rows)
+			},
 		},
-		afterRollback: func(t *testing.T, db *sql.DB) {
-			// The new (temporary) `title` column should not exist on the underlying table.
-			ColumnMustNotExist(t, db, "public", "posts", migrations.TemporaryName("title"))
-
-			// The up function no longer exists.
-			FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", "title"))
-			// The down function no longer exists.
-			FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", migrations.TemporaryName("title")))
-
-			// The up trigger no longer exists.
-			TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", "title"))
-			// The down trigger no longer exists.
-			TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", migrations.TemporaryName("title")))
-		},
-		afterComplete: func(t *testing.T, db *sql.DB) {
-			// Inserting a row that meets the check constraint into the new view works.
-			MustInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
-				"title": "post by dana",
-			})
-
-			// Inserting a row that does not meet the check constraint into the new view fails.
-			MustNotInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
-				"title": "e",
-			})
-
-			// The data in the new `posts` view is as expected.
-			rows := MustSelect(t, db, "public", "02_add_check_constraint", "posts")
-			assert.Equal(t, []map[string]any{
-				{"id": 1, "title": "post by alice"},
-				{"id": 2, "title": "---b"},
-				{"id": 3, "title": "post by carl"},
-				{"id": 5, "title": "post by dana"},
-			}, rows)
-
-			// The up function no longer exists.
-			FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", "title"))
-			// The down function no longer exists.
-			FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", migrations.TemporaryName("title")))
-
-			// The up trigger no longer exists.
-			TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", "title"))
-			// The down trigger no longer exists.
-			TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", migrations.TemporaryName("title")))
-		},
-	}})
+	})
 }
 
 func TestSetCheckConstraintValidation(t *testing.T) {

--- a/pkg/migrations/op_set_fk.go
+++ b/pkg/migrations/op_set_fk.go
@@ -26,7 +26,8 @@ func (o *OpSetForeignKey) Start(ctx context.Context, conn *sql.DB, stateSchema s
 	column := table.GetColumn(o.Column)
 
 	// Create a copy of the column on the underlying table.
-	if err := duplicateColumn(ctx, conn, table, *column); err != nil {
+	d := NewColumnDuplicator(conn, table, column)
+	if err := d.Duplicate(ctx); err != nil {
 		return fmt.Errorf("failed to duplicate column: %w", err)
 	}
 
@@ -112,11 +113,9 @@ func (o *OpSetForeignKey) Complete(ctx context.Context, conn *sql.DB, s *schema.
 	}
 
 	// Rename the new column to the old column name
-	_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s RENAME COLUMN %s TO %s",
-		pq.QuoteIdentifier(o.Table),
-		pq.QuoteIdentifier(TemporaryName(o.Column)),
-		pq.QuoteIdentifier(o.Column)))
-	if err != nil {
+	table := s.GetTable(o.Table)
+	column := table.GetColumn(o.Column)
+	if err := RenameDuplicatedColumn(ctx, conn, table, column); err != nil {
 		return err
 	}
 

--- a/pkg/migrations/op_set_fk.go
+++ b/pkg/migrations/op_set_fk.go
@@ -85,7 +85,7 @@ func (o *OpSetForeignKey) Complete(ctx context.Context, conn *sql.DB, s *schema.
 	// Validate the foreign key constraint
 	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s VALIDATE CONSTRAINT %s",
 		pq.QuoteIdentifier(o.Table),
-		pq.QuoteIdentifier(o.References.Name)))
+		pq.QuoteIdentifier(TemporaryName(o.References.Name))))
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func (o *OpSetForeignKey) addForeignKeyConstraint(ctx context.Context, conn *sql
 
 	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s) NOT VALID",
 		pq.QuoteIdentifier(o.Table),
-		pq.QuoteIdentifier(o.References.Name),
+		pq.QuoteIdentifier(TemporaryName(o.References.Name)),
 		pq.QuoteIdentifier(tempColumnName),
 		pq.QuoteIdentifier(o.References.Table),
 		pq.QuoteIdentifier(o.References.Column),

--- a/pkg/migrations/op_set_fk_test.go
+++ b/pkg/migrations/op_set_fk_test.go
@@ -13,164 +13,259 @@ import (
 func TestSetForeignKey(t *testing.T) {
 	t.Parallel()
 
-	ExecuteTests(t, TestCases{{
-		name: "add foreign key constraint",
-		migrations: []migrations.Migration{
-			{
-				Name: "01_add_tables",
-				Operations: migrations.Operations{
-					&migrations.OpCreateTable{
-						Name: "users",
-						Columns: []migrations.Column{
-							{
-								Name: "id",
-								Type: "serial",
-								Pk:   true,
-							},
-							{
-								Name: "name",
-								Type: "text",
+	ExecuteTests(t, TestCases{
+		{
+			name: "add foreign key constraint",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_tables",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name: "name",
+									Type: "text",
+								},
 							},
 						},
-					},
-					&migrations.OpCreateTable{
-						Name: "posts",
-						Columns: []migrations.Column{
-							{
-								Name: "id",
-								Type: "serial",
-								Pk:   true,
-							},
-							{
-								Name: "title",
-								Type: "text",
-							},
-							{
-								Name: "user_id",
-								Type: "integer",
+						&migrations.OpCreateTable{
+							Name: "posts",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name: "title",
+									Type: "text",
+								},
+								{
+									Name: "user_id",
+									Type: "integer",
+								},
 							},
 						},
 					},
 				},
-			},
-			{
-				Name: "02_add_fk_constraint",
-				Operations: migrations.Operations{
-					&migrations.OpAlterColumn{
-						Table:  "posts",
-						Column: "user_id",
-						References: &migrations.ForeignKeyReference{
-							Name:   "fk_users_id",
-							Table:  "users",
-							Column: "id",
+				{
+					Name: "02_add_fk_constraint",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:  "posts",
+							Column: "user_id",
+							References: &migrations.ForeignKeyReference{
+								Name:   "fk_users_id",
+								Table:  "users",
+								Column: "id",
+							},
+							Up:   "(SELECT CASE WHEN EXISTS (SELECT 1 FROM users WHERE users.id = user_id) THEN user_id ELSE NULL END)",
+							Down: "user_id",
 						},
-						Up:   "(SELECT CASE WHEN EXISTS (SELECT 1 FROM users WHERE users.id = user_id) THEN user_id ELSE NULL END)",
-						Down: "user_id",
 					},
 				},
 			},
+			afterStart: func(t *testing.T, db *sql.DB) {
+				// The new (temporary) `user_id` column should exist on the underlying table.
+				ColumnMustExist(t, db, "public", "posts", migrations.TemporaryName("user_id"))
+
+				// Inserting some data into the `users` table works.
+				MustInsert(t, db, "public", "02_add_fk_constraint", "users", map[string]string{
+					"name": "alice",
+				})
+				MustInsert(t, db, "public", "02_add_fk_constraint", "users", map[string]string{
+					"name": "bob",
+				})
+
+				// Inserting data into the new `posts` view with a valid user reference works.
+				MustInsert(t, db, "public", "02_add_fk_constraint", "posts", map[string]string{
+					"title":   "post by alice",
+					"user_id": "1",
+				})
+
+				// Inserting data into the new `posts` view with an invalid user reference fails.
+				MustNotInsert(t, db, "public", "02_add_fk_constraint", "posts", map[string]string{
+					"title":   "post by unknown user",
+					"user_id": "3",
+				})
+
+				// The post that was inserted successfully has been backfilled into the old view.
+				rows := MustSelect(t, db, "public", "01_add_tables", "posts")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "title": "post by alice", "user_id": 1},
+				}, rows)
+
+				// Inserting data into the old `posts` view with a valid user reference works.
+				MustInsert(t, db, "public", "01_add_tables", "posts", map[string]string{
+					"title":   "post by bob",
+					"user_id": "2",
+				})
+
+				// Inserting data into the old `posts` view with an invalid user reference also works.
+				MustInsert(t, db, "public", "01_add_tables", "posts", map[string]string{
+					"title":   "post by unknown user",
+					"user_id": "3",
+				})
+
+				// The post that was inserted successfully has been backfilled into the new view.
+				// The post by an unknown user has been backfilled with a NULL user_id.
+				rows = MustSelect(t, db, "public", "02_add_fk_constraint", "posts")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "title": "post by alice", "user_id": 1},
+					{"id": 3, "title": "post by bob", "user_id": 2},
+					{"id": 4, "title": "post by unknown user", "user_id": nil},
+				}, rows)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB) {
+				// The new (temporary) `user_id` column should not exist on the underlying table.
+				ColumnMustNotExist(t, db, "public", "posts", migrations.TemporaryName("user_id"))
+
+				// The up function no longer exists.
+				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", "user_id"))
+				// The down function no longer exists.
+				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", migrations.TemporaryName("user_id")))
+
+				// The up trigger no longer exists.
+				TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", "user_id"))
+				// The down trigger no longer exists.
+				TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", migrations.TemporaryName("user_id")))
+			},
+			afterComplete: func(t *testing.T, db *sql.DB) {
+				// The new (temporary) `user_id` column should not exist on the underlying table.
+				ColumnMustNotExist(t, db, "public", "posts", migrations.TemporaryName("user_id"))
+
+				// Inserting data into the new `posts` view with a valid user reference works.
+				MustInsert(t, db, "public", "02_add_fk_constraint", "posts", map[string]string{
+					"title":   "another post by alice",
+					"user_id": "1",
+				})
+
+				// Inserting data into the new `posts` view with an invalid user reference fails.
+				MustNotInsert(t, db, "public", "02_add_fk_constraint", "posts", map[string]string{
+					"title":   "post by unknown user",
+					"user_id": "3",
+				})
+
+				// The data in the new `posts` view is as expected.
+				rows := MustSelect(t, db, "public", "02_add_fk_constraint", "posts")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "title": "post by alice", "user_id": 1},
+					{"id": 3, "title": "post by bob", "user_id": 2},
+					{"id": 4, "title": "post by unknown user", "user_id": nil},
+					{"id": 5, "title": "another post by alice", "user_id": 1},
+				}, rows)
+
+				// The up function no longer exists.
+				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", "user_id"))
+				// The down function no longer exists.
+				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", migrations.TemporaryName("user_id")))
+
+				// The up trigger no longer exists.
+				TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", "user_id"))
+				// The down trigger no longer exists.
+				TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", migrations.TemporaryName("user_id")))
+			},
 		},
-		afterStart: func(t *testing.T, db *sql.DB) {
-			// The new (temporary) `user_id` column should exist on the underlying table.
-			ColumnMustExist(t, db, "public", "posts", migrations.TemporaryName("user_id"))
+		{
+			name: "column defaults are preserved when adding a foreign key constraint",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_tables",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name: "name",
+									Type: "text",
+								},
+							},
+						},
+						&migrations.OpCreateTable{
+							Name: "posts",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name: "title",
+									Type: "text",
+								},
+								{
+									Name:    "user_id",
+									Type:    "integer",
+									Default: ptr("1"),
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_add_fk_constraint",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:  "posts",
+							Column: "user_id",
+							References: &migrations.ForeignKeyReference{
+								Name:   "fk_users_id",
+								Table:  "users",
+								Column: "id",
+							},
+							Up:   "(SELECT CASE WHEN EXISTS (SELECT 1 FROM users WHERE users.id = user_id) THEN user_id ELSE NULL END)",
+							Down: "user_id",
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB) {
+				// Set up the users table with a reference row
+				MustInsert(t, db, "public", "02_add_fk_constraint", "users", map[string]string{
+					"name": "alice",
+				})
 
-			// Inserting some data into the `users` table works.
-			MustInsert(t, db, "public", "02_add_fk_constraint", "users", map[string]string{
-				"name": "alice",
-			})
-			MustInsert(t, db, "public", "02_add_fk_constraint", "users", map[string]string{
-				"name": "bob",
-			})
+				// A row can be inserted into the new version of the table.
+				// The new row does not specify `user_id`, so the default value should be used.
+				MustInsert(t, db, "public", "02_add_fk_constraint", "posts", map[string]string{
+					"title": "post by alice",
+				})
 
-			// Inserting data into the new `posts` view with a valid user reference works.
-			MustInsert(t, db, "public", "02_add_fk_constraint", "posts", map[string]string{
-				"title":   "post by alice",
-				"user_id": "1",
-			})
+				// The newly inserted row respects the default value of the `user_id` column.
+				rows := MustSelect(t, db, "public", "02_add_fk_constraint", "posts")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "title": "post by alice", "user_id": 1},
+				}, rows)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB) {
+			},
+			afterComplete: func(t *testing.T, db *sql.DB) {
+				// A row can be inserted into the new version of the table.
+				// The new row does not specify `user_id`, so the default value should be used.
+				MustInsert(t, db, "public", "02_add_fk_constraint", "posts", map[string]string{
+					"title": "another post by alice",
+				})
 
-			// Inserting data into the new `posts` view with an invalid user reference fails.
-			MustNotInsert(t, db, "public", "02_add_fk_constraint", "posts", map[string]string{
-				"title":   "post by unknown user",
-				"user_id": "3",
-			})
-
-			// The post that was inserted successfully has been backfilled into the old view.
-			rows := MustSelect(t, db, "public", "01_add_tables", "posts")
-			assert.Equal(t, []map[string]any{
-				{"id": 1, "title": "post by alice", "user_id": 1},
-			}, rows)
-
-			// Inserting data into the old `posts` view with a valid user reference works.
-			MustInsert(t, db, "public", "01_add_tables", "posts", map[string]string{
-				"title":   "post by bob",
-				"user_id": "2",
-			})
-
-			// Inserting data into the old `posts` view with an invalid user reference also works.
-			MustInsert(t, db, "public", "01_add_tables", "posts", map[string]string{
-				"title":   "post by unknown user",
-				"user_id": "3",
-			})
-
-			// The post that was inserted successfully has been backfilled into the new view.
-			// The post by an unknown user has been backfilled with a NULL user_id.
-			rows = MustSelect(t, db, "public", "02_add_fk_constraint", "posts")
-			assert.Equal(t, []map[string]any{
-				{"id": 1, "title": "post by alice", "user_id": 1},
-				{"id": 3, "title": "post by bob", "user_id": 2},
-				{"id": 4, "title": "post by unknown user", "user_id": nil},
-			}, rows)
+				// The newly inserted row respects the default value of the `user_id` column.
+				rows := MustSelect(t, db, "public", "02_add_fk_constraint", "posts")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "title": "post by alice", "user_id": 1},
+					{"id": 2, "title": "another post by alice", "user_id": 1},
+				}, rows)
+			},
 		},
-		afterRollback: func(t *testing.T, db *sql.DB) {
-			// The new (temporary) `user_id` column should not exist on the underlying table.
-			ColumnMustNotExist(t, db, "public", "posts", migrations.TemporaryName("user_id"))
-
-			// The up function no longer exists.
-			FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", "user_id"))
-			// The down function no longer exists.
-			FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", migrations.TemporaryName("user_id")))
-
-			// The up trigger no longer exists.
-			TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", "user_id"))
-			// The down trigger no longer exists.
-			TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", migrations.TemporaryName("user_id")))
-		},
-		afterComplete: func(t *testing.T, db *sql.DB) {
-			// The new (temporary) `user_id` column should not exist on the underlying table.
-			ColumnMustNotExist(t, db, "public", "posts", migrations.TemporaryName("user_id"))
-
-			// Inserting data into the new `posts` view with a valid user reference works.
-			MustInsert(t, db, "public", "02_add_fk_constraint", "posts", map[string]string{
-				"title":   "another post by alice",
-				"user_id": "1",
-			})
-
-			// Inserting data into the new `posts` view with an invalid user reference fails.
-			MustNotInsert(t, db, "public", "02_add_fk_constraint", "posts", map[string]string{
-				"title":   "post by unknown user",
-				"user_id": "3",
-			})
-
-			// The data in the new `posts` view is as expected.
-			rows := MustSelect(t, db, "public", "02_add_fk_constraint", "posts")
-			assert.Equal(t, []map[string]any{
-				{"id": 1, "title": "post by alice", "user_id": 1},
-				{"id": 3, "title": "post by bob", "user_id": 2},
-				{"id": 4, "title": "post by unknown user", "user_id": nil},
-				{"id": 5, "title": "another post by alice", "user_id": 1},
-			}, rows)
-
-			// The up function no longer exists.
-			FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", "user_id"))
-			// The down function no longer exists.
-			FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", migrations.TemporaryName("user_id")))
-
-			// The up trigger no longer exists.
-			TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", "user_id"))
-			// The down trigger no longer exists.
-			TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", migrations.TemporaryName("user_id")))
-		},
-	}})
+	})
 }
 
 func TestSetForeignKeyValidation(t *testing.T) {

--- a/pkg/migrations/op_set_unique_test.go
+++ b/pkg/migrations/op_set_unique_test.go
@@ -259,5 +259,84 @@ func TestSetColumnUnique(t *testing.T) {
 				}, rows)
 			},
 		},
+		{
+			name: "foreign keys defined on the column are preserved when adding a unique constraint",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_departments_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "departments",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name:     "name",
+									Type:     "text",
+									Nullable: false,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_add_employees_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "employees",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name:     "name",
+									Type:     "text",
+									Nullable: false,
+								},
+								{
+									Name:     "department_id",
+									Type:     "integer",
+									Nullable: true,
+									References: &migrations.ForeignKeyReference{
+										Name:   "fk_employee_department",
+										Table:  "departments",
+										Column: "id",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "03_set_unique",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:  "employees",
+							Column: "department_id",
+							Unique: &migrations.UniqueConstraint{
+								Name: "employees_department_id_unique",
+							},
+							Up:   "department_id",
+							Down: "department_id",
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB) {
+				// A temporary FK constraint has been created on the temporary column
+				ConstraintMustExist(t, db, "public", "employees", migrations.TemporaryName("fk_employee_department"))
+			},
+			afterRollback: func(t *testing.T, db *sql.DB) {
+			},
+			afterComplete: func(t *testing.T, db *sql.DB) {
+				// The foreign key constraint still exists on the column
+				ConstraintMustExist(t, db, "public", "employees", "fk_employee_department")
+			},
+		},
 	})
 }

--- a/pkg/migrations/op_set_unique_test.go
+++ b/pkg/migrations/op_set_unique_test.go
@@ -116,7 +116,7 @@ func TestSetColumnUnique(t *testing.T) {
 			},
 		},
 		{
-			name: "set unique with default user supplied down sql",
+			name: "set unique with user supplied down sql",
 			migrations: []migrations.Migration{
 				{
 					Name: "01_add_table",


### PR DESCRIPTION
Preserve properties of columns when duplicating them for backfilling to add a `FOREIGN KEY` constraint. Currently, the column properties that are preserved are:

* `DEFAULT`s
* foreign key constraints

but this list will grow as more work is done on https://github.com/xataio/pgroll/issues/227.