### PR TITLE
Update JSON schema to specify that not all `Column` fields are required

### DIFF
--- a/pkg/jsonschema/testdata/add-column-1.txtar
+++ b/pkg/jsonschema/testdata/add-column-1.txtar
@@ -1,0 +1,22 @@
+This is a valid 'add_column' migration.
+Some optional column fields are specified and some aren't.
+
+-- create_table.json --
+{
+  "name": "migration_name",
+  "operations": [
+    {
+      "add_column": {
+        "table": "reviews",
+        "column": {
+          "name": "rating",
+          "type": "text",
+          "default": "0"
+        }
+      }
+    }
+  ]
+}
+
+-- valid --
+true

--- a/pkg/jsonschema/testdata/create-table-1.txtar
+++ b/pkg/jsonschema/testdata/create-table-1.txtar
@@ -1,0 +1,33 @@
+This is a valid 'create_table' migration.
+Some optional column fields are specified and some aren't.
+
+-- create_table.json --
+{
+  "name": "migration_name",
+  "operations": [
+    {
+      "create_table": {
+        "name": "posts",
+        "columns": [
+          {
+            "name": "id",
+            "type": "serial",
+            "pk": true
+          },
+          {
+            "name": "title",
+            "type": "varchar(255)"
+          },
+          {
+            "name": "user_id",
+            "type": "integer",
+            "nullable": true
+          }
+        ]
+      }
+    }
+  ]
+}
+
+-- valid --
+true

--- a/pkg/migrations/column.go
+++ b/pkg/migrations/column.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package migrations
+
+func (c *Column) IsNullable() bool {
+	if c.Nullable != nil {
+		return *c.Nullable
+	}
+	return false
+}
+
+func (c *Column) IsUnique() bool {
+	if c.Unique != nil {
+		return *c.Unique
+	}
+	return false
+}
+
+func (c *Column) IsPrimaryKey() bool {
+	if c.Pk != nil {
+		return *c.Pk
+	}
+	return false
+}

--- a/pkg/migrations/op_add_column_test.go
+++ b/pkg/migrations/op_add_column_test.go
@@ -27,12 +27,12 @@ func TestAddColumn(t *testing.T) {
 							{
 								Name: "id",
 								Type: "serial",
-								Pk:   true,
+								Pk:   ptr(true),
 							},
 							{
 								Name:   "name",
 								Type:   "varchar(255)",
-								Unique: true,
+								Unique: ptr(true),
 							},
 						},
 					},
@@ -46,7 +46,7 @@ func TestAddColumn(t *testing.T) {
 						Column: migrations.Column{
 							Name:     "age",
 							Type:     "integer",
-							Nullable: false,
+							Nullable: ptr(false),
 							Default:  ptr("0"),
 							Comment:  ptr("the age of the user"),
 						},
@@ -125,12 +125,12 @@ func TestAddForeignKeyColumn(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: true,
+									Unique: ptr(true),
 								},
 							},
 						},
@@ -140,7 +140,7 @@ func TestAddForeignKeyColumn(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "quantity",
@@ -163,7 +163,7 @@ func TestAddForeignKeyColumn(t *testing.T) {
 									Table:  "users",
 									Column: "id",
 								},
-								Nullable: true,
+								Nullable: ptr(true),
 							},
 						},
 					},
@@ -227,12 +227,12 @@ func TestAddForeignKeyColumn(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: true,
+									Unique: ptr(true),
 								},
 							},
 						},
@@ -242,7 +242,7 @@ func TestAddForeignKeyColumn(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "quantity",
@@ -265,7 +265,7 @@ func TestAddForeignKeyColumn(t *testing.T) {
 									Table:  "users",
 									Column: "id",
 								},
-								Nullable: false,
+								Nullable: ptr(false),
 							},
 							Up: ptr("1"),
 						},
@@ -337,12 +337,12 @@ func TestAddColumnWithUpSql(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: true,
+									Unique: ptr(true),
 								},
 							},
 						},
