### PR TITLE
Run migration tests in a non-`public` schema as part of CI

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -73,14 +73,22 @@ branches:
 
       # Required. The list of status checks to require in order to merge into this branch
       contexts:
-      - test (postgres 14.8)
-      - test (postgres 15.3)
-      - test (postgres 16.0)
-      - test (postgres latest)
-      - examples (postgres 14.8)
-      - examples (postgres 15.3)
-      - examples (postgres 16.0)
-      - examples (postgres latest)
+      - test (pg: 14.8, schema: public)
+      - test (pg: 15.3, schema: public)
+      - test (pg: 16.0, schema: public)
+      - test (pg: latest, schema: public)
+      - test (pg: 14.8, schema: non_public)
+      - test (pg: 15.3, schema: non_public)
+      - test (pg: 16.0, schema: non_public)
+      - test (pg: latest, schema: non_public)
+      - examples (pg: 14.8, schema: public)
+      - examples (pg: 15.3, schema: public)
+      - examples (pg: 16.0, schema: public)
+      - examples (pg: latest, schema: public)
+      - examples (pg: 14.8, schema: non_public)
+      - examples (pg: 15.3, schema: non_public)
+      - examples (pg: 16.0, schema: non_public)
+      - examples (pg: latest, schema: non_public)
       - lint
 
     # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,12 @@ permissions:
   packages: write
 jobs:
   test:
-    name: test (postgres ${{ matrix.pgVersion }})
+    name: 'test (pg: ${{ matrix.pgVersion }}, schema: ${{ matrix.testSchema }})'
     runs-on: ubuntu-latest
     strategy:
       matrix:
         pgVersion: ['14.8', '15.3', '16.0', 'latest']
+        testSchema: [ 'public', 'non_public' ]
     steps:
     - uses: actions/checkout@v4
 
@@ -22,6 +23,7 @@ jobs:
       run: go test ./...
       env:
         POSTGRES_VERSION: ${{ matrix.pgVersion }}
+        PGROLL_TEST_SCHEMA: ${{ matrix.testSchema }}
 
   lint:
     name: lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,12 +113,13 @@ jobs:
           ./bin/license-header-checker -a -r .github/license-header.txt . go && [[ -z `git status -s` ]]
 
   examples:
-    name: examples (postgres ${{ matrix.pgVersion }})
+    name: 'examples (pg: ${{ matrix.pgVersion }}, schema: ${{ matrix.testSchema }})'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         pgVersion: ['14.8', '15.3', '16.0', 'latest']
+        testSchema: [ 'public', 'non_public' ]
     services:
       postgres:
         image: postgres:${{ matrix.pgVersion }}
@@ -141,12 +142,21 @@ jobs:
 
     - name: Run example migrations
       run: |
+        if [ "$PGROLL_SCHEMA" != "public" ]; then
+          psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U postgres -c "CREATE SCHEMA $PGROLL_SCHEMA;"
+        fi
+
         go run . init
         for file in ./examples/*.json; do
           if [ -f "$file" ]; then
             go run . start --complete $file;
           fi
         done
+      env:
+        POSTGRES_PORT: 5432
+        POSTGRES_HOST: localhost
+        PGPASSWORD: postgres
+        PGROLL_SCHEMA: ${{ matrix.testSchema }}
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ jobs:
     name: 'test (pg: ${{ matrix.pgVersion }}, schema: ${{ matrix.testSchema }})'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         pgVersion: ['14.8', '15.3', '16.0', 'latest']
         testSchema: [ 'public', 'non_public' ]


### PR DESCRIPTION
Add another dimension to the test matrix so that migration tests are run in both the `public` and a non-`public` schema.

https://github.com/xataio/pgroll/pull/276 made it possible to run migration tests in schema other than `public`. Doing so highlighted some issues that are fixed by https://github.com/xataio/pgroll/pull/278.

Fixes #273.