### PR TITLE
Add `rename_constraint` operation to `PgRollOperation` JSON schema definition

### DIFF
--- a/pkg/jsonschema/testdata/rename-constraint-1.txtar
+++ b/pkg/jsonschema/testdata/rename-constraint-1.txtar
@@ -1,0 +1,18 @@
+This is a valid 'rename constraint' migration.
+
+-- rename_constraint.json --
+{
+  "name": "migration_name",
+  "operations": [
+    {
+      "rename_constraint": {
+        "table": "people",
+        "from": "name_length",
+        "to": "name_length_check"
+      }
+    }
+  ]
+}
+
+-- valid --
+true

--- a/schema.json
+++ b/schema.json
@@ -470,6 +470,17 @@
         },
         {
           "type": "object",
+          "description": "Rename constraint operation",
+          "additionalProperties": false,
+          "properties": {
+            "rename_constraint": {
+              "$ref": "#/$defs/OpRenameConstraint"
+            }
+          },
+          "required": ["rename_constraint"]
+        },
+        {
+          "type": "object",
           "description": "Drop index operation",
           "additionalProperties": false,
           "properties": {


### PR DESCRIPTION
Otherwise migrations that include this operation are not valid according to the JSON schema.

Fixup to https://github.com/xataio/pgroll/pull/293.