### PR TITLE
Make state initialization concurrency safe

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -354,11 +354,26 @@ func New(ctx context.Context, pgURL, stateSchema string) (*State, error) {
 }
 
 func (s *State) Init(ctx context.Context) error {
-	// ensure pgroll internal tables exist
-	// TODO: eventually use migrations for this instead of hardcoding
-	_, err := s.pgConn.ExecContext(ctx, fmt.Sprintf(sqlInit, pq.QuoteIdentifier(s.schema)))
+	tx, err := s.pgConn.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
 
-	return err
+	// Try to obtain an advisory lock
+	const key int64 = 0x2c03057fb9525b
+	_, err = tx.ExecContext(ctx, "SELECT pg_advisory_xact_lock($1)", key)
+	if err != nil {
+		return err
+	}
+
+	// Perform pgroll state initialization
+	_, err = tx.ExecContext(ctx, fmt.Sprintf(sqlInit, pq.QuoteIdentifier(s.schema)))
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit()
 }
 
 func (s *State) Close() error {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -360,7 +360,9 @@ func (s *State) Init(ctx context.Context) error {
 	}
 	defer tx.Rollback()
 
-	// Try to obtain an advisory lock
+	// Try to obtain an advisory lock.
+	// The key is an arbitrary number, used to distinguish the lock from other locks.
+	// The lock is automatically released when the transaction is committed or rolled back.
 	const key int64 = 0x2c03057fb9525b
 	_, err = tx.ExecContext(ctx, "SELECT pg_advisory_xact_lock($1)", key)
 	if err != nil {


### PR DESCRIPTION
Make `pgroll` state initialization concurrency safe by using Postgres advisory locking to ensure at most one connection can initialize at at time.

See docs on Postgres advisory locking:
* https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS
* https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS

Closes https://github.com/xataio/pgroll/issues/283