### PR TITLE
Fix inferred migrations format

### DIFF
--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -5,10 +5,13 @@ package state_test
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/xataio/pgroll/pkg/migrations"
 	"github.com/xataio/pgroll/pkg/schema"
@@ -53,6 +56,70 @@ func TestSchemaOptionIsRespected(t *testing.T) {
 
 		assert.Equal(t, 1, len(currentSchema.Tables))
 		assert.Equal(t, "public", currentSchema.Name)
+	})
+}
+
+func TestInferredMigration(t *testing.T) {
+	t.Parallel()
+
+	testutils.WithStateAndConnectionToContainer(t, func(state *state.State, db *sql.DB) {
+		ctx := context.Background()
+
+		tests := []struct {
+			name          string
+			sqlStmt       string
+			wantMigration migrations.Migration
+		}{
+			{
+				name:    "create table",
+				sqlStmt: "CREATE TABLE public.table1 (id int)",
+				wantMigration: migrations.Migration{
+					Operations: migrations.Operations{
+						&migrations.OpRawSQL{
+							Up: "CREATE TABLE public.table1 (id int)",
+						},
+					},
+				},
+			},
+		}
+
+		// init the state
+		if err := state.Init(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if _, err := db.ExecContext(ctx, "DROP SCHEMA public CASCADE; CREATE SCHEMA public"); err != nil {
+					t.Fatal(err)
+				}
+
+				if _, err := db.ExecContext(ctx, tt.sqlStmt); err != nil {
+					t.Fatal(err)
+				}
+
+				var migrationStr []byte
+				err := db.QueryRowContext(ctx,
+					fmt.Sprintf("SELECT migration FROM %s.migrations WHERE schema=$1", pq.QuoteIdentifier(state.Schema())), "public").
+					Scan(&migrationStr)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				var gotMigration migrations.Migration
+				if err := json.Unmarshal(migrationStr, &gotMigration); err != nil {
+					t.Fatal(err)
+				}
+
+				// test there is a name for the migration, then remove it for the comparison
+				assert.True(t, len(gotMigration.Name) > 1)
+				gotMigration.Name = ""
+
+				if diff := cmp.Diff(tt.wantMigration, gotMigration); diff != "" {
+					t.Errorf("expected schema mismatch (-want +got):\n%s", diff)
+				}
+			})
+		}
 	})
 }
 

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -31,11 +32,6 @@ func TestSchemaOptionIsRespected(t *testing.T) {
 
 		// create a table in the public schema
 		if _, err := db.ExecContext(ctx, "CREATE TABLE public.table1 (id int)"); err != nil {
-			t.Fatal(err)
-		}
-
-		// init the state
-		if err := state.Init(ctx); err != nil {
 			t.Fatal(err)
 		}
 
@@ -83,11 +79,6 @@ func TestInferredMigration(t *testing.T) {
 			},
 		}
 
-		// init the state
-		if err := state.Init(ctx); err != nil {
-			t.Fatal(err)
-		}
-
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				if _, err := db.ExecContext(ctx, "DROP SCHEMA public CASCADE; CREATE SCHEMA public"); err != nil {
@@ -112,7 +103,7 @@ func TestInferredMigration(t *testing.T) {
 				}
 
 				// test there is a name for the migration, then remove it for the comparison
-				assert.True(t, len(gotMigration.Name) > 1)
+				assert.True(t, strings.HasPrefix(gotMigration.Name, "sql_") && len(gotMigration.Name) > 10)
 				gotMigration.Name = ""
 
 				if diff := cmp.Diff(tt.wantMigration, gotMigration); diff != "" {
@@ -379,11 +370,6 @@ func TestReadSchema(t *testing.T) {
 					},
 				},
 			},
-		}
-
-		// init the state
-		if err := state.Init(ctx); err != nil {
-			t.Fatal(err)
 		}
 
 		for _, tt := range tests {

--- a/pkg/testutils/util.go
+++ b/pkg/testutils/util.go
@@ -121,6 +121,11 @@ func WithStateAndConnectionToContainer(t *testing.T, fn func(*state.State, *sql.
 		}
 	})
 
+	// init the state
+	if err := st.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
 	fn(st, db)
 }
 


### PR DESCRIPTION
Inferred migrations do not follow the same format as all other stored migrations. From the schema history point of view, all migrations in the list should apply correctly, including these.

This change ensures we store them following the same format, so replaying a migration history is possible.