### PR TITLE
Strip schema from index names in internal schema representation

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -167,14 +167,14 @@ BEGIN
 						AND indisprimary
 				),
 				'indexes', (
-				  SELECT COALESCE(json_object_agg(ix_details.indexrelid::regclass, json_build_object(
-				    'name', ix_details.indexrelid::regclass,
+				  SELECT COALESCE(json_object_agg(ix_details.name, json_build_object(
+				    'name', ix_details.name,
 				    'unique', ix_details.indisunique,
 				    'columns', ix_details.columns
 				  )), '{}'::json)
 				  FROM (
 				    SELECT 
-				      pi.indexrelid, 
+				      reverse(split_part(reverse(pi.indexrelid::regclass::text), '.', 1)) as name,
 				      pi.indisunique,
 				      array_agg(a.attname) AS columns
 				    FROM pg_index pi


### PR DESCRIPTION
Remove the schema component from index names in the internal schema representation.

A `pgroll` migration is always run in the context of a a specific schema so the extra qualification is redundant.

Removing the schema component from the index names makes it easy to identify duplicated indexes by name when temporary columns and associated attributes are renamed on migration completion.

Tests for this change are already in place (#276, #277). As of this PR, migration tests run in a non-public schema will pass:

```bash
PGROLL_TEST_SCHEMA=foo go test ./...
```

Part of #273 