### PR TITLE
Add support for `onDelete` reference

### DIFF
--- a/pkg/migrations/errors.go
+++ b/pkg/migrations/errors.go
@@ -173,3 +173,12 @@ type InvalidReplicaIdentityError struct {
 func (e InvalidReplicaIdentityError) Error() string {
 	return fmt.Sprintf("replica identity on table %q must be one of 'NOTHING', 'DEFAULT', 'INDEX' or 'FULL', found %q", e.Table, e.Identity)
 }
+
+type InvalidEnumValueError struct {
+	Property string
+	Value    string
+}
+
+func (e InvalidEnumValueError) Error() string {
+	return fmt.Sprintf("invalid value for %q: %q", e.Property, e.Value)
+}

--- a/pkg/migrations/fk_reference.go
+++ b/pkg/migrations/fk_reference.go
@@ -19,5 +19,11 @@ func (f *ForeignKeyReference) Validate(s *schema.Schema) error {
 		return ColumnDoesNotExistError{Table: f.Table, Name: f.Column}
 	}
 
+	if f.OnDelete != nil {
+		if *f.OnDelete != ForeignKeyReferenceOnDeleteNOACTION && *f.OnDelete != ForeignKeyReferenceOnDeleteRESTRICT && *f.OnDelete != ForeignKeyReferenceOnDeleteCASCADE && *f.OnDelete != ForeignKeyReferenceOnDeleteSETNULL && *f.OnDelete != ForeignKeyReferenceOnDeleteSETDEFAULT {
+			return InvalidEnumValueError{Property: "onDelete", Value: string(*f.OnDelete)}
+		}
+	}
+
 	return nil
 }

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -134,6 +134,10 @@ func ColumnToSQL(col Column) string {
 			pq.QuoteIdentifier(col.References.Name),
 			pq.QuoteIdentifier(col.References.Table),
 			pq.QuoteIdentifier(col.References.Column))
+
+		if col.References.OnDelete != nil {
+			sql += fmt.Sprintf(" ON DELETE %s", *col.References.OnDelete)
+		}
 	}
 	if col.Check != nil {
 		sql += fmt.Sprintf(" CONSTRAINT %s CHECK (%s)",

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -50,9 +50,20 @@ type ForeignKeyReference struct {
 	// Name of the foreign key constraint
 	Name string `json:"name"`
 
+	// Action to perform when the referenced row is deleted
+	OnDelete *ForeignKeyReferenceOnDelete `json:"onDelete,omitempty"`
+
 	// Name of the referenced table
 	Table string `json:"table"`
 }
+
+type ForeignKeyReferenceOnDelete string
+
+const ForeignKeyReferenceOnDeleteCASCADE ForeignKeyReferenceOnDelete = "CASCADE"
+const ForeignKeyReferenceOnDeleteNOACTION ForeignKeyReferenceOnDelete = "NO ACTION"
+const ForeignKeyReferenceOnDeleteRESTRICT ForeignKeyReferenceOnDelete = "RESTRICT"
+const ForeignKeyReferenceOnDeleteSETDEFAULT ForeignKeyReferenceOnDelete = "SET DEFAULT"
+const ForeignKeyReferenceOnDeleteSETNULL ForeignKeyReferenceOnDelete = "SET NULL"
 
 // Add column operation
 type OpAddColumn struct {

--- a/schema.json
+++ b/schema.json
@@ -80,6 +80,17 @@
         "table": {
           "description": "Name of the referenced table",
           "type": "string"
+        },
+        "onDelete": {
+          "description": "Action to perform when the referenced row is deleted",
+          "type": "string",
+          "enum": [
+            "NO ACTION",
+            "RESTRICT",
+            "CASCADE",
+            "SET NULL",
+            "SET DEFAULT"
+          ]
         }
       },
       "required": ["column", "name", "table"],
@@ -155,11 +166,11 @@
         {
           "required": ["up", "down"],
           "oneOf": [
-            {"required": ["check"]},
-            {"required": ["type"]},
-            {"required": ["nullable"]},
-            {"required": ["unique"]},
-            {"required": ["references"]}
+            { "required": ["check"] },
+            { "required": ["type"] },
+            { "required": ["nullable"] },
+            { "required": ["unique"] },
+            { "required": ["references"] }
           ],
           "not": {
             "required": ["name"]
@@ -169,13 +180,13 @@
           "required": ["name"],
           "not": {
             "anyOf": [
-              { "required": [ "up" ] },
-              { "required": [ "down" ] },
-              { "required": [ "check" ] },
-              { "required": [ "type" ] },
-              { "required": [ "nullable" ] },
-              { "required": [ "unique" ] },
-              { "required": [ "references" ] }
+              { "required": ["up"] },
+              { "required": ["down"] },
+              { "required": ["check"] },
+              { "required": ["type"] },
+              { "required": ["nullable"] },
+              { "required": ["unique"] },
+              { "required": ["references"] }
             ]
           }
         }


### PR DESCRIPTION
Fixes #221 

@andrew-farries I'm not sure if you finally implemented it, If you have something in the works please close this PR as yours will likely be better than mine.

The `enum` parsing could be way better, but `omissis/go-jsonschema` doesn't generate much without going all-in with their validator, and even with that it's behind `enumer` or `validator`. I decided to manually check for the values, but I'd be fine with not checking it at all or adding some better enum validator.