### PR TITLE
Ensure constraint existence as part of validation for the drop constraint operation

### DIFF
--- a/pkg/migrations/errors.go
+++ b/pkg/migrations/errors.go
@@ -119,6 +119,15 @@ func (e CheckConstraintError) Error() string {
 		e.Err.Error())
 }
 
+type ConstraintDoesNotExistError struct {
+	Table      string
+	Constraint string
+}
+
+func (e ConstraintDoesNotExistError) Error() string {
+	return fmt.Sprintf("constraint %q on table %q does not exist", e.Constraint, e.Table)
+}
+
 type NoUpSQLAllowedError struct{}
 
 func (e NoUpSQLAllowedError) Error() string {

--- a/pkg/migrations/op_drop_constraint.go
+++ b/pkg/migrations/op_drop_constraint.go
@@ -142,6 +142,10 @@ func (o *OpDropConstraint) Validate(ctx context.Context, s *schema.Schema) error
 		return FieldRequiredError{Name: "name"}
 	}
 
+	if !table.ConstraintExists(o.Name) {
+		return ConstraintDoesNotExistError{Table: o.Table, Constraint: o.Name}
+	}
+
 	if o.Down == "" {
 		return FieldRequiredError{Name: "down"}
 	}

--- a/pkg/migrations/op_drop_constraint_test.go
+++ b/pkg/migrations/op_drop_constraint_test.go
@@ -538,6 +538,26 @@ func TestDropConstraintValidation(t *testing.T) {
 			wantStartErr: migrations.ColumnDoesNotExistError{Table: "posts", Name: "doesntexist"},
 		},
 		{
+			name: "constraint must exist",
+			migrations: []migrations.Migration{
+				createTableMigration,
+				addCheckMigration,
+				{
+					Name: "03_drop_check_constraint",
+					Operations: migrations.Operations{
+						&migrations.OpDropConstraint{
+							Table:  "posts",
+							Column: "title",
+							Name:   "doesntexist",
+							Up:     "title",
+							Down:   "(SELECT CASE WHEN length(title) <= 3 THEN LPAD(title, 4, '-') ELSE title END)",
+						},
+					},
+				},
+			},
+			wantStartErr: migrations.ConstraintDoesNotExistError{Table: "posts", Constraint: "doesntexist"},
+		},
+		{
 			name: "name is mandatory",
 			migrations: []migrations.Migration{
 				createTableMigration,

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -164,6 +164,19 @@ func (t *Table) GetColumn(name string) *Column {
 	return &c
 }
 
+func (t *Table) ConstraintExists(name string) bool {
+	_, ok := t.CheckConstraints[name]
+	if ok {
+		return true
+	}
+	_, ok = t.UniqueConstraints[name]
+	if ok {
+		return true
+	}
+	_, ok = t.ForeignKeys[name]
+	return ok
+}
+
 func (t *Table) GetPrimaryKey() (columns []*Column) {
 	for _, name := range t.PrimaryKey {
 		columns = append(columns, t.GetColumn(name))


### PR DESCRIPTION
Add extra validation to the drop constraint operation to ensure that the constraint to be dropped actually exists on the table. Validation fails if the constraint does not exist.

This is possible now that all supported constraints (`CHECK`, `UNIQUE` and `FOREIGN KEY`) are part of the internal schema representation.

Part of https://github.com/xataio/pgroll/issues/105