### PR TITLE
Add `Roll.Schema` method

### DIFF
--- a/pkg/roll/execute_test.go
+++ b/pkg/roll/execute_test.go
@@ -535,6 +535,22 @@ func TestMigrationHooksAreInvoked(t *testing.T) {
 	})
 }
 
+func TestRollSchemaMethodReturnsCorrectSchema(t *testing.T) {
+	t.Parallel()
+
+	t.Run("when the schema is public", func(t *testing.T) {
+		testutils.WithMigratorInSchemaAndConnectionToContainer(t, "public", func(mig *roll.Roll, _ *sql.DB) {
+			assert.Equal(t, "public", mig.Schema())
+		})
+	})
+
+	t.Run("when the schema is non-public", func(t *testing.T) {
+		testutils.WithMigratorInSchemaAndConnectionToContainer(t, "apples", func(mig *roll.Roll, _ *sql.DB) {
+			assert.Equal(t, "apples", mig.Schema())
+		})
+	})
+}
+
 func createTableOp(tableName string) *migrations.OpCreateTable {
 	return &migrations.OpCreateTable{
 		Name: tableName,

--- a/pkg/roll/roll.go
+++ b/pkg/roll/roll.go
@@ -99,6 +99,10 @@ func (m *Roll) PgConn() *sql.DB {
 	return m.pgConn
 }
 
+func (m *Roll) Schema() string {
+	return m.schema
+}
+
 func (m *Roll) Status(ctx context.Context, schema string) (*state.Status, error) {
 	return m.state.Status(ctx, schema)
 }


### PR DESCRIPTION
Having access to the name of the schema in which a migration is being applied is useful when writing migration hooks.