@@ -357,7 +357,7 @@ func TestAddColumnWithUpSql(t *testing.T) {
 							Column: migrations.Column{
 								Name:     "description",
 								Type:     "varchar(255)",
-								Nullable: true,
+								Nullable: ptr(true),
 							},
 						},
 					},
@@ -419,12 +419,12 @@ func TestAddColumnWithUpSql(t *testing.T) {
 								{
 									Name: "id",
 									Type: "text",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: true,
+									Unique: ptr(true),
 								},
 							},
 						},
@@ -439,7 +439,7 @@ func TestAddColumnWithUpSql(t *testing.T) {
 							Column: migrations.Column{
 								Name:     "description",
 								Type:     "varchar(255)",
-								Nullable: true,
+								Nullable: ptr(true),
 							},
 						},
 					},
@@ -509,12 +509,12 @@ func TestAddNotNullColumnWithNoDefault(t *testing.T) {
 							{
 								Name: "id",
 								Type: "serial",
-								Pk:   true,
+								Pk:   ptr(true),
 							},
 							{
 								Name:   "name",
 								Type:   "varchar(255)",
-								Unique: true,
+								Unique: ptr(true),
 							},
 						},
 					},
@@ -529,7 +529,7 @@ func TestAddNotNullColumnWithNoDefault(t *testing.T) {
 						Column: migrations.Column{
 							Name:     "description",
 							Type:     "varchar(255)",
-							Nullable: false,
+							Nullable: ptr(false),
 						},
 					},
 				},
@@ -575,12 +575,12 @@ func TestAddColumnValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   true,
+						Pk:   ptr(true),
 					},
 					{
 						Name:   "name",
 						Type:   "varchar(255)",
-						Unique: true,
+						Unique: ptr(true),
 					},
 				},
 			},
@@ -600,7 +600,7 @@ func TestAddColumnValidation(t *testing.T) {
 							Column: migrations.Column{
 								Name:     "age",
 								Type:     "integer",
-								Nullable: false,
+								Nullable: ptr(false),
 								Default:  ptr("0"),
 							},
 						},
@@ -640,7 +640,7 @@ func TestAddColumnValidation(t *testing.T) {
 							Column: migrations.Column{
 								Name:     "age",
 								Type:     "integer",
-								Nullable: false,
+								Nullable: ptr(false),
 							},
 						},
 					},
@@ -694,12 +694,12 @@ func TestAddColumnWithCheckConstraint(t *testing.T) {
 							{
 								Name: "id",
 								Type: "serial",
-								Pk:   true,
+								Pk:   ptr(true),
 							},
 							{
 								Name:   "name",
 								Type:   "varchar(255)",
-								Unique: true,
+								Unique: ptr(true),
 							},
 						},
 					},
@@ -769,12 +769,12 @@ func TestAddColumnWithComment(t *testing.T) {
 							{
 								Name: "id",
 								Type: "serial",
-								Pk:   true,
+								Pk:   ptr(true),
 							},
 							{
 								Name:   "name",
 								Type:   "varchar(255)",
-								Unique: true,
+								Unique: ptr(true),
 							},
 						},
 					},
