### PR TITLE
Correctly quote table and column names in the `drop column` operation

### DIFF
--- a/pkg/migrations/op_drop_column.go
+++ b/pkg/migrations/op_drop_column.go
@@ -35,7 +35,9 @@ func (o *OpDropColumn) Start(ctx context.Context, conn *sql.DB, stateSchema stri
 }
 
 func (o *OpDropColumn) Complete(ctx context.Context, conn *sql.DB, s *schema.Schema) error {
-	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", o.Table, o.Column))
+	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s",
+		pq.QuoteIdentifier(o.Table),
+		pq.QuoteIdentifier(o.Column)))
 	if err != nil {
 		return err
 	}

--- a/pkg/migrations/op_drop_column_test.go
+++ b/pkg/migrations/op_drop_column_test.go
@@ -147,5 +147,47 @@ func TestDropColumnWithDownSQL(t *testing.T) {
 				ColumnMustNotExist(t, db, "public", "users", "array")
 			},
 		},
+		{
+			name: "can drop a column in a table with a reserved word as its name",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "array",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name: "name",
+									Type: "text",
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_drop_column",
+					Operations: migrations.Operations{
+						&migrations.OpDropColumn{
+							Table:  "array",
+							Column: "name",
+							Down:   ptr("UPPER(email)"),
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB) {
+			},
+			afterRollback: func(t *testing.T, db *sql.DB) {
+			},
+			afterComplete: func(t *testing.T, db *sql.DB) {
+				// The column has been deleted from the underlying table.
+				ColumnMustNotExist(t, db, "public", "users", "array")
+			},
+		},
 	})
 }

