### PR TITLE
Add drop `NOT NULL` operation to remove `NOT NULL` from a column

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@
         * [Add check constraint](#add-check-constraint)
         * [Add foreign key](#add-foreign-key)
         * [Add not null constraint](#add-not-null-constraint)
+        * [Drop not null constraint](#drop-not-null-constraint)
         * [Add unique constraint](#add-unique-constraint)
     * [Create index](#create-index)
     * [Create table](#create-table)
@@ -675,6 +676,7 @@ See the [examples](../examples) directory for examples of each kind of operation
     * [Add check constraint](#add-check-constraint)
     * [Add foreign key](#add-foreign-key)
     * [Add not null constraint](#add-not-null-constraint)
+    * [Drop not null constraint](#drop-not-null-constraint)
     * [Add unique constraint](#add-unique-constraint)
 * [Create index](#create-index)
 * [Create table](#create-table)
@@ -847,6 +849,28 @@ Add not null operations add a `NOT NULL` constraint to a column.
 Example **add not null** migrations:
 
 * [16_set_nullable.json](../examples/16_set_nullable.json)
+
+#### Drop not null constraint
+
+Drop not null operations drop a `NOT NULL` constraint from a column.
+
+**drop not null** operations have this structure:
+
+```json
+{
+  "alter_column": {
+    "table": "table name",
+    "column": "column name",
+    "nullable": true,
+    "up": "SQL expression",
+    "down": "SQL expression"
+  }
+}
+```
+
+Example **drop not null** migrations:
+
+* [31_unset_not_null.json](../examples/31_unset_not_null.json)
 
 #### Add unique constraint
 

--- a/examples/31_unset_not_null.json
+++ b/examples/31_unset_not_null.json
@@ -1,0 +1,14 @@
+{
+  "name": "31_unset_not_null",
+  "operations": [
+    {
+      "alter_column": {
+        "table": "posts",
+        "column": "title",
+        "nullable": true,
+        "up": "title",
+        "down": "(SELECT CASE WHEN title IS NULL THEN 'placeholder title' ELSE title END)"
+      }
+    }
+  ]
+}

--- a/pkg/migrations/duplicate.go
+++ b/pkg/migrations/duplicate.go
@@ -18,6 +18,7 @@ type Duplicator struct {
 	table             *schema.Table
 	column            *schema.Column
 	asName            string
+	withoutNotNull    bool
 	withType          string
 	withoutConstraint string
 }
@@ -40,6 +41,11 @@ func (d *Duplicator) WithType(t string) *Duplicator {
 
 func (d *Duplicator) WithoutConstraint(c string) *Duplicator {
 	d.withoutConstraint = c
+	return d
+}
+
+func (d *Duplicator) WithoutNotNull() *Duplicator {
+	d.withoutNotNull = true
 	return d
 }
 
@@ -67,7 +73,7 @@ func (d *Duplicator) Duplicate(ctx context.Context) error {
 
 	// Generate SQL to add an unchecked NOT NULL constraint if the original column
 	// is NOT NULL. The constraint will be validated on migration completion.
-	if !d.column.Nullable {
+	if !d.column.Nullable && !d.withoutNotNull {
 		sql += fmt.Sprintf(", "+cAddCheckConstraintSQL,
 			pq.QuoteIdentifier(DuplicationName(NotNullConstraintName(d.column.Name))),
 			fmt.Sprintf("CHECK (%s IS NOT NULL)", pq.QuoteIdentifier(d.asName)),

--- a/pkg/migrations/errors.go
+++ b/pkg/migrations/errors.go
@@ -61,6 +61,15 @@ func (e ColumnIsNotNullableError) Error() string {
 	return fmt.Sprintf("column %q on table %q is NOT NULL", e.Name, e.Table)
 }
 
+type ColumnIsNullableError struct {
+	Table string
+	Name  string
+}
+
+func (e ColumnIsNullableError) Error() string {
+	return fmt.Sprintf("column %q on table %q is nullable", e.Name, e.Table)
+}
+
 type IndexAlreadyExistsError struct {
 	Name string
 }

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/lib/pq"
 	"github.com/xataio/pgroll/pkg/schema"
@@ -228,4 +229,8 @@ func (o *OpAddColumn) addCheckConstraint(ctx context.Context, conn *sql.DB) erro
 
 func NotNullConstraintName(columnName string) string {
 	return "_pgroll_check_not_null_" + columnName
+}
+
+func IsNotNullConstraintName(name string) bool {
+	return strings.HasPrefix(name, "_pgroll_check_not_null_")
 }

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -227,5 +227,5 @@ func (o *OpAddColumn) addCheckConstraint(ctx context.Context, conn *sql.DB) erro
 }
 
 func NotNullConstraintName(columnName string) string {
-	return "_pgroll_add_column_check_" + columnName
+	return "_pgroll_check_not_null_" + columnName
 }

--- a/pkg/migrations/op_drop_not_null.go
+++ b/pkg/migrations/op_drop_not_null.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/lib/pq"
+	"github.com/xataio/pgroll/pkg/schema"
+)
+
+type OpDropNotNull struct {
+	Table  string `json:"table"`
+	Column string `json:"column"`
+	Up     string `json:"up"`
+	Down   string `json:"down"`
+}
+
+var _ Operation = (*OpDropNotNull)(nil)
+
+func (o *OpDropNotNull) Start(ctx context.Context, conn *sql.DB, stateSchema string, s *schema.Schema, cbs ...CallbackFn) error {
+	table := s.GetTable(o.Table)
+	column := table.GetColumn(o.Column)
+
+	// Create a copy of the column on the underlying table.
+	d := NewColumnDuplicator(conn, table, column).WithoutNotNull()
+	if err := d.Duplicate(ctx); err != nil {
+		return fmt.Errorf("failed to duplicate column: %w", err)
+	}
+
+	// Add a trigger to copy values from the old column to the new, rewriting NULL values using the `up` SQL.
+	err := createTrigger(ctx, conn, triggerConfig{
+		Name:           TriggerName(o.Table, o.Column),
+		Direction:      TriggerDirectionUp,
+		Columns:        table.Columns,
+		SchemaName:     s.Name,
+		TableName:      o.Table,
+		PhysicalColumn: TemporaryName(o.Column),
+		StateSchema:    stateSchema,
+		SQL:            o.upSQL(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create up trigger: %w", err)
+	}
+
+	// Backfill the new column with values from the old column.
+	if err := backfill(ctx, conn, table, cbs...); err != nil {
+		return fmt.Errorf("failed to backfill column: %w", err)
+	}
+
+	// Add the new column to the internal schema representation. This is done
+	// here, before creation of the down trigger, so that the trigger can declare
+	// a variable for the new column.
+	table.AddColumn(o.Column, schema.Column{
+		Name: TemporaryName(o.Column),
+	})
+
+	// Add a trigger to copy values from the new column to the old.
+	err = createTrigger(ctx, conn, triggerConfig{
+		Name:           TriggerName(o.Table, TemporaryName(o.Column)),
+		Direction:      TriggerDirectionDown,
+		Columns:        table.Columns,
+		SchemaName:     s.Name,
+		TableName:      o.Table,
+		PhysicalColumn: o.Column,
+		StateSchema:    stateSchema,
+		SQL:            o.Down,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create down trigger: %w", err)
+	}
+
+	return nil
+}
+
+func (o *OpDropNotNull) Complete(ctx context.Context, conn *sql.DB, s *schema.Schema) error {
+	// Drop the old column
+	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s DROP COLUMN IF EXISTS %s",
+		pq.QuoteIdentifier(o.Table),
+		pq.QuoteIdentifier(o.Column)))
+	if err != nil {
+		return err
+	}
+
+	// Remove the up function and trigger
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("DROP FUNCTION IF EXISTS %s CASCADE",
+		pq.QuoteIdentifier(TriggerFunctionName(o.Table, o.Column))))
+	if err != nil {
+		return err
+	}
+
+	// Remove the down function and trigger
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("DROP FUNCTION IF EXISTS %s CASCADE",
+		pq.QuoteIdentifier(TriggerFunctionName(o.Table, TemporaryName(o.Column)))))
+	if err != nil {
+		return err
+	}
+
+	// Rename the new column to the old column name
+	table := s.GetTable(o.Table)
+	column := table.GetColumn(o.Column)
+	if err := RenameDuplicatedColumn(ctx, conn, table, column); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *OpDropNotNull) Rollback(ctx context.Context, conn *sql.DB) error {
+	// Drop the new column
+	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s DROP COLUMN IF EXISTS %s",
+		pq.QuoteIdentifier(o.Table),
+		pq.QuoteIdentifier(TemporaryName(o.Column)),
+	))
+	if err != nil {
+		return err
+	}
+
+	// Remove the up function and trigger
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("DROP FUNCTION IF EXISTS %s CASCADE",
+		pq.QuoteIdentifier(TriggerFunctionName(o.Table, o.Column)),
+	))
+	if err != nil {
+		return err
+	}
+
+	// Remove the down function and trigger
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("DROP FUNCTION IF EXISTS %s CASCADE",
+		pq.QuoteIdentifier(TriggerFunctionName(o.Table, TemporaryName(o.Column))),
+	))
+
+	return err
+}
+
+func (o *OpDropNotNull) Validate(ctx context.Context, s *schema.Schema) error {
+	column := s.GetTable(o.Table).GetColumn(o.Column)
+	if column.Nullable {
+		return ColumnIsNullableError{Table: o.Table, Name: o.Column}
+	}
+
+	if o.Down == "" {
+		return FieldRequiredError{Name: "down"}
+	}
+
+	return nil
+}
+
+// When removing `NOT NULL` from a column, up SQL is either user-specified or
+// defaults to copying the value from the old column to the new.
+func (o *OpDropNotNull) upSQL() string {
+	if o.Up == "" {
+		return pq.QuoteIdentifier(o.Column)
+	}
+	return o.Up
+}

--- a/pkg/migrations/op_drop_not_null.go
+++ b/pkg/migrations/op_drop_not_null.go
@@ -30,7 +30,7 @@ func (o *OpDropNotNull) Start(ctx context.Context, conn *sql.DB, stateSchema str
 		return fmt.Errorf("failed to duplicate column: %w", err)
 	}
 
-	// Add a trigger to copy values from the old column to the new, rewriting NULL values using the `up` SQL.
+	// Add a trigger to copy values from the old column to the new, rewriting values using the `up` SQL.
 	err := createTrigger(ctx, conn, triggerConfig{
 		Name:           TriggerName(o.Table, o.Column),
 		Direction:      TriggerDirectionUp,

--- a/pkg/migrations/op_drop_not_null_test.go
+++ b/pkg/migrations/op_drop_not_null_test.go
@@ -1,0 +1,564 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package migrations_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xataio/pgroll/pkg/migrations"
+	"github.com/xataio/pgroll/pkg/testutils"
+)
+
+func TestDropNotNull(t *testing.T) {
+	t.Parallel()
+
+	ExecuteTests(t, TestCases{
+		{
+			name: "remove not null with default up sql",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "reviews",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name:     "username",
+									Type:     "text",
+									Nullable: false,
+								},
+								{
+									Name:     "product",
+									Type:     "text",
+									Nullable: false,
+								},
+								{
+									Name:     "review",
+									Type:     "text",
+									Nullable: false,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_set_nullable",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:    "reviews",
+							Column:   "review",
+							Nullable: ptr(true),
+							Down:     "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB) {
+				// The new (temporary) `review` column should exist on the underlying table.
+				ColumnMustExist(t, db, "public", "reviews", migrations.TemporaryName("review"))
+
+				// Inserting a NULL into the new `review` column should succeed
+				MustInsert(t, db, "public", "02_set_nullable", "reviews", map[string]string{
+					"username": "alice",
+					"product":  "apple",
+				})
+
+				// Inserting a non-NULL value into the new `review` column should succeed
+				MustInsert(t, db, "public", "02_set_nullable", "reviews", map[string]string{
+					"username": "bob",
+					"product":  "banana",
+					"review":   "brilliant",
+				})
+
+				// The rows inserted into the new `review` column have been backfilled into the
+				// old `review` column.
+				rows := MustSelect(t, db, "public", "01_add_table", "reviews")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "username": "alice", "product": "apple", "review": "apple is good"},
+					{"id": 2, "username": "bob", "product": "banana", "review": "brilliant"},
+				}, rows)
+
+				// Inserting a NULL value into the old `review` column should fail
+				MustNotInsert(t, db, "public", "01_add_table", "reviews", map[string]string{
+					"username": "carl",
+					"product":  "carrot",
+				}, testutils.NotNullViolationErrorCode)
+
+				// Inserting a non-NULL value into the old `review` column should succeed
+				MustInsert(t, db, "public", "01_add_table", "reviews", map[string]string{
+					"username": "dana",
+					"product":  "durian",
+					"review":   "delicious",
+				})
+
+				// The non-NULL value inserted into the old `review` column has been copied
+				// unchanged into the new `review` column.
+				rows = MustSelect(t, db, "public", "02_set_nullable", "reviews")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "username": "alice", "product": "apple", "review": nil},
+					{"id": 2, "username": "bob", "product": "banana", "review": "brilliant"},
+					{"id": 4, "username": "dana", "product": "durian", "review": "delicious"},
+				}, rows)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB) {
+				// The new (temporary) `review` column should not exist on the underlying table.
+				ColumnMustNotExist(t, db, "public", "reviews", migrations.TemporaryName("review"))
+
+				// The up function no longer exists.
+				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("reviews", "review"))
+				// The down function no longer exists.
+				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("reviews", migrations.TemporaryName("review")))
+
+				// The up trigger no longer exists.
+				TriggerMustNotExist(t, db, "public", "reviews", migrations.TriggerName("reviews", "review"))
+				// The down trigger no longer exists.
+				TriggerMustNotExist(t, db, "public", "reviews", migrations.TriggerName("reviews", migrations.TemporaryName("review")))
+			},
+			afterComplete: func(t *testing.T, db *sql.DB) {
+				// The new (temporary) `review` column should not exist on the underlying table.
+				ColumnMustNotExist(t, db, "public", "reviews", migrations.TemporaryName("review"))
+
+				// Writing a NULL review into the `review` column should succeed.
+				MustInsert(t, db, "public", "02_set_nullable", "reviews", map[string]string{
+					"username": "earl",
+					"product":  "eggplant",
+				})
+
+				// Selecting from the `reviews` view should succeed.
+				rows := MustSelect(t, db, "public", "02_set_nullable", "reviews")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "username": "alice", "product": "apple", "review": "apple is good"},
+					{"id": 2, "username": "bob", "product": "banana", "review": "brilliant"},
+					{"id": 4, "username": "dana", "product": "durian", "review": "delicious"},
+					{"id": 5, "username": "earl", "product": "eggplant", "review": nil},
+				}, rows)
+
+				// The up function no longer exists.
+				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("reviews", "review"))
+				// The down function no longer exists.
+				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("reviews", migrations.TemporaryName("review")))
+
+				// The up trigger no longer exists.
+				TriggerMustNotExist(t, db, "public", "reviews", migrations.TriggerName("reviews", "review"))
+				// The down trigger no longer exists.
+				TriggerMustNotExist(t, db, "public", "reviews", migrations.TriggerName("reviews", migrations.TemporaryName("review")))
+			},
+		},
+		{
+			name: "remove not null with user-supplied up sql",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "reviews",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name:     "username",
+									Type:     "text",
+									Nullable: false,
+								},
+								{
+									Name:     "product",
+									Type:     "text",
+									Nullable: false,
+								},
+								{
+									Name:     "review",
+									Type:     "text",
+									Nullable: false,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_set_nullable",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:    "reviews",
+							Column:   "review",
+							Nullable: ptr(true),
+							Down:     "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
+							Up:       "review || ' (from the old column)'",
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB) {
+				// Inserting a non-NULL value into the old `review` column should succeed
+				MustInsert(t, db, "public", "01_add_table", "reviews", map[string]string{
+					"username": "alice",
+					"product":  "apple",
+					"review":   "amazing",
+				})
+
+				// The value inserted into the old `review` column has been backfilled into the
+				// new `review` column using the user-supplied `up` SQL.
+				rows := MustSelect(t, db, "public", "02_set_nullable", "reviews")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "username": "alice", "product": "apple", "review": "amazing (from the old column)"},
+				}, rows)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB) {
+			},
+			afterComplete: func(t *testing.T, db *sql.DB) {
+			},
+		},
+		{
+			name: "dropping not null from a foreign key column retains the foreign key constraint",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_departments_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "departments",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name:     "name",
+									Type:     "text",
+									Nullable: false,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_add_employees_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "employees",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name:     "name",
+									Type:     "text",
+									Nullable: false,
+								},
+								{
+									Name:     "department_id",
+									Type:     "integer",
+									Nullable: false,
+									References: &migrations.ForeignKeyReference{
+										Name:   "fk_employee_department",
+										Table:  "departments",
+										Column: "id",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "03_set_not_null",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:    "employees",
+							Column:   "department_id",
+							Nullable: ptr(true),
+							Down:     "(SELECT CASE WHEN department_id IS NULL THEN 1 ELSE department_id END)",
+							Up:       "department_id",
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB) {
+				// A temporary FK constraint has been created on the temporary column
+				ValidatedForeignKeyMustExist(t, db, "public", "employees", migrations.DuplicationName("fk_employee_department"))
+			},
+			afterRollback: func(t *testing.T, db *sql.DB) {
+			},
+			afterComplete: func(t *testing.T, db *sql.DB) {
+				// The foreign key constraint still exists on the column
+				ValidatedForeignKeyMustExist(t, db, "public", "employees", "fk_employee_department")
+			},
+		},
+		{
+			name: "dropping not null retains any default defined on the column",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "integer",
+									Pk:   true,
+								},
+								{
+									Name:     "name",
+									Type:     "text",
+									Nullable: false,
+									Default:  ptr("'anonymous'"),
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_set_not_null",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:    "users",
+							Column:   "name",
+							Nullable: ptr(true),
+							Up:       "name",
+							Down:     "(SELECT CASE WHEN name IS NULL THEN 'anonymous' ELSE name END)",
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB) {
+				// A row can be inserted into the new version of the table.
+				MustInsert(t, db, "public", "02_set_not_null", "users", map[string]string{
+					"id": "1",
+				})
+
+				// The newly inserted row respects the default value of the column.
+				rows := MustSelect(t, db, "public", "02_set_not_null", "users")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "name": "anonymous"},
+				}, rows)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB) {
+			},
+			afterComplete: func(t *testing.T, db *sql.DB) {
+				// A row can be inserted into the new version of the table.
+				MustInsert(t, db, "public", "02_set_not_null", "users", map[string]string{
+					"id": "2",
+				})
+
+				// The newly inserted row respects the default value of the column.
+				rows := MustSelect(t, db, "public", "02_set_not_null", "users")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "name": "anonymous"},
+					{"id": 2, "name": "anonymous"},
+				}, rows)
+			},
+		},
+		{
+			name: "dropping not null retains any check constraints defined on the column",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "integer",
+									Pk:   true,
+								},
+								{
+									Name:     "name",
+									Type:     "text",
+									Nullable: false,
+									Check: &migrations.CheckConstraint{
+										Name:       "name_length",
+										Constraint: "length(name) > 3",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_set_not_null",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:    "users",
+							Column:   "name",
+							Nullable: ptr(true),
+							Up:       "name",
+							Down:     "(SELECT CASE WHEN name IS NULL THEN 'anonymous' ELSE name END)",
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB) {
+				// Inserting a row that violates the check constraint should fail.
+				MustNotInsert(t, db, "public", "02_set_not_null", "users", map[string]string{
+					"id":   "1",
+					"name": "a",
+				}, testutils.CheckViolationErrorCode)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB) {
+			},
+			afterComplete: func(t *testing.T, db *sql.DB) {
+				// Inserting a row that violates the check constraint should fail.
+				MustNotInsert(t, db, "public", "02_set_not_null", "users", map[string]string{
+					"id":   "2",
+					"name": "b",
+				}, testutils.CheckViolationErrorCode)
+			},
+		},
+		{
+			name: "dropping not null retains any unique constraints defined on the column",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name:     "name",
+									Type:     "text",
+									Nullable: false,
+									Unique:   true,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_set_not_null",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:    "users",
+							Column:   "name",
+							Nullable: ptr(true),
+							Up:       "name",
+							Down:     "(SELECT CASE WHEN name IS NULL THEN 'anonymous' ELSE name END)",
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB) {
+				// Inserting an initial row succeeds
+				MustInsert(t, db, "public", "02_set_not_null", "users", map[string]string{
+					"name": "alice",
+				})
+
+				// Inserting a row with a duplicate `name` value fails
+				MustNotInsert(t, db, "public", "02_set_not_null", "users", map[string]string{
+					"name": "alice",
+				}, testutils.UniqueViolationErrorCode)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB) {
+			},
+			afterComplete: func(t *testing.T, db *sql.DB) {
+				// Inserting a row with a duplicate `name` value fails
+				MustNotInsert(t, db, "public", "02_set_not_null", "users", map[string]string{
+					"name": "alice",
+				}, testutils.UniqueViolationErrorCode)
+
+				// Inserting a row with a different `name` value succeeds
+				MustInsert(t, db, "public", "02_set_not_null", "users", map[string]string{
+					"name": "bob",
+				})
+			},
+		},
+	})
+}
+
+func TestDropNotNullValidation(t *testing.T) {
+	t.Parallel()
+
+	ExecuteTests(t, TestCases{
+		{
+			name: "down SQL is mandatory",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name:     "name",
+									Type:     "text",
+									Nullable: false,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_set_nullable",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:    "users",
+							Column:   "name",
+							Nullable: ptr(true),
+							Up:       "name",
+						},
+					},
+				},
+			},
+			wantStartErr: migrations.FieldRequiredError{Name: "down"},
+		},
+		{
+			name: "can't remove not null from a column that is already nullable",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name:     "name",
+									Type:     "text",
+									Nullable: true,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_set_nullable",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:    "users",
+							Column:   "name",
+							Nullable: ptr(true),
+							Up:       "name",
+							Down:     "(SELECT CASE WHEN name IS NULL THEN 'placeholder' ELSE name END)",
+						},
+					},
+				},
+			},
+			wantStartErr: migrations.ColumnIsNullableError{Table: "users", Name: "name"},
+		},
+	})
+}