@@ -788,7 +788,7 @@ func TestAddColumnWithComment(t *testing.T) {
 						Column: migrations.Column{
 							Name:     "age",
 							Type:     "integer",
-							Nullable: false,
+							Nullable: ptr(false),
 							Default:  ptr("0"),
 							Comment:  ptr("the age of the user"),
 						},

--- a/pkg/migrations/op_alter_column_test.go
+++ b/pkg/migrations/op_alter_column_test.go
@@ -20,7 +20,7 @@ func TestAlterColumnValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   true,
+						Pk:   ptr(true),
 					},
 					{
 						Name: "name",
@@ -34,7 +34,7 @@ func TestAlterColumnValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   true,
+						Pk:   ptr(true),
 					},
 					{
 						Name: "title",

--- a/pkg/migrations/op_change_type_test.go
+++ b/pkg/migrations/op_change_type_test.go
@@ -28,7 +28,7 @@ func TestChangeColumnType(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "username",
@@ -159,12 +159,12 @@ func TestChangeColumnType(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 							},
 						},
@@ -179,12 +179,12 @@ func TestChangeColumnType(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name: "department_id",
@@ -235,13 +235,13 @@ func TestChangeColumnType(t *testing.T) {
 								{
 									Name: "id",
 									Type: "integer",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "username",
 									Type:     "text",
 									Default:  ptr("'alice'"),
-									Nullable: true,
+									Nullable: ptr(true),
 								},
 							},
 						},
@@ -300,12 +300,12 @@ func TestChangeColumnType(t *testing.T) {
 								{
 									Name: "id",
 									Type: "integer",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "username",
 									Type:     "text",
-									Nullable: true,
+									Nullable: ptr(true),
 									Check: &migrations.CheckConstraint{
 										Name:       "username_length",
 										Constraint: "length(username) > 3",
@@ -357,12 +357,12 @@ func TestChangeColumnType(t *testing.T) {
 								{
 									Name: "id",
 									Type: "integer",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "username",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 							},
 						},
@@ -408,12 +408,12 @@ func TestChangeColumnType(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:   "username",
 									Type:   "text",
-									Unique: true,
+									Unique: ptr(true),
 								},
 							},
 						},
@@ -472,7 +472,7 @@ func TestChangeColumnTypeValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   true,
+						Pk:   ptr(true),
 					},
 					{
 						Name: "username",

--- a/pkg/migrations/op_common.go
+++ b/pkg/migrations/op_common.go
@@ -200,3 +200,7 @@ func OperationName(op Operation) OpName {
 
 	panic(fmt.Errorf("unknown operation for %T", op))
 }
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/pkg/migrations/op_create_index_test.go
+++ b/pkg/migrations/op_create_index_test.go
@@ -24,12 +24,12 @@ func TestCreateIndex(t *testing.T) {
 							{
 								Name: "id",
 								Type: "serial",
-								Pk:   true,
+								Pk:   ptr(true),
 							},
 							{
 								Name:     "name",
 								Type:     "varchar(255)",
-								Nullable: false,
+								Nullable: ptr(false),
 							},
 						},
 					},
@@ -75,17 +75,17 @@ func TestCreateIndexOnMultipleColumns(t *testing.T) {
 							{
 								Name: "id",
 								Type: "serial",
-								Pk:   true,
+								Pk:   ptr(true),
 							},
 							{
 								Name:     "name",
 								Type:     "varchar(255)",
-								Nullable: false,
+								Nullable: ptr(false),
 							},
 							{
 								Name:     "email",
 								Type:     "varchar(255)",
-								Nullable: false,
+								Nullable: ptr(false),
 							},
 						},
 					},

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -117,13 +117,13 @@ func columnsToSQL(cols []Column) string {
 func ColumnToSQL(col Column) string {
 	sql := fmt.Sprintf("%s %s", pq.QuoteIdentifier(col.Name), col.Type)
 
-	if col.Pk {
+	if col.IsPrimaryKey() {
 		sql += " PRIMARY KEY"
 	}
-	if col.Unique {
+	if col.IsUnique() {
 		sql += " UNIQUE"
 	}
-	if !col.Nullable {
+	if !col.IsNullable() {
 		sql += " NOT NULL"
 	}
 	if col.Default != nil {

--- a/pkg/migrations/op_create_table_test.go
+++ b/pkg/migrations/op_create_table_test.go
@@ -28,12 +28,12 @@ func TestCreateTable(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: true,
+									Unique: ptr(true),
 								},
 							},
 						},
@@ -87,12 +87,12 @@ func TestCreateTable(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: true,
+									Unique: ptr(true),
 								},
 							},
 						},
@@ -107,7 +107,7 @@ func TestCreateTable(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "user_id",
@@ -184,7 +184,7 @@ func TestCreateTable(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "name",
@@ -244,12 +244,12 @@ func TestCreateTable(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:    "name",
 									Type:    "varchar(255)",
-									Unique:  true,
+									Unique:  ptr(true),
 									Comment: ptr("the username"),
 								},
 							},
@@ -291,12 +291,12 @@ func TestCreateTableValidation(t *testing.T) {
 							{
 								Name: "id",
 								Type: "serial",
-								Pk:   true,
+								Pk:   ptr(true),
 							},
 							{
 								Name:   "name",
 								Type:   "varchar(255)",
-								Unique: true,
+								Unique: ptr(true),
 							},
 						},
 					},
@@ -311,7 +311,7 @@ func TestCreateTableValidation(t *testing.T) {
 							{
 								Name: "id",
 								Type: "serial",
-								Pk:   true,
+								Pk:   ptr(true),
 							},
 							{
 								Name: "user_id",

--- a/pkg/migrations/op_drop_column_test.go
+++ b/pkg/migrations/op_drop_column_test.go
@@ -27,17 +27,17 @@ func TestDropColumnWithDownSQL(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "varchar(255)",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name:     "email",
 									Type:     "varchar(255)",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 							},
 						},
@@ -117,7 +117,7 @@ func TestDropColumnWithDownSQL(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "array",
@@ -159,7 +159,7 @@ func TestDropColumnWithDownSQL(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "name",

--- a/pkg/migrations/op_drop_constraint_test.go
+++ b/pkg/migrations/op_drop_constraint_test.go
@@ -27,7 +27,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "title",
@@ -156,7 +156,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "title",
@@ -222,7 +222,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "name",
@@ -236,7 +236,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "title",
@@ -245,7 +245,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name:     "user_id",
 									Type:     "integer",
-									Nullable: true,
+									Nullable: ptr(true),
 								},
 							},
 						},
@@ -388,12 +388,12 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:   "name",
 									Type:   "text",
-									Unique: true,
+									Unique: ptr(true),
 								},
 							},
 						},
