### PR TITLE
Relax add_column requirements on pk

### DIFF
--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -164,10 +164,12 @@ func (o *OpAddColumn) Validate(ctx context.Context, s *schema.Schema) error {
 		}
 	}
 
-	// Ensure that the column has a primary key defined on exactly one column.
-	pk := table.GetPrimaryKey()
-	if len(pk) != 1 {
-		return InvalidPrimaryKeyError{Table: o.Table, Fields: len(pk)}
+	if o.Up != nil {
+		// needs backfill, ensure that the table has a primary key defined on exactly one column.
+		pk := table.GetPrimaryKey()
+		if len(pk) != 1 {
+			return InvalidPrimaryKeyError{Table: o.Table, Fields: len(pk)}
+		}
 	}
 
 	if !o.Column.IsNullable() && o.Column.Default == nil && o.Up == nil {

--- a/pkg/migrations/op_add_column_test.go
+++ b/pkg/migrations/op_add_column_test.go
@@ -694,7 +694,7 @@ func TestAddColumnValidation(t *testing.T) {
 						&migrations.OpAddColumn{
 							Table: "orders",
 							Column: migrations.Column{
-								Default: ptr("foo"),
+								Default: ptr("'foo'"),
 								Name:    "description",
 								Type:    "text",
 							},

--- a/pkg/migrations/op_add_column_test.go
+++ b/pkg/migrations/op_add_column_test.go
@@ -649,7 +649,7 @@ func TestAddColumnValidation(t *testing.T) {
 			wantStartErr: migrations.FieldRequiredError{Name: "up"},
 		},
 		{
-			name: "table must have a primary key on exactly one column",
+			name: "table must have a primary key on exactly one column if up is defined",
 			migrations: []migrations.Migration{
 				{
 					Name: "01_add_table",
@@ -675,6 +675,34 @@ func TestAddColumnValidation(t *testing.T) {
 				},
 			},
 			wantStartErr: migrations.InvalidPrimaryKeyError{Table: "orders", Fields: 2},
+		},
+		{
+			name: "table has no restrictions on primary keys if up is not defined",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpRawSQL{
+							Up:   "CREATE TABLE orders(id integer, order_id integer, name text, primary key (id, order_id))",
+							Down: "DROP TABLE orders",
+						},
+					},
+				},
+				{
+					Name: "02_add_column",
+					Operations: migrations.Operations{
+						&migrations.OpAddColumn{
+							Table: "orders",
+							Column: migrations.Column{
+								Default: ptr("foo"),
+								Name:    "description",
+								Type:    "text",
+							},
+						},
+					},
+				},
+			},
+			wantStartErr: nil,
 		},
 	})
 }


### PR DESCRIPTION
Primary keys are only required by pgroll when backfilling tables, relax checks in the `add_column` op so we only require a present PK if backfill will be needed (up function defined).