### PR TITLE
Preserve column properties on drop constraint operation

### DIFF
--- a/pkg/migrations/op_drop_constraint.go
+++ b/pkg/migrations/op_drop_constraint.go
@@ -18,7 +18,8 @@ func (o *OpDropConstraint) Start(ctx context.Context, conn *sql.DB, stateSchema 
 	column := table.GetColumn(o.Column)
 
 	// Create a copy of the column on the underlying table.
-	if err := duplicateColumn(ctx, conn, table, *column); err != nil {
+	d := NewColumnDuplicator(conn, table, column).WithoutConstraint(o.Name)
+	if err := d.Duplicate(ctx); err != nil {
 		return fmt.Errorf("failed to duplicate column: %w", err)
 	}
 
@@ -90,11 +91,9 @@ func (o *OpDropConstraint) Complete(ctx context.Context, conn *sql.DB, s *schema
 	}
 
 	// Rename the new column to the old column name
-	_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s RENAME COLUMN %s TO %s",
-		pq.QuoteIdentifier(o.Table),
-		pq.QuoteIdentifier(TemporaryName(o.Column)),
-		pq.QuoteIdentifier(o.Column)))
-	if err != nil {
+	table := s.GetTable(o.Table)
+	column := table.GetColumn(o.Column)
+	if err := RenameDuplicatedColumn(ctx, conn, table, column); err != nil {
 		return err
 	}
 

--- a/pkg/migrations/op_set_notnull.go
+++ b/pkg/migrations/op_set_notnull.go
@@ -187,20 +187,3 @@ func (o *OpSetNotNull) downSQL() string {
 	}
 	return o.Down
 }
-
-func duplicateColumn(ctx context.Context, conn *sql.DB, table *schema.Table, column schema.Column) error {
-	column.Name = TemporaryName(column.Name)
-
-	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s",
-		pq.QuoteIdentifier(table.Name),
-		schemaColumnToSQL(column),
-	))
-
-	return err
-}
-
-// TODO: This function needs to be able to duplicate a column more precisely
-// including constraints, indexes, defaults, etc.
-func schemaColumnToSQL(c schema.Column) string {
-	return fmt.Sprintf("%s %s", pq.QuoteIdentifier(c.Name), c.Type)
-}


### PR DESCRIPTION
Ensure that properties of a column are preserved when duplicating a column for backfilling as part of the drop constraint operation.

The properties that are preserved are:

* `NOT NULL`
* `DEFAULT`
* `FOREIGN KEY` constraints
* `CHECK` constraints
* `UNIQUE` constraints

Part of https://github.com/xataio/pgroll/issues/227