@@ -467,12 +467,12 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:    "name",
 									Type:    "text",
-									Unique:  true,
+									Unique:  ptr(true),
 									Default: ptr("'anonymous'"),
 								},
 							},
@@ -538,12 +538,12 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 							},
 						},
@@ -558,17 +558,17 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name:   "department_id",
 									Type:   "integer",
-									Unique: true,
+									Unique: ptr(true),
 									References: &migrations.ForeignKeyReference{
 										Name:   "fk_employee_department",
 										Table:  "departments",
@@ -615,13 +615,13 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "title",
 									Type:     "text",
-									Nullable: true,
-									Unique:   true,
+									Nullable: ptr(true),
+									Unique:   ptr(true),
 								},
 							},
 						},
@@ -684,13 +684,13 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "title",
 									Type:     "text",
-									Nullable: true,
-									Unique:   true,
+									Nullable: ptr(true),
+									Unique:   ptr(true),
 								},
 							},
 						},
@@ -761,13 +761,13 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "title",
 									Type:     "text",
-									Unique:   true,
-									Nullable: false,
+									Unique:   ptr(true),
+									Nullable: ptr(false),
 								},
 							},
 						},
@@ -816,7 +816,7 @@ func TestDropConstraintValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   true,
+						Pk:   ptr(true),
 					},
 					{
 						Name: "title",

--- a/pkg/migrations/op_drop_index_test.go
+++ b/pkg/migrations/op_drop_index_test.go
@@ -24,12 +24,12 @@ func TestDropIndex(t *testing.T) {
 							{
 								Name: "id",
 								Type: "serial",
-								Pk:   true,
+								Pk:   ptr(true),
 							},
 							{
 								Name:     "name",
 								Type:     "varchar(255)",
-								Nullable: false,
+								Nullable: ptr(false),
 							},
 						},
 					},

