### PR TITLE
Identify duplicated foreign key constraints by prefix

### DIFF
--- a/pkg/migrations/op_change_type_test.go
+++ b/pkg/migrations/op_change_type_test.go
@@ -213,7 +213,7 @@ func TestChangeColumnType(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB) {
 				// A temporary FK constraint has been created on the temporary column
-				ValidatedForeignKeyMustExist(t, db, "public", "employees", migrations.TemporaryName("fk_employee_department"))
+				ValidatedForeignKeyMustExist(t, db, "public", "employees", migrations.DuplicationName("fk_employee_department"))
 			},
 			afterRollback: func(t *testing.T, db *sql.DB) {
 			},

--- a/pkg/migrations/op_set_check_test.go
+++ b/pkg/migrations/op_set_check_test.go
@@ -285,7 +285,7 @@ func TestSetCheckConstraint(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB) {
 				// A temporary FK constraint has been created on the temporary column
-				ValidatedForeignKeyMustExist(t, db, "public", "employees", migrations.TemporaryName("fk_employee_department"))
+				ValidatedForeignKeyMustExist(t, db, "public", "employees", migrations.DuplicationName("fk_employee_department"))
 			},
 			afterRollback: func(t *testing.T, db *sql.DB) {
 			},

--- a/pkg/migrations/op_set_fk.go
+++ b/pkg/migrations/op_set_fk.go
@@ -85,7 +85,7 @@ func (o *OpSetForeignKey) Complete(ctx context.Context, conn *sql.DB, s *schema.
 	// Validate the foreign key constraint
 	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s VALIDATE CONSTRAINT %s",
 		pq.QuoteIdentifier(o.Table),
-		pq.QuoteIdentifier(TemporaryName(o.References.Name))))
+		pq.QuoteIdentifier(o.References.Name)))
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func (o *OpSetForeignKey) addForeignKeyConstraint(ctx context.Context, conn *sql
 
 	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s) NOT VALID",
 		pq.QuoteIdentifier(o.Table),
-		pq.QuoteIdentifier(TemporaryName(o.References.Name)),
+		pq.QuoteIdentifier(o.References.Name),
 		pq.QuoteIdentifier(tempColumnName),
 		pq.QuoteIdentifier(o.References.Table),
 		pq.QuoteIdentifier(o.References.Column),

--- a/pkg/migrations/op_set_fk_test.go
+++ b/pkg/migrations/op_set_fk_test.go
@@ -77,7 +77,7 @@ func TestSetForeignKey(t *testing.T) {
 				ColumnMustExist(t, db, "public", "posts", migrations.TemporaryName("user_id"))
 
 				// A temporary FK constraint has been created on the temporary column
-				NotValidatedForeignKeyMustExist(t, db, "public", "posts", migrations.TemporaryName("fk_users_id"))
+				NotValidatedForeignKeyMustExist(t, db, "public", "posts", "fk_users_id")
 
 				// Inserting some data into the `users` table works.
 				MustInsert(t, db, "public", "02_add_fk_constraint", "users", map[string]string{
@@ -348,7 +348,7 @@ func TestSetForeignKey(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB) {
 				// A temporary FK constraint has been created on the temporary column
-				ValidatedForeignKeyMustExist(t, db, "public", "posts", migrations.TemporaryName("fk_users_id_1"))
+				ValidatedForeignKeyMustExist(t, db, "public", "posts", migrations.DuplicationName("fk_users_id_1"))
 			},
 			afterRollback: func(t *testing.T, db *sql.DB) {
 			},

--- a/pkg/migrations/op_set_notnull_test.go
+++ b/pkg/migrations/op_set_notnull_test.go
@@ -291,7 +291,7 @@ func TestSetNotNull(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB) {
 				// A temporary FK constraint has been created on the temporary column
-				ValidatedForeignKeyMustExist(t, db, "public", "employees", migrations.TemporaryName("fk_employee_department"))
+				ValidatedForeignKeyMustExist(t, db, "public", "employees", migrations.DuplicationName("fk_employee_department"))
 			},
 			afterRollback: func(t *testing.T, db *sql.DB) {
 			},

--- a/pkg/migrations/op_set_unique_test.go
+++ b/pkg/migrations/op_set_unique_test.go
@@ -330,7 +330,7 @@ func TestSetColumnUnique(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB) {
 				// A temporary FK constraint has been created on the temporary column
-				ValidatedForeignKeyMustExist(t, db, "public", "employees", migrations.TemporaryName("fk_employee_department"))
+				ValidatedForeignKeyMustExist(t, db, "public", "employees", migrations.DuplicationName("fk_employee_department"))
 			},
 			afterRollback: func(t *testing.T, db *sql.DB) {
 			},

--- a/pkg/migrations/rename.go
+++ b/pkg/migrations/rename.go
@@ -35,11 +35,15 @@ func RenameDuplicatedColumn(ctx context.Context, conn *sql.DB, table *schema.Tab
 	// to their original name
 	var renameConstraintSQL string
 	for _, fk := range table.ForeignKeys {
+		if !IsDuplicatedName(fk.Name) {
+			continue
+		}
+
 		if slices.Contains(fk.Columns, TemporaryName(column.Name)) {
 			renameConstraintSQL = fmt.Sprintf(cRenameConstraintSQL,
 				pq.QuoteIdentifier(table.Name),
 				pq.QuoteIdentifier(fk.Name),
-				pq.QuoteIdentifier(StripTemporaryPrefix(fk.Name)),
+				pq.QuoteIdentifier(StripDuplicationPrefix(fk.Name)),
 			)
 
 			_, err = conn.ExecContext(ctx, renameConstraintSQL)


### PR DESCRIPTION
When duplicating a column for backfilling, ensure that any FK constraints on the column are duplicated with a special prefix to identify them as duplicated constraints. Naming the duplicated FK constraints in this way allows the rename process to ensure that it only attempts to rename duplicated FK constraints.