### PR TITLE
Strengthen assertions for tests that check preservation of `UNIQUE` constraints

### DIFF
--- a/pkg/migrations/op_set_notnull_test.go
+++ b/pkg/migrations/op_set_notnull_test.go
@@ -438,14 +438,25 @@ func TestSetNotNull(t *testing.T) {
 									Name:     "name",
 									Type:     "text",
 									Nullable: ptr(true),
-									Unique:   ptr(true),
 								},
 							},
 						},
 					},
 				},
 				{
-					Name: "02_set_not_null",
+					Name: "02_set_unique",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:  "users",
+							Column: "name",
+							Unique: &migrations.UniqueConstraint{Name: "unique_name"},
+							Up:     ptr("name"),
+							Down:   ptr("name"),
+						},
+					},
+				},
+				{
+					Name: "03_set_not_null",
 					Operations: migrations.Operations{
 						&migrations.OpAlterColumn{
 							Table:    "users",
@@ -458,25 +469,28 @@ func TestSetNotNull(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// Inserting an initial row succeeds
-				MustInsert(t, db, schema, "02_set_not_null", "users", map[string]string{
+				MustInsert(t, db, schema, "03_set_not_null", "users", map[string]string{
 					"name": "alice",
 				})
 
 				// Inserting a row with a duplicate `name` value fails
-				MustNotInsert(t, db, schema, "02_set_not_null", "users", map[string]string{
+				MustNotInsert(t, db, schema, "03_set_not_null", "users", map[string]string{
 					"name": "alice",
 				}, testutils.UniqueViolationErrorCode)
 			},
 			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
 			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+				// The table has a unique constraint defined on it
+				UniqueConstraintMustExist(t, db, schema, "users", "unique_name")
+
 				// Inserting a row with a duplicate `name` value fails
-				MustNotInsert(t, db, schema, "02_set_not_null", "users", map[string]string{
+				MustNotInsert(t, db, schema, "03_set_not_null", "users", map[string]string{
 					"name": "alice",
 				}, testutils.UniqueViolationErrorCode)
 
 				// Inserting a row with a different `name` value succeeds
-				MustInsert(t, db, schema, "02_set_not_null", "users", map[string]string{
+				MustInsert(t, db, schema, "03_set_not_null", "users", map[string]string{
 					"name": "bob",
 				})
 			},


### PR DESCRIPTION
Strengthen the tests that check for preservation of `UNIQUE` constraints when a column is duplicated so that they can check for the failure case in #273.

It's not enough to test that the column does not accept duplicate values after the migration completes. Both a unique index and a unique constraint will have that effect but we need to ensure that the **constraint** is present on the table once the migration completes.

Duplicating a `UNIQUE` constraint is a two-step process, first creating a `UNIQUE` index on migration start and then upgrading the index to a constraint on migration completion. #273 occurs when this upgrade fails and the column is left with the unique index but not the constraint. Subsequent migrations will then fail to duplicate the non-existent unique constraint.

Part of #273 