### PR TITLE
Parameterize schema in which migration tests run via `PGROLL_TEST_SCHEMA` env var

### DIFF
--- a/pkg/migrations/op_add_column_test.go
+++ b/pkg/migrations/op_add_column_test.go
@@ -54,52 +54,52 @@ func TestAddColumn(t *testing.T) {
 				},
 			},
 		},
-		afterStart: func(t *testing.T, db *sql.DB) {
+		afterStart: func(t *testing.T, db *sql.DB, schema string) {
 			// old and new views of the table should exist
-			ViewMustExist(t, db, "public", "01_add_table", "users")
-			ViewMustExist(t, db, "public", "02_add_column", "users")
+			ViewMustExist(t, db, schema, "01_add_table", "users")
+			ViewMustExist(t, db, schema, "02_add_column", "users")
 
 			// inserting via both the old and the new views works
-			MustInsert(t, db, "public", "01_add_table", "users", map[string]string{
+			MustInsert(t, db, schema, "01_add_table", "users", map[string]string{
 				"name": "Alice",
 			})
-			MustInsert(t, db, "public", "02_add_column", "users", map[string]string{
+			MustInsert(t, db, schema, "02_add_column", "users", map[string]string{
 				"name": "Bob",
 				"age":  "21",
 			})
 
 			// selecting from both the old and the new views works
-			resOld := MustSelect(t, db, "public", "01_add_table", "users")
+			resOld := MustSelect(t, db, schema, "01_add_table", "users")
 			assert.Equal(t, []map[string]any{
 				{"id": 1, "name": "Alice"},
 				{"id": 2, "name": "Bob"},
 			}, resOld)
-			resNew := MustSelect(t, db, "public", "02_add_column", "users")
+			resNew := MustSelect(t, db, schema, "02_add_column", "users")
 			assert.Equal(t, []map[string]any{
 				{"id": 1, "name": "Alice", "age": 0},
 				{"id": 2, "name": "Bob", "age": 21},
 			}, resNew)
 		},
-		afterRollback: func(t *testing.T, db *sql.DB) {
+		afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			// The new column has been dropped from the underlying table
 			columnName := migrations.TemporaryName("age")
-			ColumnMustNotExist(t, db, "public", "users", columnName)
+			ColumnMustNotExist(t, db, schema, "users", columnName)
 
 			// The table's column count reflects the drop of the new column
-			TableMustHaveColumnCount(t, db, "public", "users", 2)
+			TableMustHaveColumnCount(t, db, schema, "users", 2)
 		},
-		afterComplete: func(t *testing.T, db *sql.DB) {
+		afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 			// The new view still exists
-			ViewMustExist(t, db, "public", "02_add_column", "users")
+			ViewMustExist(t, db, schema, "02_add_column", "users")
 
 			// Inserting into the new view still works
-			MustInsert(t, db, "public", "02_add_column", "users", map[string]string{
+			MustInsert(t, db, schema, "02_add_column", "users", map[string]string{
 				"name": "Carl",
 				"age":  "31",
 			})
 
 			// Selecting from the new view still works
-			res := MustSelect(t, db, "public", "02_add_column", "users")
+			res := MustSelect(t, db, schema, "02_add_column", "users")
 			assert.Equal(t, []map[string]any{
 				{"id": 1, "name": "Alice", "age": 0},
 				{"id": 2, "name": "Bob", "age": 0},
@@ -169,47 +169,47 @@ func TestAddForeignKeyColumn(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The foreign key constraint exists on the new table.
-				ValidatedForeignKeyMustExist(t, db, "public", "orders", "fk_users_id")
+				ValidatedForeignKeyMustExist(t, db, schema, "orders", "fk_users_id")
 
 				// Inserting a row into the referenced table succeeds.
-				MustInsert(t, db, "public", "01_create_table", "users", map[string]string{
+				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
 					"name": "alice",
 				})
 
 				// Inserting a row into the referencing table succeeds as the referenced row exists.
-				MustInsert(t, db, "public", "02_add_column", "orders", map[string]string{
+				MustInsert(t, db, schema, "02_add_column", "orders", map[string]string{
 					"user_id":  "1",
 					"quantity": "100",
 				})
 
 				// Inserting a row into the referencing table fails as the referenced row does not exist.
-				MustNotInsert(t, db, "public", "02_add_column", "orders", map[string]string{
+				MustNotInsert(t, db, schema, "02_add_column", "orders", map[string]string{
 					"user_id":  "2",
 					"quantity": "200",
 				}, testutils.FKViolationErrorCode)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// The new column has been dropped, so the foreign key constraint is gone.
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The foreign key constraint still exists on the new table
-				ValidatedForeignKeyMustExist(t, db, "public", "orders", "fk_users_id")
+				ValidatedForeignKeyMustExist(t, db, schema, "orders", "fk_users_id")
 
 				// Inserting a row into the referenced table succeeds.
-				MustInsert(t, db, "public", "02_add_column", "users", map[string]string{
+				MustInsert(t, db, schema, "02_add_column", "users", map[string]string{
 					"name": "bob",
 				})
 
 				// Inserting a row into the referencing table succeeds as the referenced row exists.
-				MustInsert(t, db, "public", "02_add_column", "orders", map[string]string{
+				MustInsert(t, db, schema, "02_add_column", "orders", map[string]string{
 					"user_id":  "2",
 					"quantity": "200",
 				})
 
 				// Inserting a row into the referencing table fails as the referenced row does not exist.
-				MustNotInsert(t, db, "public", "02_add_column", "orders", map[string]string{
+				MustNotInsert(t, db, schema, "02_add_column", "orders", map[string]string{
 					"user_id":  "3",
 					"quantity": "300",
 				}, testutils.FKViolationErrorCode)
@@ -272,47 +272,47 @@ func TestAddForeignKeyColumn(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The foreign key constraint exists on the new table.
-				ValidatedForeignKeyMustExist(t, db, "public", "orders", "fk_users_id")
+				ValidatedForeignKeyMustExist(t, db, schema, "orders", "fk_users_id")
 
 				// Inserting a row into the referenced table succeeds.
-				MustInsert(t, db, "public", "01_create_table", "users", map[string]string{
+				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
 					"name": "alice",
 				})
 
 				// Inserting a row into the referencing table succeeds as the referenced row exists.
-				MustInsert(t, db, "public", "02_add_column", "orders", map[string]string{
+				MustInsert(t, db, schema, "02_add_column", "orders", map[string]string{
 					"user_id":  "1",
 					"quantity": "100",
 				})
 
 				// Inserting a row into the referencing table fails as the referenced row does not exist.
-				MustNotInsert(t, db, "public", "02_add_column", "orders", map[string]string{
+				MustNotInsert(t, db, schema, "02_add_column", "orders", map[string]string{
 					"user_id":  "2",
 					"quantity": "200",
 				}, testutils.FKViolationErrorCode)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// The new column has been dropped, so the foreign key constraint is gone.
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The foreign key constraint still exists on the new table
-				ValidatedForeignKeyMustExist(t, db, "public", "orders", "fk_users_id")
+				ValidatedForeignKeyMustExist(t, db, schema, "orders", "fk_users_id")
 
 				// Inserting a row into the referenced table succeeds.
-				MustInsert(t, db, "public", "02_add_column", "users", map[string]string{
+				MustInsert(t, db, schema, "02_add_column", "users", map[string]string{
 					"name": "bob",
 				})
 
 				// Inserting a row into the referencing table succeeds as the referenced row exists.
-				MustInsert(t, db, "public", "02_add_column", "orders", map[string]string{
+				MustInsert(t, db, schema, "02_add_column", "orders", map[string]string{
 					"user_id":  "2",
 					"quantity": "200",
 				})
 
 				// Inserting a row into the referencing table fails as the referenced row does not exist.
-				MustNotInsert(t, db, "public", "02_add_column", "orders", map[string]string{
+				MustNotInsert(t, db, schema, "02_add_column", "orders", map[string]string{
 					"user_id":  "3",
 					"quantity": "300",
 				}, testutils.FKViolationErrorCode)
@@ -363,17 +363,17 @@ func TestAddColumnWithUpSql(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// inserting via both the old and the new views works
-				MustInsert(t, db, "public", "01_add_table", "products", map[string]string{
+				MustInsert(t, db, schema, "01_add_table", "products", map[string]string{
 					"name": "apple",
 				})
-				MustInsert(t, db, "public", "02_add_column", "products", map[string]string{
+				MustInsert(t, db, schema, "02_add_column", "products", map[string]string{
 					"name":        "banana",
 					"description": "a yellow banana",
 				})
 
-				res := MustSelect(t, db, "public", "02_add_column", "products")
+				res := MustSelect(t, db, schema, "02_add_column", "products")
 				assert.Equal(t, []map[string]any{
 					// the description column has been populated for the product inserted into the old view.
 					{"id": 1, "name": "apple", "description": "APPLE"},
@@ -381,18 +381,18 @@ func TestAddColumnWithUpSql(t *testing.T) {
 					{"id": 2, "name": "banana", "description": "a yellow banana"},
 				}, res)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// The trigger function has been dropped.
 				triggerFnName := migrations.TriggerFunctionName("products", "description")
-				FunctionMustNotExist(t, db, "public", triggerFnName)
+				FunctionMustNotExist(t, db, schema, triggerFnName)
 
 				// The trigger has been dropped.
 				triggerName := migrations.TriggerName("products", "description")
-				TriggerMustNotExist(t, db, "public", "products", triggerName)
+				TriggerMustNotExist(t, db, schema, "products", triggerName)
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// after rollback + restart + complete, all 'description' values are the backfilled ones.
-				res := MustSelect(t, db, "public", "02_add_column", "products")
+				res := MustSelect(t, db, schema, "02_add_column", "products")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "name": "apple", "description": "APPLE"},
 					{"id": 2, "name": "banana", "description": "BANANA"},
@@ -400,11 +400,11 @@ func TestAddColumnWithUpSql(t *testing.T) {
 
 				// The trigger function has been dropped.
 				triggerFnName := migrations.TriggerFunctionName("products", "description")
-				FunctionMustNotExist(t, db, "public", triggerFnName)
+				FunctionMustNotExist(t, db, schema, triggerFnName)
 
 				// The trigger has been dropped.
 				triggerName := migrations.TriggerName("products", "description")
-				TriggerMustNotExist(t, db, "public", "products", triggerName)
+				TriggerMustNotExist(t, db, schema, "products", triggerName)
 			},
 		},
 		{
@@ -445,19 +445,19 @@ func TestAddColumnWithUpSql(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// inserting via both the old and the new views works
-				MustInsert(t, db, "public", "01_add_table", "products", map[string]string{
+				MustInsert(t, db, schema, "01_add_table", "products", map[string]string{
 					"id":   "a",
 					"name": "apple",
 				})
-				MustInsert(t, db, "public", "02_add_column", "products", map[string]string{
+				MustInsert(t, db, schema, "02_add_column", "products", map[string]string{
 					"id":          "b",
 					"name":        "banana",
 					"description": "a yellow banana",
 				})
 
-				res := MustSelect(t, db, "public", "02_add_column", "products")
+				res := MustSelect(t, db, schema, "02_add_column", "products")
 				assert.Equal(t, []map[string]any{
 					// the description column has been populated for the product inserted into the old view.
 					{"id": "a", "name": "apple", "description": "APPLE"},
@@ -465,18 +465,18 @@ func TestAddColumnWithUpSql(t *testing.T) {
 					{"id": "b", "name": "banana", "description": "a yellow banana"},
 				}, res)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// The trigger function has been dropped.
 				triggerFnName := migrations.TriggerFunctionName("products", "description")
-				FunctionMustNotExist(t, db, "public", triggerFnName)
+				FunctionMustNotExist(t, db, schema, triggerFnName)
 
 				// The trigger has been dropped.
 				triggerName := migrations.TriggerName("products", "description")
-				TriggerMustNotExist(t, db, "public", "products", triggerName)
+				TriggerMustNotExist(t, db, schema, "products", triggerName)
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// after rollback + restart + complete, all 'description' values are the backfilled ones.
-				res := MustSelect(t, db, "public", "02_add_column", "products")
+				res := MustSelect(t, db, schema, "02_add_column", "products")
 				assert.Equal(t, []map[string]any{
 					{"id": "a", "name": "apple", "description": "APPLE"},
 					{"id": "b", "name": "banana", "description": "BANANA"},
@@ -484,11 +484,11 @@ func TestAddColumnWithUpSql(t *testing.T) {
 
 				// The trigger function has been dropped.
 				triggerFnName := migrations.TriggerFunctionName("products", "description")
-				FunctionMustNotExist(t, db, "public", triggerFnName)
+				FunctionMustNotExist(t, db, schema, triggerFnName)
 
 				// The trigger has been dropped.
 				triggerName := migrations.TriggerName("products", "description")
-				TriggerMustNotExist(t, db, "public", "products", triggerName)
+				TriggerMustNotExist(t, db, schema, "products", triggerName)
 			},
 		},
 	})
@@ -535,28 +535,28 @@ func TestAddNotNullColumnWithNoDefault(t *testing.T) {
 				},
 			},
 		},
-		afterStart: func(t *testing.T, db *sql.DB) {
+		afterStart: func(t *testing.T, db *sql.DB, schema string) {
 			// Inserting a null description through the old view works (due to `up` sql populating the column).
-			MustInsert(t, db, "public", "01_add_table", "products", map[string]string{
+			MustInsert(t, db, schema, "01_add_table", "products", map[string]string{
 				"name": "apple",
 			})
 			// Inserting a null description through the new view fails.
-			MustNotInsert(t, db, "public", "02_add_column", "products", map[string]string{
+			MustNotInsert(t, db, schema, "02_add_column", "products", map[string]string{
 				"name": "banana",
 			}, testutils.CheckViolationErrorCode)
 		},
-		afterRollback: func(t *testing.T, db *sql.DB) {
+		afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			// the check constraint has been dropped.
 			constraintName := migrations.NotNullConstraintName("description")
-			CheckConstraintMustNotExist(t, db, "public", "products", constraintName)
+			CheckConstraintMustNotExist(t, db, schema, "products", constraintName)
 		},
-		afterComplete: func(t *testing.T, db *sql.DB) {
+		afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 			// the check constraint has been dropped.
 			constraintName := migrations.NotNullConstraintName("description")
-			CheckConstraintMustNotExist(t, db, "public", "products", constraintName)
+			CheckConstraintMustNotExist(t, db, schema, "products", constraintName)
 
 			// can't insert a null description into the new view; the column now has a NOT NULL constraint.
-			MustNotInsert(t, db, "public", "02_add_column", "products", map[string]string{
+			MustNotInsert(t, db, schema, "02_add_column", "products", map[string]string{
 				"name": "orange",
 			}, testutils.NotNullViolationErrorCode)
 		},
@@ -723,30 +723,30 @@ func TestAddColumnWithCheckConstraint(t *testing.T) {
 				},
 			},
 		},
-		afterStart: func(t *testing.T, db *sql.DB) {
+		afterStart: func(t *testing.T, db *sql.DB, schema string) {
 			// Inserting a row that meets the constraint into the new view succeeds.
-			MustInsert(t, db, "public", "02_add_column", "users", map[string]string{
+			MustInsert(t, db, schema, "02_add_column", "users", map[string]string{
 				"name": "alice",
 				"age":  "30",
 			})
 
 			// Inserting a row that does not meet the constraint into the new view fails.
-			MustNotInsert(t, db, "public", "02_add_column", "users", map[string]string{
+			MustNotInsert(t, db, schema, "02_add_column", "users", map[string]string{
 				"name": "bob",
 				"age":  "3",
 			}, testutils.CheckViolationErrorCode)
 		},
-		afterRollback: func(t *testing.T, db *sql.DB) {
+		afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 		},
-		afterComplete: func(t *testing.T, db *sql.DB) {
+		afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 			// Inserting a row that meets the constraint into the new view succeeds.
-			MustInsert(t, db, "public", "02_add_column", "users", map[string]string{
+			MustInsert(t, db, schema, "02_add_column", "users", map[string]string{
 				"name": "carl",
 				"age":  "30",
 			})
 
 			// Inserting a row that does not meet the constraint into the new view fails.
-			MustNotInsert(t, db, "public", "02_add_column", "users", map[string]string{
+			MustNotInsert(t, db, schema, "02_add_column", "users", map[string]string{
 				"name": "dana",
 				"age":  "3",
 			}, testutils.CheckViolationErrorCode)
@@ -796,16 +796,16 @@ func TestAddColumnWithComment(t *testing.T) {
 				},
 			},
 		},
-		afterStart: func(t *testing.T, db *sql.DB) {
+		afterStart: func(t *testing.T, db *sql.DB, schema string) {
 			// The comment has been added to the underlying column.
 			columnName := migrations.TemporaryName("age")
-			ColumnMustHaveComment(t, db, "public", "users", columnName, "the age of the user")
+			ColumnMustHaveComment(t, db, schema, "users", columnName, "the age of the user")
 		},
-		afterRollback: func(t *testing.T, db *sql.DB) {
+		afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 		},
-		afterComplete: func(t *testing.T, db *sql.DB) {
+		afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 			// The comment is still present on the underlying column.
-			ColumnMustHaveComment(t, db, "public", "users", "age", "the age of the user")
+			ColumnMustHaveComment(t, db, schema, "users", "age", "the age of the user")
 		},
 	}})
 }

--- a/pkg/migrations/op_create_index_test.go
+++ b/pkg/migrations/op_create_index_test.go
@@ -46,15 +46,15 @@ func TestCreateIndex(t *testing.T) {
 				},
 			},
 		},
-		afterStart: func(t *testing.T, db *sql.DB) {
+		afterStart: func(t *testing.T, db *sql.DB, schema string) {
 			// The index has been created on the underlying table.
-			IndexMustExist(t, db, "public", "users", "idx_users_name")
+			IndexMustExist(t, db, schema, "users", "idx_users_name")
 		},
-		afterRollback: func(t *testing.T, db *sql.DB) {
+		afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			// The index has been dropped from the the underlying table.
-			IndexMustNotExist(t, db, "public", "users", "idx_users_name")
+			IndexMustNotExist(t, db, schema, "users", "idx_users_name")
 		},
-		afterComplete: func(t *testing.T, db *sql.DB) {
+		afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 			// Complete is a no-op.
 		},
 	}})
@@ -102,15 +102,15 @@ func TestCreateIndexOnMultipleColumns(t *testing.T) {
 				},
 			},
 		},
-		afterStart: func(t *testing.T, db *sql.DB) {
+		afterStart: func(t *testing.T, db *sql.DB, schema string) {
 			// The index has been created on the underlying table.
-			IndexMustExist(t, db, "public", "users", "idx_users_name_email")
+			IndexMustExist(t, db, schema, "users", "idx_users_name_email")
 		},
-		afterRollback: func(t *testing.T, db *sql.DB) {
+		afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			// The index has been dropped from the the underlying table.
-			IndexMustNotExist(t, db, "public", "users", "idx_users_name_email")
+			IndexMustNotExist(t, db, schema, "users", "idx_users_name_email")
 		},
-		afterComplete: func(t *testing.T, db *sql.DB) {
+		afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 			// Complete is a no-op.
 		},
 	}})

--- a/pkg/migrations/op_create_table_test.go
+++ b/pkg/migrations/op_create_table_test.go
@@ -279,62 +279,64 @@ func TestCreateTable(t *testing.T) {
 func TestCreateTableValidation(t *testing.T) {
 	t.Parallel()
 
-	ExecuteTests(t, TestCases{TestCase{
-		name: "foreign key validity",
-		migrations: []migrations.Migration{
-			{
-				Name: "01_create_table",
-				Operations: migrations.Operations{
-					&migrations.OpCreateTable{
-						Name: "users",
-						Columns: []migrations.Column{
-							{
-								Name: "id",
-								Type: "serial",
-								Pk:   ptr(true),
-							},
-							{
-								Name:   "name",
-								Type:   "varchar(255)",
-								Unique: ptr(true),
-							},
-						},
-					},
-				},
-			},
-			{
-				Name: "02_create_table_with_fk",
-				Operations: migrations.Operations{
-					&migrations.OpCreateTable{
-						Name: "orders",
-						Columns: []migrations.Column{
-							{
-								Name: "id",
-								Type: "serial",
-								Pk:   ptr(true),
-							},
-							{
-								Name: "user_id",
-								Type: "integer",
-								References: &migrations.ForeignKeyReference{
-									Name:   "fk_users_doesntexist",
-									Table:  "users",
-									Column: "doesntexist",
+	ExecuteTests(t, TestCases{
+		{
+			name: "foreign key validity",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_create_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   ptr(true),
+								},
+								{
+									Name:   "name",
+									Type:   "varchar(255)",
+									Unique: ptr(true),
 								},
 							},
-							{
-								Name: "quantity",
-								Type: "integer",
+						},
+					},
+				},
+				{
+					Name: "02_create_table_with_fk",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "orders",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   ptr(true),
+								},
+								{
+									Name: "user_id",
+									Type: "integer",
+									References: &migrations.ForeignKeyReference{
+										Name:   "fk_users_doesntexist",
+										Table:  "users",
+										Column: "doesntexist",
+									},
+								},
+								{
+									Name: "quantity",
+									Type: "integer",
+								},
 							},
 						},
 					},
 				},
 			},
+			wantStartErr: migrations.ColumnReferenceError{
+				Table:  "orders",
+				Column: "user_id",
+				Err:    migrations.ColumnDoesNotExistError{Table: "users", Name: "doesntexist"},
+			},
 		},
-		wantStartErr: migrations.ColumnReferenceError{
-			Table:  "orders",
-			Column: "user_id",
-			Err:    migrations.ColumnDoesNotExistError{Table: "users", Name: "doesntexist"},
-		},
-	}})
+	})
 }

--- a/pkg/migrations/op_create_table_test.go
+++ b/pkg/migrations/op_create_table_test.go
@@ -40,36 +40,36 @@ func TestCreateTable(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The new view exists in the new version schema.
-				ViewMustExist(t, db, "public", "01_create_table", "users")
+				ViewMustExist(t, db, schema, "01_create_table", "users")
 
 				// Data can be inserted into the new view.
-				MustInsert(t, db, "public", "01_create_table", "users", map[string]string{
+				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
 					"name": "Alice",
 				})
 
 				// Data can be retrieved from the new view.
-				rows := MustSelect(t, db, "public", "01_create_table", "users")
+				rows := MustSelect(t, db, schema, "01_create_table", "users")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "name": "Alice"},
 				}, rows)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// The underlying table has been dropped.
-				TableMustNotExist(t, db, "public", "users")
+				TableMustNotExist(t, db, schema, "users")
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The view still exists
-				ViewMustExist(t, db, "public", "01_create_table", "users")
+				ViewMustExist(t, db, schema, "01_create_table", "users")
 
 				// Data can be inserted into the new view.
-				MustInsert(t, db, "public", "01_create_table", "users", map[string]string{
+				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
 					"name": "Alice",
 				})
 
 				// Data can be retrieved from the new view.
-				rows := MustSelect(t, db, "public", "01_create_table", "users")
+				rows := MustSelect(t, db, schema, "01_create_table", "users")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "name": "Alice"},
 				}, rows)
@@ -127,46 +127,46 @@ func TestCreateTable(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The foreign key constraint exists on the new table.
-				ValidatedForeignKeyMustExist(t, db, "public", migrations.TemporaryName("orders"), "fk_users_id")
+				ValidatedForeignKeyMustExist(t, db, schema, migrations.TemporaryName("orders"), "fk_users_id")
 
 				// Inserting a row into the referenced table succeeds.
-				MustInsert(t, db, "public", "01_create_table", "users", map[string]string{
+				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
 					"name": "alice",
 				})
 
 				// Inserting a row into the referencing table succeeds as the referenced row exists.
-				MustInsert(t, db, "public", "02_create_table_with_fk", "orders", map[string]string{
+				MustInsert(t, db, schema, "02_create_table_with_fk", "orders", map[string]string{
 					"user_id":  "1",
 					"quantity": "100",
 				})
 
 				// Inserting a row into the referencing table fails as the referenced row does not exist.
-				MustNotInsert(t, db, "public", "02_create_table_with_fk", "orders", map[string]string{
+				MustNotInsert(t, db, schema, "02_create_table_with_fk", "orders", map[string]string{
 					"user_id":  "2",
 					"quantity": "200",
 				}, testutils.FKViolationErrorCode)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// The table has been dropped, so the foreign key constraint is gone.
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
-				ValidatedForeignKeyMustExist(t, db, "public", "orders", "fk_users_id")
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+				ValidatedForeignKeyMustExist(t, db, schema, "orders", "fk_users_id")
 
 				// Inserting a row into the referenced table succeeds.
-				MustInsert(t, db, "public", "02_create_table_with_fk", "users", map[string]string{
+				MustInsert(t, db, schema, "02_create_table_with_fk", "users", map[string]string{
 					"name": "bob",
 				})
 
 				// Inserting a row into the referencing table succeeds as the referenced row exists.
-				MustInsert(t, db, "public", "02_create_table_with_fk", "orders", map[string]string{
+				MustInsert(t, db, schema, "02_create_table_with_fk", "orders", map[string]string{
 					"user_id":  "2",
 					"quantity": "200",
 				})
 
 				// Inserting a row into the referencing table fails as the referenced row does not exist.
-				MustNotInsert(t, db, "public", "02_create_table_with_fk", "orders", map[string]string{
+				MustNotInsert(t, db, schema, "02_create_table_with_fk", "orders", map[string]string{
 					"user_id":  "3",
 					"quantity": "300",
 				}, testutils.FKViolationErrorCode)
@@ -199,34 +199,34 @@ func TestCreateTable(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The check constraint exists on the new table.
-				CheckConstraintMustExist(t, db, "public", migrations.TemporaryName("users"), "check_name_length")
+				CheckConstraintMustExist(t, db, schema, migrations.TemporaryName("users"), "check_name_length")
 
 				// Inserting a row into the table succeeds when the check constraint is satisfied.
-				MustInsert(t, db, "public", "01_create_table", "users", map[string]string{
+				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
 					"name": "alice",
 				})
 
 				// Inserting a row into the table fails when the check constraint is not satisfied.
-				MustNotInsert(t, db, "public", "01_create_table", "users", map[string]string{
+				MustNotInsert(t, db, schema, "01_create_table", "users", map[string]string{
 					"name": "b",
 				}, testutils.CheckViolationErrorCode)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// The table has been dropped, so the check constraint is gone.
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The check constraint exists on the new table.
-				CheckConstraintMustExist(t, db, "public", "users", "check_name_length")
+				CheckConstraintMustExist(t, db, schema, "users", "check_name_length")
 
 				// Inserting a row into the table succeeds when the check constraint is satisfied.
-				MustInsert(t, db, "public", "01_create_table", "users", map[string]string{
+				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
 					"name": "bobby",
 				})
 
 				// Inserting a row into the table fails when the check constraint is not satisfied.
-				MustNotInsert(t, db, "public", "01_create_table", "users", map[string]string{
+				MustNotInsert(t, db, schema, "01_create_table", "users", map[string]string{
 					"name": "c",
 				}, testutils.CheckViolationErrorCode)
 			},
@@ -257,20 +257,20 @@ func TestCreateTable(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				tableName := migrations.TemporaryName("users")
 				// The comment has been added to the underlying table.
-				TableMustHaveComment(t, db, "public", tableName, "the users table")
+				TableMustHaveComment(t, db, schema, tableName, "the users table")
 				// The comment has been added to the underlying column.
-				ColumnMustHaveComment(t, db, "public", tableName, "name", "the username")
+				ColumnMustHaveComment(t, db, schema, tableName, "name", "the username")
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The comment is still present on the underlying table.
-				TableMustHaveComment(t, db, "public", "users", "the users table")
+				TableMustHaveComment(t, db, schema, "users", "the users table")
 				// The comment is still present on the underlying column.
-				ColumnMustHaveComment(t, db, "public", "users", "name", "the username")
+				ColumnMustHaveComment(t, db, schema, "users", "name", "the username")
 			},
 		},
 	})

--- a/pkg/migrations/op_drop_column_test.go
+++ b/pkg/migrations/op_drop_column_test.go
@@ -54,51 +54,51 @@ func TestDropColumnWithDownSQL(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The deleted column is not present on the view in the new version schema.
-				versionSchema := roll.VersionedSchemaName("public", "02_drop_column")
+				versionSchema := roll.VersionedSchemaName(schema, "02_drop_column")
 				ColumnMustNotExist(t, db, versionSchema, "users", "name")
 
 				// But the column is still present on the underlying table.
-				ColumnMustExist(t, db, "public", "users", "name")
+				ColumnMustExist(t, db, schema, "users", "name")
 
 				// Inserting into the view in the new version schema should succeed.
-				MustInsert(t, db, "public", "02_drop_column", "users", map[string]string{
+				MustInsert(t, db, schema, "02_drop_column", "users", map[string]string{
 					"email": "foo@example.com",
 				})
 
 				// The "down" SQL has populated the removed column ("name")
-				results := MustSelect(t, db, "public", "01_add_table", "users")
+				results := MustSelect(t, db, schema, "01_add_table", "users")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "name": "FOO@EXAMPLE.COM", "email": "foo@example.com"},
 				}, results)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// The trigger function has been dropped.
 				triggerFnName := migrations.TriggerFunctionName("users", "name")
-				FunctionMustNotExist(t, db, "public", triggerFnName)
+				FunctionMustNotExist(t, db, schema, triggerFnName)
 
 				// The trigger has been dropped.
 				triggerName := migrations.TriggerName("users", "name")
-				TriggerMustNotExist(t, db, "public", "users", triggerName)
+				TriggerMustNotExist(t, db, schema, "users", triggerName)
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The column has been deleted from the underlying table.
-				ColumnMustNotExist(t, db, "public", "users", "name")
+				ColumnMustNotExist(t, db, schema, "users", "name")
 
 				// The trigger function has been dropped.
 				triggerFnName := migrations.TriggerFunctionName("users", "name")
-				FunctionMustNotExist(t, db, "public", triggerFnName)
+				FunctionMustNotExist(t, db, schema, triggerFnName)
 
 				// The trigger has been dropped.
 				triggerName := migrations.TriggerName("users", "name")
-				TriggerMustNotExist(t, db, "public", "users", triggerName)
+				TriggerMustNotExist(t, db, schema, "users", triggerName)
 
 				// Inserting into the view in the new version schema should succeed.
-				MustInsert(t, db, "public", "02_drop_column", "users", map[string]string{
+				MustInsert(t, db, schema, "02_drop_column", "users", map[string]string{
 					"email": "bar@example.com",
 				})
-				results := MustSelect(t, db, "public", "02_drop_column", "users")
+				results := MustSelect(t, db, schema, "02_drop_column", "users")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "email": "foo@example.com"},
 					{"id": 2, "email": "bar@example.com"},
@@ -138,13 +138,13 @@ func TestDropColumnWithDownSQL(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The column has been deleted from the underlying table.
-				ColumnMustNotExist(t, db, "public", "users", "array")
+				ColumnMustNotExist(t, db, schema, "users", "array")
 			},
 		},
 		{
@@ -180,13 +180,13 @@ func TestDropColumnWithDownSQL(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The column has been deleted from the underlying table.
-				ColumnMustNotExist(t, db, "public", "users", "array")
+				ColumnMustNotExist(t, db, schema, "users", "array")
 			},
 		},
 	})

--- a/pkg/migrations/op_drop_constraint_test.go
+++ b/pkg/migrations/op_drop_constraint_test.go
@@ -64,68 +64,68 @@ func TestDropConstraint(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The new (temporary) `title` column should exist on the underlying table.
-				ColumnMustExist(t, db, "public", "posts", migrations.TemporaryName("title"))
+				ColumnMustExist(t, db, schema, "posts", migrations.TemporaryName("title"))
 
 				// Inserting a row that meets the check constraint into the old view works.
-				MustInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+				MustInsert(t, db, schema, "02_add_check_constraint", "posts", map[string]string{
 					"title": "post by alice",
 				})
 
 				// Inserting a row that does not meet the check constraint into the old view fails.
-				MustNotInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+				MustNotInsert(t, db, schema, "02_add_check_constraint", "posts", map[string]string{
 					"title": "b",
 				}, testutils.CheckViolationErrorCode)
 
 				// The inserted row has been backfilled into the new view.
-				rows := MustSelect(t, db, "public", "03_drop_check_constraint", "posts")
+				rows := MustSelect(t, db, schema, "03_drop_check_constraint", "posts")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "title": "post by alice"},
 				}, rows)
 
 				// Inserting a row that meets the check constraint into the new view works.
-				MustInsert(t, db, "public", "03_drop_check_constraint", "posts", map[string]string{
+				MustInsert(t, db, schema, "03_drop_check_constraint", "posts", map[string]string{
 					"title": "post by carl",
 				})
 
 				// Inserting a row that does not meet the check constraint into the new view also works.
-				MustInsert(t, db, "public", "03_drop_check_constraint", "posts", map[string]string{
+				MustInsert(t, db, schema, "03_drop_check_constraint", "posts", map[string]string{
 					"title": "d",
 				})
 
 				// Both rows that were inserted into the new view have been backfilled
 				// into the old view. The short `title` value has been rewritten to meet the
 				// check constraint present on the old view.
-				rows = MustSelect(t, db, "public", "02_add_check_constraint", "posts")
+				rows = MustSelect(t, db, schema, "02_add_check_constraint", "posts")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "title": "post by alice"},
 					{"id": 3, "title": "post by carl"},
 					{"id": 4, "title": "---d"},
 				}, rows)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// The new (temporary) `title` column should not exist on the underlying table.
-				ColumnMustNotExist(t, db, "public", "posts", migrations.TemporaryName("title"))
+				ColumnMustNotExist(t, db, schema, "posts", migrations.TemporaryName("title"))
 
 				// The up function no longer exists.
-				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", "title"))
+				FunctionMustNotExist(t, db, schema, migrations.TriggerFunctionName("posts", "title"))
 				// The down function no longer exists.
-				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", migrations.TemporaryName("title")))
+				FunctionMustNotExist(t, db, schema, migrations.TriggerFunctionName("posts", migrations.TemporaryName("title")))
 
 				// The up trigger no longer exists.
-				TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", "title"))
+				TriggerMustNotExist(t, db, schema, "posts", migrations.TriggerName("posts", "title"))
 				// The down trigger no longer exists.
-				TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", migrations.TemporaryName("title")))
+				TriggerMustNotExist(t, db, schema, "posts", migrations.TriggerName("posts", migrations.TemporaryName("title")))
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// Inserting a row that does not meet the check constraint into the new view works.
-				MustInsert(t, db, "public", "03_drop_check_constraint", "posts", map[string]string{
+				MustInsert(t, db, schema, "03_drop_check_constraint", "posts", map[string]string{
 					"title": "e",
 				})
 
 				// The data in the new `posts` view is as expected.
-				rows := MustSelect(t, db, "public", "03_drop_check_constraint", "posts")
+				rows := MustSelect(t, db, schema, "03_drop_check_constraint", "posts")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "title": "post by alice"},
 					{"id": 3, "title": "post by carl"},
@@ -134,14 +134,14 @@ func TestDropConstraint(t *testing.T) {
 				}, rows)
 
 				// The up function no longer exists.
-				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", "title"))
+				FunctionMustNotExist(t, db, schema, migrations.TriggerFunctionName("posts", "title"))
 				// The down function no longer exists.
-				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", migrations.TemporaryName("title")))
+				FunctionMustNotExist(t, db, schema, migrations.TriggerFunctionName("posts", migrations.TemporaryName("title")))
 
 				// The up trigger no longer exists.
-				TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", "title"))
+				TriggerMustNotExist(t, db, schema, "posts", migrations.TriggerName("posts", "title"))
 				// The down trigger no longer exists.
-				TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", migrations.TemporaryName("title")))
+				TriggerMustNotExist(t, db, schema, "posts", migrations.TriggerName("posts", migrations.TemporaryName("title")))
 			},
 		},
 		{
@@ -194,20 +194,20 @@ func TestDropConstraint(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// Inserting a row that meets the check constraint into the old view works.
-				MustInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+				MustInsert(t, db, schema, "02_add_check_constraint", "posts", map[string]string{
 					"title": "post by alice",
 				})
 				// The inserted row has been backfilled into the new view, using the user-supplied `up` SQL.
-				rows := MustSelect(t, db, "public", "03_drop_check_constraint", "posts")
+				rows := MustSelect(t, db, schema, "03_drop_check_constraint", "posts")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "title": "post by alice!"},
 				}, rows)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 			},
 		},
 		{
@@ -280,84 +280,84 @@ func TestDropConstraint(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The new (temporary) `user_id` column should exist on the underlying table.
-				ColumnMustExist(t, db, "public", "posts", migrations.TemporaryName("user_id"))
+				ColumnMustExist(t, db, schema, "posts", migrations.TemporaryName("user_id"))
 
 				// Inserting some data into the `users` table works.
-				MustInsert(t, db, "public", "03_drop_fk_constraint", "users", map[string]string{
+				MustInsert(t, db, schema, "03_drop_fk_constraint", "users", map[string]string{
 					"name": "alice",
 				})
-				MustInsert(t, db, "public", "03_drop_fk_constraint", "users", map[string]string{
+				MustInsert(t, db, schema, "03_drop_fk_constraint", "users", map[string]string{
 					"name": "bob",
 				})
 
 				// Inserting data into the new `posts` view with a valid user reference works.
-				MustInsert(t, db, "public", "03_drop_fk_constraint", "posts", map[string]string{
+				MustInsert(t, db, schema, "03_drop_fk_constraint", "posts", map[string]string{
 					"title":   "post by alice",
 					"user_id": "1",
 				})
 
 				// Inserting data into the new `posts` view with an invalid user reference also works.
-				MustInsert(t, db, "public", "03_drop_fk_constraint", "posts", map[string]string{
+				MustInsert(t, db, schema, "03_drop_fk_constraint", "posts", map[string]string{
 					"title":   "post by unknown user",
 					"user_id": "3",
 				})
 
 				// The inserted rows have been backfilled into the old view.
 				// The invalid user reference has been rewritten to NULL.
-				rows := MustSelect(t, db, "public", "02_add_fk_constraint", "posts")
+				rows := MustSelect(t, db, schema, "02_add_fk_constraint", "posts")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "title": "post by alice", "user_id": 1},
 					{"id": 2, "title": "post by unknown user", "user_id": nil},
 				}, rows)
 
 				// Inserting data into the old `posts` view with a valid user reference works.
-				MustInsert(t, db, "public", "02_add_fk_constraint", "posts", map[string]string{
+				MustInsert(t, db, schema, "02_add_fk_constraint", "posts", map[string]string{
 					"title":   "post by bob",
 					"user_id": "2",
 				})
 
 				// Inserting data into the old `posts` view with an invalid user reference fails.
-				MustNotInsert(t, db, "public", "02_add_fk_constraint", "posts", map[string]string{
+				MustNotInsert(t, db, schema, "02_add_fk_constraint", "posts", map[string]string{
 					"title":   "post by unknown user",
 					"user_id": "3",
 				}, testutils.FKViolationErrorCode)
 
 				// The post that was inserted successfully has been backfilled into the new view.
-				rows = MustSelect(t, db, "public", "03_drop_fk_constraint", "posts")
+				rows = MustSelect(t, db, schema, "03_drop_fk_constraint", "posts")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "title": "post by alice", "user_id": 1},
 					{"id": 2, "title": "post by unknown user", "user_id": 3},
 					{"id": 3, "title": "post by bob", "user_id": 2},
 				}, rows)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// The new (temporary) `user_id` column should not exist on the underlying table.
-				ColumnMustNotExist(t, db, "public", "posts", migrations.TemporaryName("user_id"))
+				ColumnMustNotExist(t, db, schema, "posts", migrations.TemporaryName("user_id"))
 
 				// The up function no longer exists.
-				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", "user_id"))
+				FunctionMustNotExist(t, db, schema, migrations.TriggerFunctionName("posts", "user_id"))
 				// The down function no longer exists.
-				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", migrations.TemporaryName("user_id")))
+				FunctionMustNotExist(t, db, schema, migrations.TriggerFunctionName("posts", migrations.TemporaryName("user_id")))
 
 				// The up trigger no longer exists.
-				TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", "user_id"))
+				TriggerMustNotExist(t, db, schema, "posts", migrations.TriggerName("posts", "user_id"))
 				// The down trigger no longer exists.
-				TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", migrations.TemporaryName("user_id")))
+				TriggerMustNotExist(t, db, schema, "posts", migrations.TriggerName("posts", migrations.TemporaryName("user_id")))
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The new (temporary) `user_id` column should not exist on the underlying table.
-				ColumnMustNotExist(t, db, "public", "posts", migrations.TemporaryName("user_id"))
+				ColumnMustNotExist(t, db, schema, "posts", migrations.TemporaryName("user_id"))
 
 				// Inserting a row that does not meet the check constraint into the new view works.
-				MustInsert(t, db, "public", "03_drop_fk_constraint", "posts", map[string]string{
+				MustInsert(t, db, schema, "03_drop_fk_constraint", "posts", map[string]string{
 					"title":   "another post by an unknown user",
 					"user_id": "4",
 				})
 
 				// The data in the new `posts` view is as expected.
-				rows := MustSelect(t, db, "public", "03_drop_fk_constraint", "posts")
+				rows := MustSelect(t, db, schema, "03_drop_fk_constraint", "posts")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "title": "post by alice", "user_id": 1},
 					{"id": 2, "title": "post by unknown user", "user_id": nil},
@@ -366,14 +366,14 @@ func TestDropConstraint(t *testing.T) {
 				}, rows)
 
 				// The up function no longer exists.
-				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", "user_id"))
+				FunctionMustNotExist(t, db, schema, migrations.TriggerFunctionName("posts", "user_id"))
 				// The down function no longer exists.
-				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", migrations.TemporaryName("user_id")))
+				FunctionMustNotExist(t, db, schema, migrations.TriggerFunctionName("posts", migrations.TemporaryName("user_id")))
 
 				// The up trigger no longer exists.
-				TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", "user_id"))
+				TriggerMustNotExist(t, db, schema, "posts", migrations.TriggerName("posts", "user_id"))
 				// The down trigger no longer exists.
-				TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", migrations.TemporaryName("user_id")))
+				TriggerMustNotExist(t, db, schema, "posts", migrations.TriggerName("posts", migrations.TemporaryName("user_id")))
 			},
 		},
 		{
@@ -412,45 +412,45 @@ func TestDropConstraint(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The new (temporary) `name` column should exist on the underlying table.
-				ColumnMustExist(t, db, "public", "users", migrations.TemporaryName("name"))
+				ColumnMustExist(t, db, schema, "users", migrations.TemporaryName("name"))
 
 				// Inserting a row that meets the unique constraint into the old view works.
-				MustInsert(t, db, "public", "01_add_tables", "users", map[string]string{
+				MustInsert(t, db, schema, "01_add_tables", "users", map[string]string{
 					"name": "alice",
 				})
 
 				// Inserting a row that does not meet the unique constraint into the old view fails.
-				MustNotInsert(t, db, "public", "01_add_tables", "users", map[string]string{
+				MustNotInsert(t, db, schema, "01_add_tables", "users", map[string]string{
 					"name": "alice",
 				}, testutils.UniqueViolationErrorCode)
 
 				// Inserting a row that does not meet the unique constraint into the new view works.
-				MustInsert(t, db, "public", "02_drop_unique_constraint", "users", map[string]string{
+				MustInsert(t, db, schema, "02_drop_unique_constraint", "users", map[string]string{
 					"name": "alice",
 				})
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// The new (temporary) `name` column should not exist on the underlying table.
-				ColumnMustNotExist(t, db, "public", "users", migrations.TemporaryName("name"))
+				ColumnMustNotExist(t, db, schema, "users", migrations.TemporaryName("name"))
 
 				// The up function no longer exists.
-				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("users", "name"))
+				FunctionMustNotExist(t, db, schema, migrations.TriggerFunctionName("users", "name"))
 				// The down function no longer exists.
-				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("users", migrations.TemporaryName("name")))
+				FunctionMustNotExist(t, db, schema, migrations.TriggerFunctionName("users", migrations.TemporaryName("name")))
 
 				// The up trigger no longer exists.
-				TriggerMustNotExist(t, db, "public", "users", migrations.TriggerName("users", "name"))
+				TriggerMustNotExist(t, db, schema, "users", migrations.TriggerName("users", "name"))
 				// The down trigger no longer exists.
-				TriggerMustNotExist(t, db, "public", "users", migrations.TriggerName("users", migrations.TemporaryName("name")))
+				TriggerMustNotExist(t, db, schema, "users", migrations.TriggerName("users", migrations.TemporaryName("name")))
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The new (temporary) `name` column should not exist on the underlying table.
-				ColumnMustNotExist(t, db, "public", "users", migrations.TemporaryName("name"))
+				ColumnMustNotExist(t, db, schema, "users", migrations.TemporaryName("name"))
 
 				// Inserting a row that does not meet the unique constraint into the new view works.
-				MustInsert(t, db, "public", "02_drop_unique_constraint", "users", map[string]string{
+				MustInsert(t, db, schema, "02_drop_unique_constraint", "users", map[string]string{
 					"name": "alice",
 				})
 			},
@@ -492,35 +492,35 @@ func TestDropConstraint(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// A row can be inserted into the new version of the table.
-				MustInsert(t, db, "public", "02_drop_unique_constraint", "users", map[string]string{
+				MustInsert(t, db, schema, "02_drop_unique_constraint", "users", map[string]string{
 					"id": "1",
 				})
 
 				// The newly inserted row respects the default value of the column.
-				rows := MustSelect(t, db, "public", "02_drop_unique_constraint", "users")
+				rows := MustSelect(t, db, schema, "02_drop_unique_constraint", "users")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "name": "anonymous"},
 				}, rows)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// Delete the row that was inserted in the `afterStart` hook to
 				// ensure that another row with a default 'name` can be inserted
 				// without violating the UNIQUE constraint on the column.
-				MustDelete(t, db, "public", "02_drop_unique_constraint", "users", map[string]string{
+				MustDelete(t, db, schema, "02_drop_unique_constraint", "users", map[string]string{
 					"id": "1",
 				})
 
 				// A row can be inserted into the new version of the table.
-				MustInsert(t, db, "public", "02_drop_unique_constraint", "users", map[string]string{
+				MustInsert(t, db, schema, "02_drop_unique_constraint", "users", map[string]string{
 					"id": "2",
 				})
 
 				// The newly inserted row respects the default value of the column.
-				rows := MustSelect(t, db, "public", "02_drop_unique_constraint", "users")
+				rows := MustSelect(t, db, schema, "02_drop_unique_constraint", "users")
 				assert.Equal(t, []map[string]any{
 					{"id": 2, "name": "anonymous"},
 				}, rows)
@@ -592,15 +592,15 @@ func TestDropConstraint(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// A temporary FK constraint has been created on the temporary column
-				ValidatedForeignKeyMustExist(t, db, "public", "employees", migrations.DuplicationName("fk_employee_department"))
+				ValidatedForeignKeyMustExist(t, db, schema, "employees", migrations.DuplicationName("fk_employee_department"))
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The foreign key constraint still exists on the column
-				ValidatedForeignKeyMustExist(t, db, "public", "employees", "fk_employee_department")
+				ValidatedForeignKeyMustExist(t, db, schema, "employees", "fk_employee_department")
 			},
 		},
 		{
@@ -655,18 +655,18 @@ func TestDropConstraint(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// Inserting a row that violates the check constraint should fail
-				MustNotInsert(t, db, "public", "03_drop_unique_constraint", "posts", map[string]string{
+				MustNotInsert(t, db, schema, "03_drop_unique_constraint", "posts", map[string]string{
 					"id":    "1",
 					"title": "a",
 				}, testutils.CheckViolationErrorCode)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// Inserting a row that violates the check constraint should fail.
-				MustNotInsert(t, db, "public", "03_drop_unique_constraint", "posts", map[string]string{
+				MustNotInsert(t, db, schema, "03_drop_unique_constraint", "posts", map[string]string{
 					"id":    "2",
 					"title": "b",
 				}, testutils.CheckViolationErrorCode)
@@ -724,27 +724,27 @@ func TestDropConstraint(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// Inserting an initial row into the `posts` table succeeds
-				MustInsert(t, db, "public", "03_drop_check_constraint", "posts", map[string]string{
+				MustInsert(t, db, schema, "03_drop_check_constraint", "posts", map[string]string{
 					"title": "post by alice",
 				})
 
 				// Inserting another row with a duplicate `title` value fails
-				MustNotInsert(t, db, "public", "03_drop_check_constraint", "posts", map[string]string{
+				MustNotInsert(t, db, schema, "03_drop_check_constraint", "posts", map[string]string{
 					"title": "post by alice",
 				}, testutils.UniqueViolationErrorCode)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// Inserting a row with a duplicate `title` value fails
-				MustNotInsert(t, db, "public", "03_drop_check_constraint", "posts", map[string]string{
+				MustNotInsert(t, db, schema, "03_drop_check_constraint", "posts", map[string]string{
 					"title": "post by alice",
 				}, testutils.UniqueViolationErrorCode)
 
 				// Inserting a row with a different `title` value succeeds
-				MustInsert(t, db, "public", "03_drop_check_constraint", "posts", map[string]string{
+				MustInsert(t, db, schema, "03_drop_check_constraint", "posts", map[string]string{
 					"title": "post by bob",
 				})
 			},
@@ -786,17 +786,17 @@ func TestDropConstraint(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// Inserting a row that violates the NOT NULL constraint fails.
-				MustNotInsert(t, db, "public", "02_drop_unique_constraint", "posts", map[string]string{
+				MustNotInsert(t, db, schema, "02_drop_unique_constraint", "posts", map[string]string{
 					"id": "1",
 				}, testutils.NotNullViolationErrorCode)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// Inserting a row that violates the NOT NULL constraint fails.
-				MustNotInsert(t, db, "public", "02_drop_unique_constraint", "posts", map[string]string{
+				MustNotInsert(t, db, schema, "02_drop_unique_constraint", "posts", map[string]string{
 					"id": "2",
 				}, testutils.NotNullViolationErrorCode)
 			},

--- a/pkg/migrations/op_drop_index_test.go
+++ b/pkg/migrations/op_drop_index_test.go
@@ -54,16 +54,16 @@ func TestDropIndex(t *testing.T) {
 				},
 			},
 		},
-		afterStart: func(t *testing.T, db *sql.DB) {
+		afterStart: func(t *testing.T, db *sql.DB, schema string) {
 			// The index has not yet been dropped.
-			IndexMustExist(t, db, "public", "users", "idx_users_name")
+			IndexMustExist(t, db, schema, "users", "idx_users_name")
 		},
-		afterRollback: func(t *testing.T, db *sql.DB) {
+		afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			// Rollback is a no-op.
 		},
-		afterComplete: func(t *testing.T, db *sql.DB) {
+		afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 			// The index has been removed from the underlying table.
-			IndexMustNotExist(t, db, "public", "users", "idx_users_name")
+			IndexMustNotExist(t, db, schema, "users", "idx_users_name")
 		},
 	}})
 }

--- a/pkg/migrations/op_drop_not_null_test.go
+++ b/pkg/migrations/op_drop_not_null_test.go
@@ -60,18 +60,18 @@ func TestDropNotNull(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The new (temporary) `review` column should exist on the underlying table.
-				ColumnMustExist(t, db, "public", "reviews", migrations.TemporaryName("review"))
+				ColumnMustExist(t, db, schema, "reviews", migrations.TemporaryName("review"))
 
 				// Inserting a NULL into the new `review` column should succeed
-				MustInsert(t, db, "public", "02_set_nullable", "reviews", map[string]string{
+				MustInsert(t, db, schema, "02_set_nullable", "reviews", map[string]string{
 					"username": "alice",
 					"product":  "apple",
 				})
 
 				// Inserting a non-NULL value into the new `review` column should succeed
-				MustInsert(t, db, "public", "02_set_nullable", "reviews", map[string]string{
+				MustInsert(t, db, schema, "02_set_nullable", "reviews", map[string]string{
 					"username": "bob",
 					"product":  "banana",
 					"review":   "brilliant",
@@ -79,20 +79,20 @@ func TestDropNotNull(t *testing.T) {
 
 				// The rows inserted into the new `review` column have been backfilled into the
 				// old `review` column.
-				rows := MustSelect(t, db, "public", "01_add_table", "reviews")
+				rows := MustSelect(t, db, schema, "01_add_table", "reviews")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "username": "alice", "product": "apple", "review": "apple is good"},
 					{"id": 2, "username": "bob", "product": "banana", "review": "brilliant"},
 				}, rows)
 
 				// Inserting a NULL value into the old `review` column should fail
-				MustNotInsert(t, db, "public", "01_add_table", "reviews", map[string]string{
+				MustNotInsert(t, db, schema, "01_add_table", "reviews", map[string]string{
 					"username": "carl",
 					"product":  "carrot",
 				}, testutils.NotNullViolationErrorCode)
 
 				// Inserting a non-NULL value into the old `review` column should succeed
-				MustInsert(t, db, "public", "01_add_table", "reviews", map[string]string{
+				MustInsert(t, db, schema, "01_add_table", "reviews", map[string]string{
 					"username": "dana",
 					"product":  "durian",
 					"review":   "delicious",
@@ -100,39 +100,39 @@ func TestDropNotNull(t *testing.T) {
 
 				// The non-NULL value inserted into the old `review` column has been copied
 				// unchanged into the new `review` column.
-				rows = MustSelect(t, db, "public", "02_set_nullable", "reviews")
+				rows = MustSelect(t, db, schema, "02_set_nullable", "reviews")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "username": "alice", "product": "apple", "review": nil},
 					{"id": 2, "username": "bob", "product": "banana", "review": "brilliant"},
 					{"id": 4, "username": "dana", "product": "durian", "review": "delicious"},
 				}, rows)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// The new (temporary) `review` column should not exist on the underlying table.
-				ColumnMustNotExist(t, db, "public", "reviews", migrations.TemporaryName("review"))
+				ColumnMustNotExist(t, db, schema, "reviews", migrations.TemporaryName("review"))
 
 				// The up function no longer exists.
-				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("reviews", "review"))
+				FunctionMustNotExist(t, db, schema, migrations.TriggerFunctionName("reviews", "review"))
 				// The down function no longer exists.
-				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("reviews", migrations.TemporaryName("review")))
+				FunctionMustNotExist(t, db, schema, migrations.TriggerFunctionName("reviews", migrations.TemporaryName("review")))
 
 				// The up trigger no longer exists.
-				TriggerMustNotExist(t, db, "public", "reviews", migrations.TriggerName("reviews", "review"))
+				TriggerMustNotExist(t, db, schema, "reviews", migrations.TriggerName("reviews", "review"))
 				// The down trigger no longer exists.
-				TriggerMustNotExist(t, db, "public", "reviews", migrations.TriggerName("reviews", migrations.TemporaryName("review")))
+				TriggerMustNotExist(t, db, schema, "reviews", migrations.TriggerName("reviews", migrations.TemporaryName("review")))
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The new (temporary) `review` column should not exist on the underlying table.
-				ColumnMustNotExist(t, db, "public", "reviews", migrations.TemporaryName("review"))
+				ColumnMustNotExist(t, db, schema, "reviews", migrations.TemporaryName("review"))
 
 				// Writing a NULL review into the `review` column should succeed.
-				MustInsert(t, db, "public", "02_set_nullable", "reviews", map[string]string{
+				MustInsert(t, db, schema, "02_set_nullable", "reviews", map[string]string{
 					"username": "earl",
 					"product":  "eggplant",
 				})
 
 				// Selecting from the `reviews` view should succeed.
-				rows := MustSelect(t, db, "public", "02_set_nullable", "reviews")
+				rows := MustSelect(t, db, schema, "02_set_nullable", "reviews")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "username": "alice", "product": "apple", "review": "apple is good"},
 					{"id": 2, "username": "bob", "product": "banana", "review": "brilliant"},
@@ -141,14 +141,14 @@ func TestDropNotNull(t *testing.T) {
 				}, rows)
 
 				// The up function no longer exists.
-				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("reviews", "review"))
+				FunctionMustNotExist(t, db, schema, migrations.TriggerFunctionName("reviews", "review"))
 				// The down function no longer exists.
-				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("reviews", migrations.TemporaryName("review")))
+				FunctionMustNotExist(t, db, schema, migrations.TriggerFunctionName("reviews", migrations.TemporaryName("review")))
 
 				// The up trigger no longer exists.
-				TriggerMustNotExist(t, db, "public", "reviews", migrations.TriggerName("reviews", "review"))
+				TriggerMustNotExist(t, db, schema, "reviews", migrations.TriggerName("reviews", "review"))
 				// The down trigger no longer exists.
-				TriggerMustNotExist(t, db, "public", "reviews", migrations.TriggerName("reviews", migrations.TemporaryName("review")))
+				TriggerMustNotExist(t, db, schema, "reviews", migrations.TriggerName("reviews", migrations.TemporaryName("review")))
 			},
 		},
 		{
@@ -197,9 +197,9 @@ func TestDropNotNull(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// Inserting a non-NULL value into the old `review` column should succeed
-				MustInsert(t, db, "public", "01_add_table", "reviews", map[string]string{
+				MustInsert(t, db, schema, "01_add_table", "reviews", map[string]string{
 					"username": "alice",
 					"product":  "apple",
 					"review":   "amazing",
@@ -207,14 +207,14 @@ func TestDropNotNull(t *testing.T) {
 
 				// The value inserted into the old `review` column has been backfilled into the
 				// new `review` column using the user-supplied `up` SQL.
-				rows := MustSelect(t, db, "public", "02_set_nullable", "reviews")
+				rows := MustSelect(t, db, schema, "02_set_nullable", "reviews")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "username": "alice", "product": "apple", "review": "amazing (from the old column)"},
 				}, rows)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 			},
 		},
 		{
@@ -283,15 +283,15 @@ func TestDropNotNull(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// A temporary FK constraint has been created on the temporary column
-				ValidatedForeignKeyMustExist(t, db, "public", "employees", migrations.DuplicationName("fk_employee_department"))
+				ValidatedForeignKeyMustExist(t, db, schema, "employees", migrations.DuplicationName("fk_employee_department"))
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The foreign key constraint still exists on the column
-				ValidatedForeignKeyMustExist(t, db, "public", "employees", "fk_employee_department")
+				ValidatedForeignKeyMustExist(t, db, schema, "employees", "fk_employee_department")
 			},
 		},
 		{
@@ -331,28 +331,28 @@ func TestDropNotNull(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// A row can be inserted into the new version of the table.
-				MustInsert(t, db, "public", "02_set_not_null", "users", map[string]string{
+				MustInsert(t, db, schema, "02_set_not_null", "users", map[string]string{
 					"id": "1",
 				})
 
 				// The newly inserted row respects the default value of the column.
-				rows := MustSelect(t, db, "public", "02_set_not_null", "users")
+				rows := MustSelect(t, db, schema, "02_set_not_null", "users")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "name": "anonymous"},
 				}, rows)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// A row can be inserted into the new version of the table.
-				MustInsert(t, db, "public", "02_set_not_null", "users", map[string]string{
+				MustInsert(t, db, schema, "02_set_not_null", "users", map[string]string{
 					"id": "2",
 				})
 
 				// The newly inserted row respects the default value of the column.
-				rows := MustSelect(t, db, "public", "02_set_not_null", "users")
+				rows := MustSelect(t, db, schema, "02_set_not_null", "users")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "name": "anonymous"},
 					{"id": 2, "name": "anonymous"},
@@ -399,18 +399,18 @@ func TestDropNotNull(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// Inserting a row that violates the check constraint should fail.
-				MustNotInsert(t, db, "public", "02_set_not_null", "users", map[string]string{
+				MustNotInsert(t, db, schema, "02_set_not_null", "users", map[string]string{
 					"id":   "1",
 					"name": "a",
 				}, testutils.CheckViolationErrorCode)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// Inserting a row that violates the check constraint should fail.
-				MustNotInsert(t, db, "public", "02_set_not_null", "users", map[string]string{
+				MustNotInsert(t, db, schema, "02_set_not_null", "users", map[string]string{
 					"id":   "2",
 					"name": "b",
 				}, testutils.CheckViolationErrorCode)
@@ -453,27 +453,27 @@ func TestDropNotNull(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// Inserting an initial row succeeds
-				MustInsert(t, db, "public", "02_set_not_null", "users", map[string]string{
+				MustInsert(t, db, schema, "02_set_not_null", "users", map[string]string{
 					"name": "alice",
 				})
 
 				// Inserting a row with a duplicate `name` value fails
-				MustNotInsert(t, db, "public", "02_set_not_null", "users", map[string]string{
+				MustNotInsert(t, db, schema, "02_set_not_null", "users", map[string]string{
 					"name": "alice",
 				}, testutils.UniqueViolationErrorCode)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// Inserting a row with a duplicate `name` value fails
-				MustNotInsert(t, db, "public", "02_set_not_null", "users", map[string]string{
+				MustNotInsert(t, db, schema, "02_set_not_null", "users", map[string]string{
 					"name": "alice",
 				}, testutils.UniqueViolationErrorCode)
 
 				// Inserting a row with a different `name` value succeeds
-				MustInsert(t, db, "public", "02_set_not_null", "users", map[string]string{
+				MustInsert(t, db, schema, "02_set_not_null", "users", map[string]string{
 					"name": "bob",
 				})
 			},

--- a/pkg/migrations/op_drop_table_test.go
+++ b/pkg/migrations/op_drop_table_test.go
@@ -45,19 +45,19 @@ func TestDropTable(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The view for the deleted table does not exist in the new version schema.
-				ViewMustNotExist(t, db, "public", "02_drop_table", "users")
+				ViewMustNotExist(t, db, schema, "02_drop_table", "users")
 
 				// But the underlying table has not been deleted.
-				TableMustExist(t, db, "public", "users")
+				TableMustExist(t, db, schema, "users")
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// Rollback is a no-op.
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The underlying table has been deleted.
-				TableMustNotExist(t, db, "public", "users")
+				TableMustNotExist(t, db, schema, "users")
 			},
 		},
 	})

--- a/pkg/migrations/op_drop_table_test.go
+++ b/pkg/migrations/op_drop_table_test.go
@@ -12,51 +12,53 @@ import (
 func TestDropTable(t *testing.T) {
 	t.Parallel()
 
-	ExecuteTests(t, TestCases{TestCase{
-		name: "drop table",
-		migrations: []migrations.Migration{
-			{
-				Name: "01_create_table",
-				Operations: migrations.Operations{
-					&migrations.OpCreateTable{
-						Name: "users",
-						Columns: []migrations.Column{
-							{
-								Name: "id",
-								Type: "serial",
-								Pk:   ptr(true),
-							},
-							{
-								Name:   "name",
-								Type:   "varchar(255)",
-								Unique: ptr(true),
+	ExecuteTests(t, TestCases{
+		{
+			name: "drop table",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_create_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   ptr(true),
+								},
+								{
+									Name:   "name",
+									Type:   "varchar(255)",
+									Unique: ptr(true),
+								},
 							},
 						},
 					},
 				},
-			},
-			{
-				Name: "02_drop_table",
-				Operations: migrations.Operations{
-					&migrations.OpDropTable{
-						Name: "users",
+				{
+					Name: "02_drop_table",
+					Operations: migrations.Operations{
+						&migrations.OpDropTable{
+							Name: "users",
+						},
 					},
 				},
 			},
-		},
-		afterStart: func(t *testing.T, db *sql.DB) {
-			// The view for the deleted table does not exist in the new version schema.
-			ViewMustNotExist(t, db, "public", "02_drop_table", "users")
+			afterStart: func(t *testing.T, db *sql.DB) {
+				// The view for the deleted table does not exist in the new version schema.
+				ViewMustNotExist(t, db, "public", "02_drop_table", "users")
 
-			// But the underlying table has not been deleted.
-			TableMustExist(t, db, "public", "users")
+				// But the underlying table has not been deleted.
+				TableMustExist(t, db, "public", "users")
+			},
+			afterRollback: func(t *testing.T, db *sql.DB) {
+				// Rollback is a no-op.
+			},
+			afterComplete: func(t *testing.T, db *sql.DB) {
+				// The underlying table has been deleted.
+				TableMustNotExist(t, db, "public", "users")
+			},
 		},
-		afterRollback: func(t *testing.T, db *sql.DB) {
-			// Rollback is a no-op.
-		},
-		afterComplete: func(t *testing.T, db *sql.DB) {
-			// The underlying table has been deleted.
-			TableMustNotExist(t, db, "public", "users")
-		},
-	}})
+	})
 }

--- a/pkg/migrations/op_raw_sql_test.go
+++ b/pkg/migrations/op_raw_sql_test.go
@@ -33,22 +33,22 @@ func TestRawSQL(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// table can be accessed after start
-				ViewMustExist(t, db, "public", "01_create_table", "test_table")
+				ViewMustExist(t, db, schema, "01_create_table", "test_table")
 
 				// inserts work
-				MustInsert(t, db, "public", "01_create_table", "test_table", map[string]string{
+				MustInsert(t, db, schema, "01_create_table", "test_table", map[string]string{
 					"name": "foo",
 				})
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// table is dropped after rollback
-				TableMustNotExist(t, db, "public", "test_table")
+				TableMustNotExist(t, db, schema, "test_table")
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// inserts still work after complete
-				MustInsert(t, db, "public", "01_create_table", "test_table", map[string]string{
+				MustInsert(t, db, schema, "01_create_table", "test_table", map[string]string{
 					"name": "foo",
 				})
 			},
@@ -82,27 +82,27 @@ func TestRawSQL(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// table can be accessed after start
-				ViewMustExist(t, db, "public", "01_create_table", "test_table")
+				ViewMustExist(t, db, schema, "01_create_table", "test_table")
 
 				// table is renamed in new version
-				ViewMustExist(t, db, "public", "02_rename_table", "test_table_renamed")
+				ViewMustExist(t, db, schema, "02_rename_table", "test_table_renamed")
 
 				// inserts work
-				MustInsert(t, db, "public", "01_create_table", "test_table", map[string]string{
+				MustInsert(t, db, schema, "01_create_table", "test_table", map[string]string{
 					"name": "foo",
 				})
-				MustInsert(t, db, "public", "02_rename_table", "test_table_renamed", map[string]string{
+				MustInsert(t, db, schema, "02_rename_table", "test_table_renamed", map[string]string{
 					"name": "foo",
 				})
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// table can still be accessed after complete
-				ViewMustExist(t, db, "public", "02_rename_table", "test_table_renamed")
+				ViewMustExist(t, db, schema, "02_rename_table", "test_table_renamed")
 
 				// inserts work
-				MustInsert(t, db, "public", "02_rename_table", "test_table_renamed", map[string]string{
+				MustInsert(t, db, schema, "02_rename_table", "test_table_renamed", map[string]string{
 					"name": "foo",
 				})
 			},

--- a/pkg/migrations/op_rename_column_test.go
+++ b/pkg/migrations/op_rename_column_test.go
@@ -47,32 +47,32 @@ func TestRenameColumn(t *testing.T) {
 				},
 			},
 		},
-		afterStart: func(t *testing.T, db *sql.DB) {
+		afterStart: func(t *testing.T, db *sql.DB, schema string) {
 			// The column in the underlying table has not been renamed.
-			ColumnMustExist(t, db, "public", "users", "username")
+			ColumnMustExist(t, db, schema, "users", "username")
 
 			// Insertions to the new column name in the new version schema should work.
-			MustInsert(t, db, "public", "02_rename_column", "users", map[string]string{"name": "alice"})
+			MustInsert(t, db, schema, "02_rename_column", "users", map[string]string{"name": "alice"})
 
 			// Insertions to the old column name in the old version schema should work.
-			MustInsert(t, db, "public", "01_add_table", "users", map[string]string{"username": "bob"})
+			MustInsert(t, db, schema, "01_add_table", "users", map[string]string{"username": "bob"})
 
 			// Data can be read from the view in the new version schema.
-			rows := MustSelect(t, db, "public", "02_rename_column", "users")
+			rows := MustSelect(t, db, schema, "02_rename_column", "users")
 			assert.Equal(t, []map[string]any{
 				{"id": 1, "name": "alice"},
 				{"id": 2, "name": "bob"},
 			}, rows)
 		},
-		afterRollback: func(t *testing.T, db *sql.DB) {
+		afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			// no-op
 		},
-		afterComplete: func(t *testing.T, db *sql.DB) {
+		afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 			// The column in the underlying table has been renamed.
-			ColumnMustExist(t, db, "public", "users", "name")
+			ColumnMustExist(t, db, schema, "users", "name")
 
 			// Data can be read from the view in the new version schema.
-			rows := MustSelect(t, db, "public", "02_rename_column", "users")
+			rows := MustSelect(t, db, schema, "02_rename_column", "users")
 			assert.Equal(t, []map[string]any{
 				{"id": 1, "name": "alice"},
 				{"id": 2, "name": "bob"},

--- a/pkg/migrations/op_rename_table_test.go
+++ b/pkg/migrations/op_rename_table_test.go
@@ -45,22 +45,22 @@ func TestRenameTable(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// check that the table with the new name can be accessed
-				ViewMustExist(t, db, "public", "01_create_table", "test_table")
-				ViewMustExist(t, db, "public", "02_rename_table", "renamed_table")
+				ViewMustExist(t, db, schema, "01_create_table", "test_table")
+				ViewMustExist(t, db, schema, "02_rename_table", "renamed_table")
 
 				// inserts work
-				MustInsert(t, db, "public", "01_create_table", "test_table", map[string]string{
+				MustInsert(t, db, schema, "01_create_table", "test_table", map[string]string{
 					"name": "foo",
 				})
-				MustInsert(t, db, "public", "02_rename_table", "renamed_table", map[string]string{
+				MustInsert(t, db, schema, "02_rename_table", "renamed_table", map[string]string{
 					"name": "bar",
 				})
 
 				// selects work in both versions
-				resNew := MustSelect(t, db, "public", "01_create_table", "test_table")
-				resOld := MustSelect(t, db, "public", "02_rename_table", "renamed_table")
+				resNew := MustSelect(t, db, schema, "01_create_table", "test_table")
+				resOld := MustSelect(t, db, schema, "02_rename_table", "renamed_table")
 
 				assert.Equal(t, resOld, resNew)
 				assert.Equal(t, []map[string]any{
@@ -74,16 +74,16 @@ func TestRenameTable(t *testing.T) {
 					},
 				}, resNew)
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// the table still exists with the new name
-				ViewMustNotExist(t, db, "public", "02_rename_table", "testTable")
-				ViewMustExist(t, db, "public", "02_rename_table", "renamed_table")
+				ViewMustNotExist(t, db, schema, "02_rename_table", "testTable")
+				ViewMustExist(t, db, schema, "02_rename_table", "renamed_table")
 
 				// inserts & select work
-				MustInsert(t, db, "public", "02_rename_table", "renamed_table", map[string]string{
+				MustInsert(t, db, schema, "02_rename_table", "renamed_table", map[string]string{
 					"name": "baz",
 				})
-				res := MustSelect(t, db, "public", "02_rename_table", "renamed_table")
+				res := MustSelect(t, db, schema, "02_rename_table", "renamed_table")
 				assert.Equal(t, []map[string]any{
 					{
 						"id":   1,

--- a/pkg/migrations/op_set_check_test.go
+++ b/pkg/migrations/op_set_check_test.go
@@ -53,82 +53,82 @@ func TestSetCheckConstraint(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The new (temporary) `title` column should exist on the underlying table.
-				ColumnMustExist(t, db, "public", "posts", migrations.TemporaryName("title"))
+				ColumnMustExist(t, db, schema, "posts", migrations.TemporaryName("title"))
 
 				// A check constraint has been added to the temporary column
-				CheckConstraintMustExist(t, db, "public", "posts", "check_title_length")
+				CheckConstraintMustExist(t, db, schema, "posts", "check_title_length")
 
 				// Inserting a row that meets the check constraint into the old view works.
-				MustInsert(t, db, "public", "01_add_table", "posts", map[string]string{
+				MustInsert(t, db, schema, "01_add_table", "posts", map[string]string{
 					"title": "post by alice",
 				})
 
 				// Inserting a row that does not meet the check constraint into the old view also works.
-				MustInsert(t, db, "public", "01_add_table", "posts", map[string]string{
+				MustInsert(t, db, schema, "01_add_table", "posts", map[string]string{
 					"title": "b",
 				})
 
 				// Both rows have been backfilled into the new view; the short title has
 				// been rewritten using `up` SQL to meet the length constraint.
-				rows := MustSelect(t, db, "public", "02_add_check_constraint", "posts")
+				rows := MustSelect(t, db, schema, "02_add_check_constraint", "posts")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "title": "post by alice"},
 					{"id": 2, "title": "---b"},
 				}, rows)
 
 				// Inserting a row that meets the check constraint into the new view works.
-				MustInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+				MustInsert(t, db, schema, "02_add_check_constraint", "posts", map[string]string{
 					"title": "post by carl",
 				})
 
 				// Inserting a row that does not meet the check constraint into the new view fails.
-				MustNotInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+				MustNotInsert(t, db, schema, "02_add_check_constraint", "posts", map[string]string{
 					"title": "d",
 				}, testutils.CheckViolationErrorCode)
 
 				// The row that was inserted into the new view has been backfilled into the old view.
-				rows = MustSelect(t, db, "public", "01_add_table", "posts")
+				rows = MustSelect(t, db, schema, "01_add_table", "posts")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "title": "post by alice"},
 					{"id": 2, "title": "b"},
 					{"id": 3, "title": "post by carl"},
 				}, rows)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// The new (temporary) `title` column should not exist on the underlying table.
-				ColumnMustNotExist(t, db, "public", "posts", migrations.TemporaryName("title"))
+				ColumnMustNotExist(t, db, schema, "posts", migrations.TemporaryName("title"))
 
 				// The check constraint no longer exists.
-				CheckConstraintMustNotExist(t, db, "public", "posts", "check_title_length")
+				CheckConstraintMustNotExist(t, db, schema, "posts", "check_title_length")
 
 				// The up function no longer exists.
-				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", "title"))
+				FunctionMustNotExist(t, db, schema, migrations.TriggerFunctionName("posts", "title"))
 				// The down function no longer exists.
-				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", migrations.TemporaryName("title")))
+				FunctionMustNotExist(t, db, schema, migrations.TriggerFunctionName("posts", migrations.TemporaryName("title")))
 
 				// The up trigger no longer exists.
-				TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", "title"))
+				TriggerMustNotExist(t, db, schema, "posts", migrations.TriggerName("posts", "title"))
 				// The down trigger no longer exists.
-				TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", migrations.TemporaryName("title")))
+				TriggerMustNotExist(t, db, schema, "posts", migrations.TriggerName("posts", migrations.TemporaryName("title")))
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The check constraint exists on the new table.
-				CheckConstraintMustExist(t, db, "public", "posts", "check_title_length")
+				CheckConstraintMustExist(t, db, schema, "posts", "check_title_length")
 
 				// Inserting a row that meets the check constraint into the new view works.
-				MustInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+				MustInsert(t, db, schema, "02_add_check_constraint", "posts", map[string]string{
 					"title": "post by dana",
 				})
 
 				// Inserting a row that does not meet the check constraint into the new view fails.
-				MustNotInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+				MustNotInsert(t, db, schema, "02_add_check_constraint", "posts", map[string]string{
 					"title": "e",
 				}, testutils.CheckViolationErrorCode)
 
 				// The data in the new `posts` view is as expected.
-				rows := MustSelect(t, db, "public", "02_add_check_constraint", "posts")
+				rows := MustSelect(t, db, schema, "02_add_check_constraint", "posts")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "title": "post by alice"},
 					{"id": 2, "title": "---b"},
@@ -137,14 +137,14 @@ func TestSetCheckConstraint(t *testing.T) {
 				}, rows)
 
 				// The up function no longer exists.
-				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", "title"))
+				FunctionMustNotExist(t, db, schema, migrations.TriggerFunctionName("posts", "title"))
 				// The down function no longer exists.
-				FunctionMustNotExist(t, db, "public", migrations.TriggerFunctionName("posts", migrations.TemporaryName("title")))
+				FunctionMustNotExist(t, db, schema, migrations.TriggerFunctionName("posts", migrations.TemporaryName("title")))
 
 				// The up trigger no longer exists.
-				TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", "title"))
+				TriggerMustNotExist(t, db, schema, "posts", migrations.TriggerName("posts", "title"))
 				// The down trigger no longer exists.
-				TriggerMustNotExist(t, db, "public", "posts", migrations.TriggerName("posts", migrations.TemporaryName("title")))
+				TriggerMustNotExist(t, db, schema, "posts", migrations.TriggerName("posts", migrations.TemporaryName("title")))
 			},
 		},
 		{
@@ -186,28 +186,28 @@ func TestSetCheckConstraint(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// A row can be inserted into the new version of the table.
-				MustInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+				MustInsert(t, db, schema, "02_add_check_constraint", "posts", map[string]string{
 					"id": "1",
 				})
 
 				// The newly inserted row respects the default value of the column.
-				rows := MustSelect(t, db, "public", "02_add_check_constraint", "posts")
+				rows := MustSelect(t, db, schema, "02_add_check_constraint", "posts")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "title": "untitled"},
 				}, rows)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// A row can be inserted into the new version of the table.
-				MustInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+				MustInsert(t, db, schema, "02_add_check_constraint", "posts", map[string]string{
 					"id": "2",
 				})
 
 				// The newly inserted row respects the default value of the column.
-				rows := MustSelect(t, db, "public", "02_add_check_constraint", "posts")
+				rows := MustSelect(t, db, schema, "02_add_check_constraint", "posts")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "title": "untitled"},
 					{"id": 2, "title": "untitled"},
@@ -283,15 +283,15 @@ func TestSetCheckConstraint(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// A temporary FK constraint has been created on the temporary column
-				ValidatedForeignKeyMustExist(t, db, "public", "employees", migrations.DuplicationName("fk_employee_department"))
+				ValidatedForeignKeyMustExist(t, db, schema, "employees", migrations.DuplicationName("fk_employee_department"))
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The foreign key constraint still exists on the column
-				ValidatedForeignKeyMustExist(t, db, "public", "employees", "fk_employee_department")
+				ValidatedForeignKeyMustExist(t, db, schema, "employees", "fk_employee_department")
 			},
 		},
 		{
@@ -340,19 +340,19 @@ func TestSetCheckConstraint(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The check constraint on the `title` column still exists.
-				MustNotInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+				MustNotInsert(t, db, schema, "02_add_check_constraint", "posts", map[string]string{
 					"id":    "1",
 					"title": "a",
 					"body":  "this is the post body",
 				}, testutils.CheckViolationErrorCode)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The check constraint on the `title` column still exists.
-				MustNotInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+				MustNotInsert(t, db, schema, "02_add_check_constraint", "posts", map[string]string{
 					"id":    "2",
 					"title": "b",
 					"body":  "this is another post body",
@@ -398,17 +398,17 @@ func TestSetCheckConstraint(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// Inserting a row that violates the NOT NULL constraint on `title` fails.
-				MustNotInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+				MustNotInsert(t, db, schema, "02_add_check_constraint", "posts", map[string]string{
 					"id": "1",
 				}, testutils.NotNullViolationErrorCode)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// Inserting a row that violates the NOT NULL constraint on `title` fails.
-				MustNotInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+				MustNotInsert(t, db, schema, "02_add_check_constraint", "posts", map[string]string{
 					"id": "1",
 				}, testutils.NotNullViolationErrorCode)
 			},
@@ -452,27 +452,27 @@ func TestSetCheckConstraint(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// Inserting an initial row succeeds
-				MustInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+				MustInsert(t, db, schema, "02_add_check_constraint", "posts", map[string]string{
 					"title": "post by alice",
 				})
 
 				// Inserting a row with a duplicate `title` value fails
-				MustNotInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+				MustNotInsert(t, db, schema, "02_add_check_constraint", "posts", map[string]string{
 					"title": "post by alice",
 				}, testutils.UniqueViolationErrorCode)
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// Inserting a row with a duplicate `title` value fails
-				MustNotInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+				MustNotInsert(t, db, schema, "02_add_check_constraint", "posts", map[string]string{
 					"title": "post by alice",
 				}, testutils.UniqueViolationErrorCode)
 
 				// Inserting a row with a different `title` value succeeds
-				MustInsert(t, db, "public", "02_add_check_constraint", "posts", map[string]string{
+				MustInsert(t, db, schema, "02_add_check_constraint", "posts", map[string]string{
 					"title": "post by bob",
 				})
 			},

--- a/pkg/migrations/op_set_replica_identity_test.go
+++ b/pkg/migrations/op_set_replica_identity_test.go
@@ -48,14 +48,14 @@ func TestSetReplicaIdentity(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The replica identity has been set to 'f' (full).
-				ReplicaIdentityMustBe(t, db, "public", "users", "f")
+				ReplicaIdentityMustBe(t, db, schema, "users", "f")
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// Rollback is a no-op
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// Complete is a no-op
 			},
 		},
@@ -73,14 +73,14 @@ func TestSetReplicaIdentity(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The replica identity has been set to 'n' (nothing).
-				ReplicaIdentityMustBe(t, db, "public", "users", "n")
+				ReplicaIdentityMustBe(t, db, schema, "users", "n")
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// Rollback is a no-op
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// Complete is a no-op
 			},
 		},
@@ -98,14 +98,14 @@ func TestSetReplicaIdentity(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The replica identity has been set to 'd' (default).
-				ReplicaIdentityMustBe(t, db, "public", "users", "d")
+				ReplicaIdentityMustBe(t, db, schema, "users", "d")
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// Rollback is a no-op
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// Complete is a no-op
 			},
 		},
@@ -126,14 +126,14 @@ func TestSetReplicaIdentity(t *testing.T) {
 					},
 				},
 			},
-			afterStart: func(t *testing.T, db *sql.DB) {
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The replica identity has been set to 'i' (index).
-				ReplicaIdentityMustBe(t, db, "public", "users", "i")
+				ReplicaIdentityMustBe(t, db, schema, "users", "i")
 			},
-			afterRollback: func(t *testing.T, db *sql.DB) {
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// Rollback is a no-op
 			},
-			afterComplete: func(t *testing.T, db *sql.DB) {
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// Complete is a no-op
 			},
 		},

--- a/pkg/testutils/util.go
+++ b/pkg/testutils/util.go
@@ -75,6 +75,16 @@ func SharedTestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
+// TestSchema returns the schema in which migration tests apply migrations. By
+// default, migrations will be applied to the "public" schema.
+func TestSchema() string {
+	testSchema := os.Getenv("PGROLL_TEST_SCHEMA")
+	if testSchema != "" {
+		return testSchema
+	}
+	return "public"
+}
+
 func WithStateAndConnectionToContainer(t *testing.T, fn func(*state.State, *sql.DB)) {
 	t.Helper()
 	ctx := context.Background()


### PR DESCRIPTION
Parameterize the migration tests so that the schema in which migrations are applied is taken from the `PGROLL_TEST_SCHEMA` environment variable, or `public` if unset.

#273 highlights an area in which there is a lack of test coverage: migration tests apply migrations only in the `public` schema. #273 is an error that is only reproducible when running migrations in a non-`public` schema and there are currently also other problems with migration validation in non-`public` schema.

This PR makes repetitive changes to all tests:
* Update the `afterStart`, `afterComplete` and `afterRollback` hooks to take a `schema string` parameter.
* Update all hard-coded occurences of `"public"` in those hooks with the `schema` parameter.

Later PRs will fix the issues with running migrations in non-`public` schema and run non-`public` migration tests in CI. For now, to run migration tests in a non-`public` schema run:

```
PGROLL_TEST_SCHEMA=foo go test ./...
```

Part of https://github.com/xataio/pgroll/issues/273

