### PR TITLE
Include key columns for an index in the internal schema representation

### DIFF
--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -78,6 +78,9 @@ type Index struct {
 
 	// Unique indicates whether or not the index is unique
 	Unique bool `json:"unique"`
+
+	// Columns is the set of key columns on which the index is defined
+	Columns []string `json:"columns"`
 }
 
 type ForeignKey struct {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -281,6 +281,37 @@ func TestReadSchema(t *testing.T) {
 					},
 				},
 			},
+			{
+				name:       "multi-column index",
+				createStmt: "CREATE TABLE public.table1 (a text, b text); CREATE INDEX idx_ab ON public.table1 (a, b);",
+				wantSchema: &schema.Schema{
+					Name: "public",
+					Tables: map[string]schema.Table{
+						"table1": {
+							Name: "table1",
+							Columns: map[string]schema.Column{
+								"a": {
+									Name:     "a",
+									Type:     "text",
+									Nullable: true,
+								},
+								"b": {
+									Name:     "b",
+									Type:     "text",
+									Nullable: true,
+								},
+							},
+							Indexes: map[string]schema.Index{
+								"idx_ab": {
+									Name:    "idx_ab",
+									Unique:  false,
+									Columns: []string{"a", "b"},
+								},
+							},
+						},
+					},
+				},
+			},
 		}
 
 		// init the state

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -104,8 +104,9 @@ func TestReadSchema(t *testing.T) {
 							},
 							Indexes: map[string]schema.Index{
 								"id_unique": {
-									Name:   "id_unique",
-									Unique: true,
+									Name:    "id_unique",
+									Unique:  true,
+									Columns: []string{"id"},
 								},
 							},
 							UniqueConstraints: map[string]schema.UniqueConstraint{
@@ -140,8 +141,9 @@ func TestReadSchema(t *testing.T) {
 							},
 							Indexes: map[string]schema.Index{
 								"idx_name": {
-									Name:   "idx_name",
-									Unique: false,
+									Name:    "idx_name",
+									Unique:  false,
+									Columns: []string{"name"},
 								},
 							},
 						},
@@ -167,8 +169,9 @@ func TestReadSchema(t *testing.T) {
 							PrimaryKey: []string{"id"},
 							Indexes: map[string]schema.Index{
 								"table1_pkey": {
-									Name:   "table1_pkey",
-									Unique: true,
+									Name:    "table1_pkey",
+									Unique:  true,
+									Columns: []string{"id"},
 								},
 							},
 						},
@@ -217,8 +220,9 @@ func TestReadSchema(t *testing.T) {
 							PrimaryKey: []string{"id"},
 							Indexes: map[string]schema.Index{
 								"table1_pkey": {
-									Name:   "table1_pkey",
-									Unique: true,
+									Name:    "table1_pkey",
+									Unique:  true,
+									Columns: []string{"id"},
 								},
 							},
 							CheckConstraints: map[string]schema.CheckConstraint{
@@ -257,12 +261,14 @@ func TestReadSchema(t *testing.T) {
 							PrimaryKey: []string{"id"},
 							Indexes: map[string]schema.Index{
 								"table1_pkey": {
-									Name:   "table1_pkey",
-									Unique: true,
+									Name:    "table1_pkey",
+									Unique:  true,
+									Columns: []string{"id"},
 								},
 								"name_unique": {
-									Name:   "name_unique",
-									Unique: true,
+									Name:    "name_unique",
+									Unique:  true,
+									Columns: []string{"name"},
 								},
 							},
 							UniqueConstraints: map[string]schema.UniqueConstraint{


### PR DESCRIPTION
In the internal schema representation, include the key columns on which an index is defined in the details for an index. With the new `columns` field, the representation for an index now looks like:

```json
"indexes": {
    "_pgroll_new_products_pkey": {
        "name": "_pgroll_new_products_pkey",
        "unique": true,
        "columns": [
            "id"
        ]
    }
}
```