### PR TITLE
Add `UNIQUE` constraints to `pgroll`'s internal schema representation

### DIFF
--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -52,6 +52,9 @@ type Table struct {
 
 	// CheckConstraints is a map of all check constraints defined on the table
 	CheckConstraints map[string]CheckConstraint `json:"checkConstraints"`
+
+	// UniqueConstraints is a map of all unique constraints defined on the table
+	UniqueConstraints map[string]UniqueConstraint `json:"uniqueConstraints"`
 }
 
 type Column struct {
@@ -97,6 +100,14 @@ type CheckConstraint struct {
 
 	// The definition of the check constraint
 	Definition string `json:"definition"`
+}
+
+type UniqueConstraint struct {
+	// Name is the name of the unique constraint in postgres
+	Name string `json:"name"`
+
+	// The columns that the unique constraint is defined on
+	Columns []string `json:"columns"`
 }
 
 func (s *Schema) GetTable(name string) *Table {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -107,6 +107,12 @@ func TestReadSchema(t *testing.T) {
 									Name: "id_unique",
 								},
 							},
+							UniqueConstraints: map[string]schema.UniqueConstraint{
+								"id_unique": {
+									Name:    "id_unique",
+									Columns: []string{"id"},
+								},
+							},
 						},
 					},
 				},
@@ -187,6 +193,47 @@ func TestReadSchema(t *testing.T) {
 									Name:       "age_check",
 									Columns:    []string{"age"},
 									Definition: "CHECK ((age > 18))",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				name:       "unique constraint",
+				createStmt: "CREATE TABLE public.table1 (id int PRIMARY KEY, name TEXT, CONSTRAINT name_unique UNIQUE(name) );",
+				wantSchema: &schema.Schema{
+					Name: "public",
+					Tables: map[string]schema.Table{
+						"table1": {
+							Name: "table1",
+							Columns: map[string]schema.Column{
+								"id": {
+									Name:     "id",
+									Type:     "integer",
+									Nullable: false,
+									Unique:   true,
+								},
+								"name": {
+									Name:     "name",
+									Type:     "text",
+									Unique:   true,
+									Nullable: true,
+								},
+							},
+							PrimaryKey: []string{"id"},
+							Indexes: map[string]schema.Index{
+								"table1_pkey": {
+									Name: "table1_pkey",
+								},
+								"name_unique": {
+									Name: "name_unique",
+								},
+							},
+							UniqueConstraints: map[string]schema.UniqueConstraint{
+								"name_unique": {
+									Name:    "name_unique",
+									Columns: []string{"name"},
 								},
 							},
 						},


### PR DESCRIPTION
Add knowledge of `UNIQUE` constraints defined on a table to `pgroll`'s internal schema representation.

`UNIQUE` constraints were already present as indexes, but this PR adds them as their own top-level field in the `Table` schema and includes information about the columns involved in the constraint.

Part of https://github.com/xataio/pgroll/issues/105