--- a/pkg/migrations/op_drop_not_null_test.go
+++ b/pkg/migrations/op_drop_not_null_test.go
@@ -27,22 +27,22 @@ func TestDropNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "username",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name:     "product",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name:     "review",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 							},
 						},
@@ -163,22 +163,22 @@ func TestDropNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "username",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name:     "product",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name:     "review",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 							},
 						},
@@ -229,12 +229,12 @@ func TestDropNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 							},
 						},
@@ -249,17 +249,17 @@ func TestDropNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name:     "department_id",
 									Type:     "integer",
-									Nullable: false,
+									Nullable: ptr(false),
 									References: &migrations.ForeignKeyReference{
 										Name:   "fk_employee_department",
 										Table:  "departments",
@@ -306,12 +306,12 @@ func TestDropNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "integer",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 									Default:  ptr("'anonymous'"),
 								},
 							},
@@ -371,12 +371,12 @@ func TestDropNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "integer",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 									Check: &migrations.CheckConstraint{
 										Name:       "name_length",
 										Constraint: "length(name) > 3",
@@ -428,13 +428,13 @@ func TestDropNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "text",
-									Nullable: false,
-									Unique:   true,
+									Nullable: ptr(false),
+									Unique:   ptr(true),
 								},
 							},
 						},
@@ -497,12 +497,12 @@ func TestDropNotNullValidation(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 							},
 						},
@@ -534,12 +534,12 @@ func TestDropNotNullValidation(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "text",
-									Nullable: true,
+									Nullable: ptr(true),
 								},
 							},
 						},

--- a/pkg/migrations/op_drop_table_test.go
+++ b/pkg/migrations/op_drop_table_test.go
@@ -24,12 +24,12 @@ func TestDropTable(t *testing.T) {
 							{
 								Name: "id",
 								Type: "serial",
-								Pk:   true,
+								Pk:   ptr(true),
 							},
 							{
 								Name:   "name",
 								Type:   "varchar(255)",
-								Unique: true,
+								Unique: ptr(true),
 							},
 						},
 					},

--- a/pkg/migrations/op_rename_column_test.go
+++ b/pkg/migrations/op_rename_column_test.go
@@ -25,12 +25,12 @@ func TestRenameColumn(t *testing.T) {
 							{
 								Name: "id",
 								Type: "serial",
-								Pk:   true,
+								Pk:   ptr(true),
 							},
 							{
 								Name:     "username",
 								Type:     "varchar(255)",
-								Nullable: false,
+								Nullable: ptr(false),
 							},
 						},
 					},

--- a/pkg/migrations/op_set_check_test.go
+++ b/pkg/migrations/op_set_check_test.go
@@ -27,7 +27,7 @@ func TestSetCheckConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "title",
@@ -159,7 +159,7 @@ func TestSetCheckConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:    "title",
@@ -226,12 +226,12 @@ func TestSetCheckConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 							},
 						},
@@ -246,17 +246,17 @@ func TestSetCheckConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name:     "department_id",
 									Type:     "integer",
-									Nullable: true,
+									Nullable: ptr(true),
 									References: &migrations.ForeignKeyReference{
 										Name:   "fk_employee_department",
 										Table:  "departments",
@@ -306,7 +306,7 @@ func TestSetCheckConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "title",
@@ -371,12 +371,12 @@ func TestSetCheckConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "title",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 							},
 						},
@@ -425,12 +425,12 @@ func TestSetCheckConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:   "title",
 									Type:   "text",
-									Unique: true,
+									Unique: ptr(true),
 								},
 							},
 						},
@@ -492,7 +492,7 @@ func TestSetCheckConstraintValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   true,
+						Pk:   ptr(true),
 					},
 					{
 						Name: "title",

--- a/pkg/migrations/op_set_fk_test.go
+++ b/pkg/migrations/op_set_fk_test.go
@@ -27,7 +27,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "name",
@@ -41,7 +41,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "title",
@@ -50,7 +50,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name:     "user_id",
 									Type:     "integer",
-									Nullable: true,
+									Nullable: ptr(true),
 								},
 							},
 						},
