### PR TITLE
Preserve `UNIQUE` constraints on column duplication

### DIFF
--- a/pkg/migrations/op_set_check_test.go
+++ b/pkg/migrations/op_set_check_test.go
@@ -413,6 +413,70 @@ func TestSetCheckConstraint(t *testing.T) {
 				}, testutils.NotNullViolationErrorCode)
 			},
 		},
+		{
+			name: "unique constraints are preserved when adding a check constraint",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "posts",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name:   "title",
+									Type:   "text",
+									Unique: true,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_add_check_constraint",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:  "posts",
+							Column: "title",
+							Check: &migrations.CheckConstraint{
+								Name:       "check_title_length",
+								Constraint: "length(title) > 3",
+							},
+							Up:   "(SELECT CASE WHEN length(title) <= 3 THEN LPAD(title, 4, '-') ELSE title END)",
+							Down: "title",
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB) {
+				// Inserting an initial row succeeds
+				MustInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+					"title": "post by alice",
+				})
+
+				// Inserting a row with a duplicate `title` value fails
+				MustNotInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+					"title": "post by alice",
+				}, testutils.UniqueViolationErrorCode)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB) {
+			},
+			afterComplete: func(t *testing.T, db *sql.DB) {
+				// Inserting a row with a duplicate `title` value fails
+				MustNotInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+					"title": "post by alice",
+				}, testutils.UniqueViolationErrorCode)
+
+				// Inserting a row with a different `title` value succeeds
+				MustInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+					"title": "post by bob",
+				})
+			},
+		},
 	})
 }
 

--- a/pkg/migrations/op_set_unique_test.go
+++ b/pkg/migrations/op_set_unique_test.go
@@ -462,5 +462,10 @@ func TestSetColumnUnique(t *testing.T) {
 				}, testutils.NotNullViolationErrorCode)
 			},
 		},
+		// It should be possible to add multiple unique constraints to a column
+		// once unique constraints covering multiple columns are supported.
+		//
+		// In that case it should be possible to test that existing unique constraints are
+		// preserved when adding a new unique constraint covering the same column.
 	})
 }


### PR DESCRIPTION
When duplicating a column for backfilling ensure that any `UNIQUE` constraints on the original column are re-created on the duplicated column. The `UNIQUE` constraint is initially created as an index concurrently and then converted to a constraint on migration completion.

This is part of https://github.com/xataio/pgroll/issues/227

As of this PR, column properties that are preserved when duplicating a column for backfilling are:

* `DEFAULT` values
* `FOREIGN KEY` constraints
* `CHECK` constraints
* `UNIQUE` constraints