### PR TITLE
Preserve `CHECK` constraints on duplication

### DIFF
--- a/pkg/migrations/op_set_notnull_test.go
+++ b/pkg/migrations/op_set_notnull_test.go
@@ -301,7 +301,7 @@ func TestSetNotNull(t *testing.T) {
 			},
 		},
 		{
-			name: "setting a nullable column to not null retains any default defined on the column",
+			name: "setting a column to not null retains any default defined on the column",
 			migrations: []migrations.Migration{
 				{
 					Name: "01_add_table",
@@ -362,6 +362,62 @@ func TestSetNotNull(t *testing.T) {
 					{"id": 1, "name": "anonymous"},
 					{"id": 2, "name": "anonymous"},
 				}, rows)
+			},
+		},
+		{
+			name: "setting a column to not null retains any check constraints defined on the column",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "integer",
+									Pk:   true,
+								},
+								{
+									Name:     "name",
+									Type:     "text",
+									Nullable: true,
+									Check: &migrations.CheckConstraint{
+										Name:       "name_length",
+										Constraint: "length(name) > 3",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_set_not_null",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:    "users",
+							Column:   "name",
+							Nullable: ptr(false),
+							Up:       "(SELECT CASE WHEN name IS NULL THEN 'anonymous' ELSE name END)",
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB) {
+				// Inserting a row that violates the check constraint should fail.
+				MustNotInsert(t, db, "public", "02_set_not_null", "users", map[string]string{
+					"id":   "1",
+					"name": "a",
+				}, testutils.CheckViolationErrorCode)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB) {
+			},
+			afterComplete: func(t *testing.T, db *sql.DB) {
+				// Inserting a row that violates the check constraint should fail.
+				MustNotInsert(t, db, "public", "02_set_not_null", "users", map[string]string{
+					"id":   "2",
+					"name": "b",
+				}, testutils.CheckViolationErrorCode)
 			},
 		},
 	})

--- a/pkg/migrations/rename.go
+++ b/pkg/migrations/rename.go
@@ -12,12 +12,15 @@ import (
 	"github.com/xataio/pgroll/pkg/schema"
 )
 
-// RenameDuplicatedColumn renames a duplicated column to its original name and renames any foreign keys
-// on the duplicated column to their original name.
+// RenameDuplicatedColumn:
+// * renames a duplicated column to its original name
+// * renames any foreign keys on the duplicated column to their original name.
+// * Validates and renames any temporary `CHECK` constraints on the duplicated column.
 func RenameDuplicatedColumn(ctx context.Context, conn *sql.DB, table *schema.Table, column *schema.Column) error {
 	const (
-		cRenameColumnSQL     = `ALTER TABLE IF EXISTS %s RENAME COLUMN %s TO %s`
-		cRenameConstraintSQL = `ALTER TABLE IF EXISTS %s RENAME CONSTRAINT %s TO %s`
+		cRenameColumnSQL       = `ALTER TABLE IF EXISTS %s RENAME COLUMN %s TO %s`
+		cRenameConstraintSQL   = `ALTER TABLE IF EXISTS %s RENAME CONSTRAINT %s TO %s`
+		cValidateConstraintSQL = `ALTER TABLE IF EXISTS %s VALIDATE CONSTRAINT %s`
 	)
 
 	// Rename the old column to the new column name
@@ -33,14 +36,13 @@ func RenameDuplicatedColumn(ctx context.Context, conn *sql.DB, table *schema.Tab
 
 	// Rename any foreign keys on the duplicated column from their temporary name
 	// to their original name
-	var renameConstraintSQL string
 	for _, fk := range table.ForeignKeys {
 		if !IsDuplicatedName(fk.Name) {
 			continue
 		}
 
 		if slices.Contains(fk.Columns, TemporaryName(column.Name)) {
-			renameConstraintSQL = fmt.Sprintf(cRenameConstraintSQL,
+			renameConstraintSQL := fmt.Sprintf(cRenameConstraintSQL,
 				pq.QuoteIdentifier(table.Name),
 				pq.QuoteIdentifier(fk.Name),
 				pq.QuoteIdentifier(StripDuplicationPrefix(fk.Name)),
@@ -48,7 +50,38 @@ func RenameDuplicatedColumn(ctx context.Context, conn *sql.DB, table *schema.Tab
 
 			_, err = conn.ExecContext(ctx, renameConstraintSQL)
 			if err != nil {
-				return fmt.Errorf("failed to rename column constraint %q: %w", fk.Name, err)
+				return fmt.Errorf("failed to rename foreign key constraint %q: %w", fk.Name, err)
+			}
+		}
+	}
+
+	// Validate and rename any temporary `CHECK` constraints on the duplicated
+	// column.
+	for _, cc := range table.CheckConstraints {
+		if !IsDuplicatedName(cc.Name) {
+			continue
+		}
+
+		if slices.Contains(cc.Columns, TemporaryName(column.Name)) {
+			validateConstraintSQL := fmt.Sprintf(cValidateConstraintSQL,
+				pq.QuoteIdentifier(table.Name),
+				pq.QuoteIdentifier(cc.Name),
+			)
+
+			_, err = conn.ExecContext(ctx, validateConstraintSQL)
+			if err != nil {
+				return fmt.Errorf("failed to validate check constraint %q: %w", cc.Name, err)
+			}
+
+			renameConstraintSQL := fmt.Sprintf(cRenameConstraintSQL,
+				pq.QuoteIdentifier(table.Name),
+				pq.QuoteIdentifier(cc.Name),
+				pq.QuoteIdentifier(StripDuplicationPrefix(cc.Name)),
+			)
+
+			_, err = conn.ExecContext(ctx, renameConstraintSQL)
+			if err != nil {
+				return fmt.Errorf("failed to rename check constraint %q: %w", cc.Name, err)
 			}
 		}
 	}


### PR DESCRIPTION
When duplicating a column for backfilling ensure that any `CHECK` constraints on the original column are re-created on the duplicated column. The `CHECK` constraint is initially created as `NOT VALID` then validated after migration completion.

This is part of https://github.com/xataio/pgroll/issues/227

As of this PR, column properties that are preserved when duplicating a column for backfilling are:

* `DEFAULT` values
* `FOREIGN KEY` constraints
* `CHECK` constraints