@@ -192,7 +192,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "name",
@@ -206,7 +206,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "title",
@@ -285,7 +285,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "name",
@@ -299,7 +299,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "title",
@@ -370,7 +370,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "name",
@@ -384,7 +384,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "title",
@@ -455,7 +455,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "name",
@@ -469,17 +469,17 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "title",
 									Type:     "text",
-									Nullable: true,
+									Nullable: ptr(true),
 								},
 								{
 									Name:     "user_id",
 									Type:     "integer",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 							},
 						},
@@ -531,7 +531,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "name",
@@ -545,7 +545,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "title",
@@ -554,7 +554,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name:   "user_id",
 									Type:   "integer",
-									Unique: true,
+									Unique: ptr(true),
 								},
 							},
 						},
@@ -633,7 +633,7 @@ func TestSetForeignKeyValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   true,
+						Pk:   ptr(true),
 					},
 					{
 						Name: "name",
@@ -647,7 +647,7 @@ func TestSetForeignKeyValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   true,
+						Pk:   ptr(true),
 					},
 					{
 						Name: "title",

--- a/pkg/migrations/op_set_notnull_test.go
+++ b/pkg/migrations/op_set_notnull_test.go
@@ -27,22 +27,22 @@ func TestSetNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "username",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name:     "product",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name:     "review",
 									Type:     "text",
-									Nullable: true,
+									Nullable: ptr(true),
 								},
 							},
 						},
@@ -169,22 +169,22 @@ func TestSetNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "username",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name:     "product",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name:     "review",
 									Type:     "text",
-									Nullable: true,
+									Nullable: ptr(true),
 								},
 							},
 						},
@@ -235,12 +235,12 @@ func TestSetNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 							},
 						},
@@ -255,17 +255,17 @@ func TestSetNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name:     "department_id",
 									Type:     "integer",
-									Nullable: true,
+									Nullable: ptr(true),
 									References: &migrations.ForeignKeyReference{
 										Name:   "fk_employee_department",
 										Table:  "departments",
@@ -312,12 +312,12 @@ func TestSetNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "integer",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "text",
-									Nullable: true,
+									Nullable: ptr(true),
 									Default:  ptr("'anonymous'"),
 								},
 							},
@@ -376,12 +376,12 @@ func TestSetNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "integer",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "text",
-									Nullable: true,
+									Nullable: ptr(true),
 									Check: &migrations.CheckConstraint{
 										Name:       "name_length",
 										Constraint: "length(name) > 3",
@@ -432,13 +432,13 @@ func TestSetNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "text",
-									Nullable: true,
-									Unique:   true,
+									Nullable: ptr(true),
+									Unique:   ptr(true),
 								},
 							},
 						},
@@ -496,22 +496,22 @@ func TestSetNotNullValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   true,
+						Pk:   ptr(true),
 					},
 					{
 						Name:     "username",
 						Type:     "text",
-						Nullable: false,
+						Nullable: ptr(false),
 					},
 					{
 						Name:     "product",
 						Type:     "text",
-						Nullable: false,
+						Nullable: ptr(false),
 					},
 					{
 						Name:     "review",
 						Type:     "text",
-						Nullable: true,
+						Nullable: ptr(true),
 					},
 				},
 			},
@@ -549,22 +549,22 @@ func TestSetNotNullValidation(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "username",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name:     "product",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name:     "review",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 							},
 						},

--- a/pkg/migrations/op_set_replica_identity_test.go
+++ b/pkg/migrations/op_set_replica_identity_test.go
@@ -21,12 +21,12 @@ func TestSetReplicaIdentity(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   true,
+						Pk:   ptr(true),
 					},
 					{
 						Name:     "name",
 						Type:     "varchar(255)",
-						Nullable: false,
+						Nullable: ptr(false),
 					},
 				},
 			},
