### PR TITLE
Bump `golangci-lint` action to `v4`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         go-version-file: 'go.mod'
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v4
       with:
         # Require: The version of golangci-lint to use.
         # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
+        cache: false
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v4


### PR DESCRIPTION
Bump the `golangci-lint` action to `v4` and stop using the cache from `setup-go` as `golangci-lint` manages its own cache.

This removes all warnings from the summary page from workflow runs.