### PR TITLE
Fix raw SQL migrations spec in schema.json

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -415,11 +415,11 @@
           "description": "Raw SQL operation",
           "additionalProperties": false,
           "properties": {
-            "raw_sql": {
+            "sql": {
               "$ref": "#/$defs/OpRawSQL"
             }
           },
-          "required": ["raw_sql"]
+          "required": ["sql"]
         },
         {
           "type": "object",


### PR DESCRIPTION
[User facing ](https://github.com/xataio/pgroll/blob/7e65cda1ed9cc51ad1b46f0b39673c1f61cea28f/pkg/migrations/op_common.go#L25) these operations are called `sql`, not `raw_sql`