@@ -152,12 +152,12 @@ func TestSetReplicaIdentityValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   true,
+						Pk:   ptr(true),
 					},
 					{
 						Name:   "name",
 						Type:   "varchar(255)",
-						Unique: true,
+						Unique: ptr(true),
 					},
 				},
 			},

--- a/pkg/migrations/op_set_unique_test.go
+++ b/pkg/migrations/op_set_unique_test.go
@@ -27,22 +27,22 @@ func TestSetColumnUnique(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "username",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name:     "product",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name:     "review",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 							},
 						},
@@ -128,22 +128,22 @@ func TestSetColumnUnique(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "username",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name:     "product",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name:     "review",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 							},
 						},
@@ -192,7 +192,7 @@ func TestSetColumnUnique(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:    "username",
@@ -272,12 +272,12 @@ func TestSetColumnUnique(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 							},
 						},
@@ -292,17 +292,17 @@ func TestSetColumnUnique(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "name",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name:     "department_id",
 									Type:     "integer",
-									Nullable: true,
+									Nullable: ptr(true),
 									References: &migrations.ForeignKeyReference{
 										Name:   "fk_employee_department",
 										Table:  "departments",
@@ -351,7 +351,7 @@ func TestSetColumnUnique(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name: "username",
@@ -413,12 +413,12 @@ func TestSetColumnUnique(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   true,
+									Pk:   ptr(true),
 								},
 								{
 									Name:     "username",
 									Type:     "text",
-									Nullable: false,
+									Nullable: ptr(false),
 								},
 								{
 									Name: "product",

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -27,10 +27,10 @@ type Column struct {
 	Name string `json:"name"`
 
 	// Indicates if the column is nullable
-	Nullable bool `json:"nullable"`
+	Nullable *bool `json:"nullable,omitempty"`
 
 	// Indicates if the column is part of the primary key
-	Pk bool `json:"pk"`
+	Pk *bool `json:"pk,omitempty"`
 
 	// Foreign key constraint for the column
 	References *ForeignKeyReference `json:"references,omitempty"`
@@ -39,7 +39,7 @@ type Column struct {
 	Type string `json:"type"`
 
 	// Indicates if the column values must be unique
-	Unique bool `json:"unique"`
+	Unique *bool `json:"unique,omitempty"`
 }
 
 // Foreign key reference definition

--- a/pkg/roll/execute_test.go
+++ b/pkg/roll/execute_test.go
@@ -495,12 +495,12 @@ func createTableOp(tableName string) *migrations.OpCreateTable {
 			{
 				Name: "id",
 				Type: "integer",
-				Pk:   true,
+				Pk:   ptr(true),
 			},
 			{
 				Name:   "name",
 				Type:   "varchar(255)",
-				Unique: true,
+				Unique: ptr(true),
 			},
 		},
 	}
@@ -512,7 +512,7 @@ func addColumnOp(tableName string) *migrations.OpAddColumn {
 		Column: migrations.Column{
 			Name:     "age",
 			Type:     "integer",
-			Nullable: true,
+			Nullable: ptr(true),
 		},
 	}
 }
@@ -558,4 +558,8 @@ func MustSelect(t *testing.T, db *sql.DB, schema, version, table string) []map[s
 	}
 
 	return res
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }

--- a/schema.json
+++ b/schema.json
@@ -62,7 +62,7 @@
           "type": "string"
         }
       },
-      "required": ["name", "nullable", "pk", "type", "unique"],
+      "required": ["name", "type"],
       "type": "object"
     },
     "ForeignKeyReference": {


### PR DESCRIPTION
Update the JSON schema in `schema.json` to state that only `name` and `type` are required fields when specifying a column. 

Previously `required` was set to `["name", "nullable", "pk", "type", "unique"]` resulting in some valid `create_table` and `add_column` migrations failing to validate.

Add two new testcases to the JSON schema tests to cover 'create_table' and 'add_column' operations.