### PR TITLE
Preserve `NOT NULL` attributes on column duplication

### DIFF
--- a/pkg/migrations/op_drop_constraint_test.go
+++ b/pkg/migrations/op_drop_constraint_test.go
@@ -243,8 +243,9 @@ func TestDropConstraint(t *testing.T) {
 									Type: "text",
 								},
 								{
-									Name: "user_id",
-									Type: "integer",
+									Name:     "user_id",
+									Type:     "integer",
+									Nullable: true,
 								},
 							},
 						},

--- a/pkg/migrations/op_set_fk_test.go
+++ b/pkg/migrations/op_set_fk_test.go
@@ -48,8 +48,9 @@ func TestSetForeignKey(t *testing.T) {
 									Type: "text",
 								},
 								{
-									Name: "user_id",
-									Type: "integer",
+									Name:     "user_id",
+									Type:     "integer",
+									Nullable: true,
 								},
 							},
 						},

--- a/pkg/migrations/op_set_fk_test.go
+++ b/pkg/migrations/op_set_fk_test.go
@@ -443,6 +443,82 @@ func TestSetForeignKey(t *testing.T) {
 				}, testutils.CheckViolationErrorCode)
 			},
 		},
+		{
+			name: "not null is preserved when adding a foreign key constraint",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_tables",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name: "name",
+									Type: "text",
+								},
+							},
+						},
+						&migrations.OpCreateTable{
+							Name: "posts",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name:     "title",
+									Type:     "text",
+									Nullable: true,
+								},
+								{
+									Name:     "user_id",
+									Type:     "integer",
+									Nullable: false,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_add_fk_constraint",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:  "posts",
+							Column: "user_id",
+							References: &migrations.ForeignKeyReference{
+								Name:   "fk_users_id",
+								Table:  "users",
+								Column: "id",
+							},
+							Up:   "(SELECT CASE WHEN EXISTS (SELECT 1 FROM users WHERE users.id = user_id) THEN user_id ELSE NULL END)",
+							Down: "user_id",
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB) {
+				// Inserting a row that violates the NOT NULL constraint on `user_id` fails.
+				MustNotInsert(t, db, "public", "02_add_fk_constraint", "posts", map[string]string{
+					"id":    "1",
+					"title": "post by alice",
+				}, testutils.NotNullViolationErrorCode)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB) {
+			},
+			afterComplete: func(t *testing.T, db *sql.DB) {
+				// Inserting a row that violates the NOT NULL constraint on `user_id` fails.
+				MustNotInsert(t, db, "public", "02_add_fk_constraint", "posts", map[string]string{
+					"id":    "1",
+					"title": "post by alice",
+				}, testutils.NotNullViolationErrorCode)
+			},
+		},
 	})
 }
 

--- a/pkg/migrations/rename.go
+++ b/pkg/migrations/rename.go
@@ -21,6 +21,8 @@ func RenameDuplicatedColumn(ctx context.Context, conn *sql.DB, table *schema.Tab
 		cRenameColumnSQL       = `ALTER TABLE IF EXISTS %s RENAME COLUMN %s TO %s`
 		cRenameConstraintSQL   = `ALTER TABLE IF EXISTS %s RENAME CONSTRAINT %s TO %s`
 		cValidateConstraintSQL = `ALTER TABLE IF EXISTS %s VALIDATE CONSTRAINT %s`
+		cSetNotNullSQL         = `ALTER TABLE IF EXISTS %s ALTER COLUMN %s SET NOT NULL`
+		cDropConstraintSQL     = `ALTER TABLE IF EXISTS %s DROP CONSTRAINT IF EXISTS %s`
 	)
 
 	// Rename the old column to the new column name
@@ -86,5 +88,41 @@ func RenameDuplicatedColumn(ctx context.Context, conn *sql.DB, table *schema.Tab
 		}
 	}
 
+	// If the original column was NOT NULL, convert the duplicated unchecked `NOT
+	// NULL` constraint into a `NOT NULL` attribute on the column.
+	if !column.Nullable {
+		// Validate the constraint
+		validateConstraintSQL := fmt.Sprintf(cValidateConstraintSQL,
+			pq.QuoteIdentifier(table.Name),
+			pq.QuoteIdentifier(NotNullConstraintName(column.Name)),
+		)
+
+		_, err = conn.ExecContext(ctx, validateConstraintSQL)
+		if err != nil {
+			return fmt.Errorf("failed to validate not null constraint: %w", err)
+		}
+
+		// Apply `NOT NULL` attribute to the column. This uses the validated constraint
+		setNotNullSQL := fmt.Sprintf(cSetNotNullSQL,
+			pq.QuoteIdentifier(table.Name),
+			pq.QuoteIdentifier(column.Name),
+		)
+
+		_, err = conn.ExecContext(ctx, setNotNullSQL)
+		if err != nil {
+			return fmt.Errorf("failed to set column not null: %w", err)
+		}
+
+		// Drop the constraint
+		dropConstraintSQL := fmt.Sprintf(cDropConstraintSQL,
+			pq.QuoteIdentifier(table.Name),
+			pq.QuoteIdentifier(NotNullConstraintName(column.Name)),
+		)
+
+		_, err = conn.ExecContext(ctx, dropConstraintSQL)
+		if err != nil {
+			return fmt.Errorf("failed to drop not null constraint: %w", err)
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
When duplicating a column for backfilling ensure that a `NOT NULL` attribute on the original column is re-created on the duplicated column. A `CHECK IS NOT NULL` constraint is initially created as `NOT VALID` then validated  and converted to a `NOT NULL` column attribute after migration completion.

This is part of https://github.com/xataio/pgroll/issues/227

As of this PR, column properties that are preserved when duplicating a column for backfilling are:

* `DEFAULT` values
* `FOREIGN KEY` constraints
* `CHECK` constraints
* `NOT NULL` attributes