### PR TITLE
Relax backfill requirements so it works with unique columns

### DIFF
--- a/pkg/migrations/backfill.go
+++ b/pkg/migrations/backfill.go
@@ -20,15 +20,15 @@ import (
 // 4. Repeat steps 2 and 3 until no more rows are returned.
 func backfill(ctx context.Context, conn *sql.DB, table *schema.Table, cbs ...CallbackFn) error {
 	// get the backfill column
-	pk := getBackfillColumn(table)
-	if pk == nil {
+	backFillColumn := getBackfillColumn(table)
+	if backFillColumn == nil {
 		return BackfillNotPossible{Table: table.Name}
 	}
 
 	// Create a batcher for the table.
 	b := batcher{
 		table:          table,
-		backfillColumn: pk,
+		backfillColumn: backFillColumn,
 		lastValue:      nil,
 		batchSize:      1000,
 	}

--- a/pkg/migrations/errors.go
+++ b/pkg/migrations/errors.go
@@ -157,13 +157,12 @@ func (e MultipleAlterColumnChangesError) Error() string {
 	return fmt.Sprintf("alter column operations require exactly one change, found %d", e.Changes)
 }
 
-type InvalidPrimaryKeyError struct {
-	Table  string
-	Fields int
+type BackfillNotPossible struct {
+	Table string
 }
 
-func (e InvalidPrimaryKeyError) Error() string {
-	return fmt.Sprintf("primary key on table %q must be defined on exactly one column, found %d", e.Table, e.Fields)
+func (e BackfillNotPossible) Error() string {
+	return fmt.Sprintf("backfills is required but table %q doesn't have a suitable column for backfill, single column primary key or unique not null colum is required", e.Table)
 }
 
 type InvalidReplicaIdentityError struct {

--- a/pkg/migrations/errors.go
+++ b/pkg/migrations/errors.go
@@ -157,12 +157,12 @@ func (e MultipleAlterColumnChangesError) Error() string {
 	return fmt.Sprintf("alter column operations require exactly one change, found %d", e.Changes)
 }
 
-type BackfillNotPossible struct {
+type BackfillNotPossibleError struct {
 	Table string
 }
 
-func (e BackfillNotPossible) Error() string {
-	return fmt.Sprintf("backfills is required but table %q doesn't have a suitable column for backfill, single column primary key or unique not null colum is required", e.Table)
+func (e BackfillNotPossibleError) Error() string {
+	return fmt.Sprintf("a backfill is required but table %q doesn't have a single column primary key or a UNIQUE, NOT NULL column", e.Table)
 }
 
 type InvalidReplicaIdentityError struct {

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -164,10 +164,12 @@ func (o *OpAddColumn) Validate(ctx context.Context, s *schema.Schema) error {
 		}
 	}
 
-	// Ensure that the column has a primary key defined on exactly one column.
-	pk := table.GetPrimaryKey()
-	if len(pk) != 1 {
-		return InvalidPrimaryKeyError{Table: o.Table, Fields: len(pk)}
+	// Ensure backfill is possible
+	if o.Up != nil {
+		err := checkBackfill(table)
+		if err != nil {
+			return err
+		}
 	}
 
 	if !o.Column.IsNullable() && o.Column.Default == nil && o.Up == nil {

--- a/pkg/migrations/op_add_column_test.go
+++ b/pkg/migrations/op_add_column_test.go
@@ -674,7 +674,7 @@ func TestAddColumnValidation(t *testing.T) {
 					},
 				},
 			},
-			wantStartErr: migrations.InvalidPrimaryKeyError{Table: "orders", Fields: 2},
+			wantStartErr: migrations.BackfillNotPossible{Table: "orders"},
 		},
 	})
 }

--- a/pkg/migrations/op_add_column_test.go
+++ b/pkg/migrations/op_add_column_test.go
@@ -849,6 +849,7 @@ func TestAddColumnValidation(t *testing.T) {
 					Operations: migrations.Operations{
 						&migrations.OpAddColumn{
 							Table: "users",
+							Up:    ptr("UPPER(name)"),
 							Column: migrations.Column{
 								Default: ptr("'foo'"),
 								Name:    "description",
@@ -861,7 +862,7 @@ func TestAddColumnValidation(t *testing.T) {
 			wantStartErr: migrations.BackfillNotPossibleError{Table: "users"},
 		},
 		{
-			name: "table must have a primary key on exactly one column or a unique not null if up is defined",
+			name: "table with a unique not null column can be backfilled",
 			migrations: []migrations.Migration{
 				addTableMigrationNoPKNotNull,
 				{
@@ -869,6 +870,7 @@ func TestAddColumnValidation(t *testing.T) {
 					Operations: migrations.Operations{
 						&migrations.OpAddColumn{
 							Table: "users",
+							Up:    ptr("UPPER(name)"),
 							Column: migrations.Column{
 								Default: ptr("'foo'"),
 								Name:    "description",

--- a/pkg/migrations/op_add_column_test.go
+++ b/pkg/migrations/op_add_column_test.go
@@ -766,7 +766,7 @@ func TestAddColumnValidation(t *testing.T) {
 					},
 				},
 			},
-			wantStartErr: migrations.BackfillNotPossible{Table: "orders"},
+			wantStartErr: migrations.BackfillNotPossibleError{Table: "orders"},
 		},
 		{
 			name: "table has no restrictions on primary keys if up is not defined",

--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -45,9 +45,9 @@ func (o *OpAlterColumn) Validate(ctx context.Context, s *schema.Schema) error {
 	}
 
 	// Ensure that the column has a primary key defined on exactly one column.
-	pk := table.GetPrimaryKey()
-	if len(pk) != 1 {
-		return InvalidPrimaryKeyError{Table: o.Table, Fields: len(pk)}
+	err := checkBackfill(table)
+	if err != nil {
+		return err
 	}
 
 	// Apply any special validation rules for the inner operation

--- a/pkg/migrations/op_alter_column_test.go
+++ b/pkg/migrations/op_alter_column_test.go
@@ -177,7 +177,7 @@ func TestAlterColumnValidation(t *testing.T) {
 					},
 				},
 			},
-			wantStartErr: migrations.BackfillNotPossible{Table: "orders"},
+			wantStartErr: migrations.BackfillNotPossibleError{Table: "orders"},
 		},
 	})
 }

--- a/pkg/migrations/op_alter_column_test.go
+++ b/pkg/migrations/op_alter_column_test.go
@@ -177,7 +177,7 @@ func TestAlterColumnValidation(t *testing.T) {
 					},
 				},
 			},
-			wantStartErr: migrations.InvalidPrimaryKeyError{Table: "orders", Fields: 2},
+			wantStartErr: migrations.BackfillNotPossible{Table: "orders"},
 		},
 	})
 }

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -131,7 +131,7 @@ BEGIN
 								SELECT 1
 								FROM pg_constraint
 								WHERE conrelid = attr.attrelid
-								AND conkey::int[] @> ARRAY[attr.attnum::int]
+								AND ARRAY[attr.attnum::int] @> conkey::int[]
 								AND contype = 'u'
 							) OR EXISTS (
 								SELECT 1
@@ -139,7 +139,7 @@ BEGIN
 								JOIN pg_class ON pg_class.oid = pg_index.indexrelid
 								WHERE indrelid = attr.attrelid
 								AND indisunique
-								AND pg_index.indkey::int[] @> ARRAY[attr.attnum::int]
+								AND ARRAY[attr.attnum::int] @> pg_index.indkey::int[]
 							)) AS unique
 						FROM
 							pg_attribute AS attr

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -407,6 +407,53 @@ func TestReadSchema(t *testing.T) {
 				},
 			},
 			{
+				name:       "multicolumn unique constraint",
+				createStmt: "CREATE TABLE public.table1 (id int PRIMARY KEY, name TEXT, CONSTRAINT name_id_unique UNIQUE(id, name));",
+				wantSchema: &schema.Schema{
+					Name: "public",
+					Tables: map[string]schema.Table{
+						"table1": {
+							Name: "table1",
+							Columns: map[string]schema.Column{
+								"id": {
+									Name:     "id",
+									Type:     "integer",
+									Nullable: false,
+									Unique:   true,
+								},
+								"name": {
+									Name:     "name",
+									Type:     "text",
+									Nullable: true,
+									Unique:   false,
+								},
+							},
+							PrimaryKey: []string{"id"},
+							Indexes: map[string]schema.Index{
+								"table1_pkey": {
+									Name:    "table1_pkey",
+									Unique:  true,
+									Columns: []string{"id"},
+								},
+								"name_id_unique": {
+									Name:    "name_id_unique",
+									Unique:  true,
+									Columns: []string{"id", "name"},
+								},
+							},
+							ForeignKeys:      map[string]schema.ForeignKey{},
+							CheckConstraints: map[string]schema.CheckConstraint{},
+							UniqueConstraints: map[string]schema.UniqueConstraint{
+								"name_id_unique": {
+									Name:    "name_id_unique",
+									Columns: []string{"id", "name"},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
 				name:       "multi-column index",
 				createStmt: "CREATE TABLE public.table1 (a text, b text); CREATE INDEX idx_ab ON public.table1 (a, b);",
 				wantSchema: &schema.Schema{


### PR DESCRIPTION
UNIQUE NOT NULL columns should also work in order to perform backfills. This change relaxes the check on backfill requirements to use those columns if a primary key is not available.

Validation will still error out if no suitable column is found

Note: this also fixes the `unique` retrieval from schema, where we were failing to understand composed unique indices, resulting in columns flagged as unique where they weren't really unique.