--- a/pkg/migrations/op_set_notnull.go
+++ b/pkg/migrations/op_set_notnull.go
@@ -35,7 +35,7 @@ func (o *OpSetNotNull) Start(ctx context.Context, conn *sql.DB, stateSchema stri
 		return fmt.Errorf("failed to add not null constraint: %w", err)
 	}
 
-	// Add a trigger to copy values from the old column to the new, rewriting NULL values using the `up` SQL.
+	// Add a trigger to copy values from the old column to the new, rewriting values using the `up` SQL.
 	err := createTrigger(ctx, conn, triggerConfig{
 		Name:           TriggerName(o.Table, o.Column),
 		Direction:      TriggerDirectionUp,

--- a/pkg/migrations/op_set_notnull_test.go
+++ b/pkg/migrations/op_set_notnull_test.go
@@ -16,7 +16,7 @@ func TestSetNotNull(t *testing.T) {
 
 	ExecuteTests(t, TestCases{
 		{
-			name: "set nullable with default down sql",
+			name: "set not null with default down sql",
 			migrations: []migrations.Migration{
 				{
 					Name: "01_add_table",
@@ -158,7 +158,7 @@ func TestSetNotNull(t *testing.T) {
 			},
 		},
 		{
-			name: "set nullable with user-supplied down sql",
+			name: "set not null with user-supplied down sql",
 			migrations: []migrations.Migration{
 				{
 					Name: "01_add_table",

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -80,7 +80,8 @@ type OpAlterColumn struct {
 	// New name of the column (for rename column operation)
 	Name string `json:"name"`
 
-	// Indicates if the column is nullable (for add not null constraint operation)
+	// Indicates if the column is nullable (for add/remove not null constraint
+	// operation)
 	Nullable *bool `json:"nullable,omitempty"`
 
 	// Add foreign key constraint to the column

--- a/schema.json
+++ b/schema.json
@@ -126,7 +126,7 @@
           "type": "string"
         },
         "nullable": {
-          "description": "Indicates if the column is nullable (for add not null constraint operation)",
+          "description": "Indicates if the column is nullable (for add/remove not null constraint operation)",
           "type": "boolean"
         },
         "references": {


### PR DESCRIPTION
Add a new sub-operation to the 'alter column' operation to drop `NOT NULL` constraints from columns.

Currently, it is only possible to **set** `NOT NULL` constraints on columns but not remove them. The syntax for doing this is:

```json
{
  "name": "16_set_nullable",
  "operations": [
    {
      "alter_column": {
        "table": "reviews",
        "column": "review",
        "nullable": false,
        "up": "(SELECT CASE WHEN review IS NULL THEN product || ' is good' ELSE review END)",
        "down": "review"
      }
    }
  ]
}
```

Setting `nullable: true` in the above migration would result in a validation error saying that removing `NOT NULL` constraints was not supported. This PR removes this restriction and allows `nullable: true`  to remove an existing `NOT NULL` constraint.

A migration to remove a `NOT NULL` constraint looks like:

```json
{
  "name": "31_unset_not_null",
  "operations": [
    {
      "alter_column": {
        "table": "posts",
        "column": "title",
        "nullable": true,
        "up": "title",
        "down": "(SELECT CASE WHEN title IS NULL THEN 'placeholder title' ELSE title END)"
      }
    }
  ]
}
```

The differences between adding and removing a `NOT NULL` constraint are:
* `nullable: true` vs `nullable: false`
* The roles of `up` and `down` SQL are reversed; `down` now needs to rewrite any `NULL`s to meet the `NOT NULL` constraint on the old column. `up` defaults to a simple copy of the data from the old column to the new.


Fixes #223 