### PR TITLE
Add `CHECK` constraints to `pgroll`'s internal schema representation

### DIFF
--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -49,6 +49,9 @@ type Table struct {
 
 	// ForeignKeys is a map of all foreign keys defined on the table
 	ForeignKeys map[string]ForeignKey `json:"foreignKeys"`
+
+	// CheckConstraints is a map of all check constraints defined on the table
+	CheckConstraints map[string]CheckConstraint `json:"checkConstraints"`
 }
 
 type Column struct {
@@ -83,6 +86,17 @@ type ForeignKey struct {
 
 	// The columns in the referenced table that the foreign key references
 	ReferencedColumns []string `json:"referencedColumns"`
+}
+
+type CheckConstraint struct {
+	// Name is the name of the check constraint in postgres
+	Name string `json:"name"`
+
+	// The columns that the check constraint is defined on
+	Columns []string `json:"columns"`
+
+	// The definition of the check constraint
+	Definition string `json:"definition"`
 }
 
 func (s *Schema) GetTable(name string) *Table {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -155,6 +155,44 @@ func TestReadSchema(t *testing.T) {
 					},
 				},
 			},
+			{
+				name:       "check constraint",
+				createStmt: "CREATE TABLE public.table1 (id int PRIMARY KEY, age INTEGER, CONSTRAINT age_check CHECK (age > 18));",
+				wantSchema: &schema.Schema{
+					Name: "public",
+					Tables: map[string]schema.Table{
+						"table1": {
+							Name: "table1",
+							Columns: map[string]schema.Column{
+								"id": {
+									Name:     "id",
+									Type:     "integer",
+									Nullable: false,
+									Unique:   true,
+								},
+								"age": {
+									Name:     "age",
+									Type:     "integer",
+									Nullable: true,
+								},
+							},
+							PrimaryKey: []string{"id"},
+							Indexes: map[string]schema.Index{
+								"table1_pkey": {
+									Name: "table1_pkey",
+								},
+							},
+							CheckConstraints: map[string]schema.CheckConstraint{
+								"age_check": {
+									Name:       "age_check",
+									Columns:    []string{"age"},
+									Definition: "CHECK ((age > 18))",
+								},
+							},
+						},
+					},
+				},
+			},
 		}
 
 		// init the state


### PR DESCRIPTION
Add knowledge of `CHECK` constraints defined on a table to `pgroll`'s internal schema representation

Part of https://github.com/xataio/pgroll/issues/105