--- a/pkg/migrations/op_drop_column_test.go
+++ b/pkg/migrations/op_drop_column_test.go
@@ -14,94 +14,138 @@ import (
 func TestDropColumnWithDownSQL(t *testing.T) {
 	t.Parallel()
 
-	ExecuteTests(t, TestCases{{
-		name: "drop column",
-		migrations: []migrations.Migration{
-			{
-				Name: "01_add_table",
-				Operations: migrations.Operations{
-					&migrations.OpCreateTable{
-						Name: "users",
-						Columns: []migrations.Column{
-							{
-								Name: "id",
-								Type: "serial",
-								Pk:   true,
-							},
-							{
-								Name:     "name",
-								Type:     "varchar(255)",
-								Nullable: false,
-							},
-							{
-								Name:     "email",
-								Type:     "varchar(255)",
-								Nullable: false,
+	ExecuteTests(t, TestCases{
+		{
+			name: "drop column",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name:     "name",
+									Type:     "varchar(255)",
+									Nullable: false,
+								},
+								{
+									Name:     "email",
+									Type:     "varchar(255)",
+									Nullable: false,
+								},
 							},
 						},
 					},
 				},
-			},
-			{
-				Name: "02_drop_column",
-				Operations: migrations.Operations{
-					&migrations.OpDropColumn{
-						Table:  "users",
-						Column: "name",
-						Down:   ptr("UPPER(email)"),
+				{
+					Name: "02_drop_column",
+					Operations: migrations.Operations{
+						&migrations.OpDropColumn{
+							Table:  "users",
+							Column: "name",
+							Down:   ptr("UPPER(email)"),
+						},
 					},
 				},
 			},
+			afterStart: func(t *testing.T, db *sql.DB) {
+				// The deleted column is not present on the view in the new version schema.
+				versionSchema := roll.VersionedSchemaName("public", "02_drop_column")
+				ColumnMustNotExist(t, db, versionSchema, "users", "name")
+
+				// But the column is still present on the underlying table.
+				ColumnMustExist(t, db, "public", "users", "name")
+
+				// Inserting into the view in the new version schema should succeed.
+				MustInsert(t, db, "public", "02_drop_column", "users", map[string]string{
+					"email": "foo@example.com",
+				})
+
+				// The "down" SQL has populated the removed column ("name")
+				results := MustSelect(t, db, "public", "01_add_table", "users")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "name": "FOO@EXAMPLE.COM", "email": "foo@example.com"},
+				}, results)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB) {
+				// The trigger function has been dropped.
+				triggerFnName := migrations.TriggerFunctionName("users", "name")
+				FunctionMustNotExist(t, db, "public", triggerFnName)
+
+				// The trigger has been dropped.
+				triggerName := migrations.TriggerName("users", "name")
+				TriggerMustNotExist(t, db, "public", "users", triggerName)
+			},
+			afterComplete: func(t *testing.T, db *sql.DB) {
+				// The column has been deleted from the underlying table.
+				ColumnMustNotExist(t, db, "public", "users", "name")
+
+				// The trigger function has been dropped.
+				triggerFnName := migrations.TriggerFunctionName("users", "name")
+				FunctionMustNotExist(t, db, "public", triggerFnName)
+
+				// The trigger has been dropped.
+				triggerName := migrations.TriggerName("users", "name")
+				TriggerMustNotExist(t, db, "public", "users", triggerName)
+
+				// Inserting into the view in the new version schema should succeed.
+				MustInsert(t, db, "public", "02_drop_column", "users", map[string]string{
+					"email": "bar@example.com",
+				})
+				results := MustSelect(t, db, "public", "02_drop_column", "users")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "email": "foo@example.com"},
+					{"id": 2, "email": "bar@example.com"},
+				}, results)
+			},
 		},
-		afterStart: func(t *testing.T, db *sql.DB) {
-			// The deleted column is not present on the view in the new version schema.
-			versionSchema := roll.VersionedSchemaName("public", "02_drop_column")
-			ColumnMustNotExist(t, db, versionSchema, "users", "name")
-
-			// But the column is still present on the underlying table.
-			ColumnMustExist(t, db, "public", "users", "name")
-
-			// Inserting into the view in the new version schema should succeed.
-			MustInsert(t, db, "public", "02_drop_column", "users", map[string]string{
-				"email": "foo@example.com",
-			})
-
-			// The "down" SQL has populated the removed column ("name")
-			results := MustSelect(t, db, "public", "01_add_table", "users")
-			assert.Equal(t, []map[string]any{
-				{"id": 1, "name": "FOO@EXAMPLE.COM", "email": "foo@example.com"},
-			}, results)
+		{
+			name: "can drop a column with a reserved word as its name",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name: "array",
+									Type: "int[]",
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_drop_column",
+					Operations: migrations.Operations{
+						&migrations.OpDropColumn{
+							Table:  "users",
+							Column: "array",
+							Down:   ptr("UPPER(email)"),
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB) {
+			},
+			afterRollback: func(t *testing.T, db *sql.DB) {
+			},
+			afterComplete: func(t *testing.T, db *sql.DB) {
+				// The column has been deleted from the underlying table.
+				ColumnMustNotExist(t, db, "public", "users", "array")
+			},
 		},
-		afterRollback: func(t *testing.T, db *sql.DB) {
-			// The trigger function has been dropped.
-			triggerFnName := migrations.TriggerFunctionName("users", "name")
-			FunctionMustNotExist(t, db, "public", triggerFnName)
-
-			// The trigger has been dropped.
-			triggerName := migrations.TriggerName("users", "name")
-			TriggerMustNotExist(t, db, "public", "users", triggerName)
-		},
-		afterComplete: func(t *testing.T, db *sql.DB) {
-			// The column has been deleted from the underlying table.
-			ColumnMustNotExist(t, db, "public", "users", "name")
-
-			// The trigger function has been dropped.
-			triggerFnName := migrations.TriggerFunctionName("users", "name")
-			FunctionMustNotExist(t, db, "public", triggerFnName)
-
-			// The trigger has been dropped.
-			triggerName := migrations.TriggerName("users", "name")
-			TriggerMustNotExist(t, db, "public", "users", triggerName)
-
-			// Inserting into the view in the new version schema should succeed.
-			MustInsert(t, db, "public", "02_drop_column", "users", map[string]string{
-				"email": "bar@example.com",
-			})
-			results := MustSelect(t, db, "public", "02_drop_column", "users")
-			assert.Equal(t, []map[string]any{
-				{"id": 1, "email": "foo@example.com"},
-				{"id": 2, "email": "bar@example.com"},
-			}, results)
-		},
-	}})
+	})
 }


### PR DESCRIPTION
Quote table and column names correctly in the drop column operation.

Add testcases to ensure that 
* a column with a reserved word name can be dropped
* a column in a table with a reserved word name can be dropped.