### PR TITLE
Add two new options to help with replication control

### DIFF
--- a/pkg/roll/options.go
+++ b/pkg/roll/options.go
@@ -14,6 +14,10 @@ type options struct {
 
 	// a map of setting/value pairs to be set for the duration of migration start
 	settingsOnMigrationStart map[string]string
+
+	// whether to make a no-op schema change in between completing the DDL
+	// operations for migration start and performing backfills
+	kickstartReplication bool
 }
 
 type Option func(*options)
@@ -46,5 +50,15 @@ func WithDisableViewsManagement() Option {
 func WithSettingsOnMigrationStart(settings map[string]string) Option {
 	return func(o *options) {
 		o.settingsOnMigrationStart = settings
+	}
+}
+
+// WithKickstartReplication defines an option that when set will make a no-op
+// schema change in between completing the DDL operations for migration start
+// and performing backfills. This can be used to ensure that schema replication
+// is up-to-date before starting backfills.
+func WithKickstartReplication() Option {
+	return func(o *options) {
+		o.kickstartReplication = true
 	}
 }

--- a/pkg/roll/options.go
+++ b/pkg/roll/options.go
@@ -11,6 +11,9 @@ type options struct {
 
 	// disable pgroll version schemas creation and deletion
 	disableVersionSchemas bool
+
+	// a map of setting/value pairs to be set for the duration of migration start
+	settingsOnMigrationStart map[string]string
 }
 
 type Option func(*options)
@@ -34,5 +37,14 @@ func WithRole(role string) Option {
 func WithDisableViewsManagement() Option {
 	return func(o *options) {
 		o.disableVersionSchemas = true
+	}
+}
+
+// WithSettingsOnMigrationStart defines a map of Postgres setting/value pairs
+// to be set for the duration of the DDL phase of migration start. Settings
+// will be restored to their previous values once the DDL phase is complete.
+func WithSettingsOnMigrationStart(settings map[string]string) Option {
+	return func(o *options) {
+		o.settingsOnMigrationStart = settings
 	}
 }

--- a/pkg/roll/roll.go
+++ b/pkg/roll/roll.go
@@ -25,6 +25,9 @@ type Roll struct {
 	// disable pgroll version schemas creation and deletion
 	disableVersionSchemas bool
 
+	// a map of setting/value pairs to be set for the duration of migration start
+	settingsOnMigrationStart map[string]string
+
 	state     *state.State
 	pgVersion PGVersion
 }
@@ -77,11 +80,12 @@ func New(ctx context.Context, pgURL, schema string, state *state.State, opts ...
 	}
 
 	return &Roll{
-		pgConn:                conn,
-		schema:                schema,
-		state:                 state,
-		pgVersion:             PGVersion(pgMajorVersion),
-		disableVersionSchemas: options.disableVersionSchemas,
+		pgConn:                   conn,
+		schema:                   schema,
+		state:                    state,
+		pgVersion:                PGVersion(pgMajorVersion),
+		disableVersionSchemas:    options.disableVersionSchemas,
+		settingsOnMigrationStart: options.settingsOnMigrationStart,
 	}, nil
 }
 

--- a/pkg/roll/roll.go
+++ b/pkg/roll/roll.go
@@ -28,6 +28,10 @@ type Roll struct {
 	// a map of setting/value pairs to be set for the duration of migration start
 	settingsOnMigrationStart map[string]string
 
+	// whether to make a no-op schema change in between completing the DDL
+	// operations for migration start and performing backfills
+	kickstartReplication bool
+
 	state     *state.State
 	pgVersion PGVersion
 }
@@ -86,6 +90,7 @@ func New(ctx context.Context, pgURL, schema string, state *state.State, opts ...
 		pgVersion:                PGVersion(pgMajorVersion),
 		disableVersionSchemas:    options.disableVersionSchemas,
 		settingsOnMigrationStart: options.settingsOnMigrationStart,
+		kickstartReplication:     options.kickstartReplication,
 	}, nil
 }
 


### PR DESCRIPTION
Add two new migration options:

* `WithSettingsOnMigrationStart`: defines a map of Postgres setting/value pairs to be set for the duration of the DDL phase of migration start. Settings will be restored to their previous values once the DDL phase is complete.
* `WithKickstartReplication`: defines an option that when set will make a no-op schema change in between completing the DDL operations for migration start and performing backfills. This can be used to ensure that schema replication is up-to-date before starting backfills.

Neither of these options are exposed via the CLI; they are intended for use by `pgroll` integrators, ie modules using `pgroll` as a Go dependency.