### PR TITLE
Add CI step to validate examples against the JSON schema

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,6 +142,10 @@ jobs:
       with:
         go-version-file: 'go.mod'
 
+    - name: Validate examples against JSON schema
+      run: |
+        npx -y ajv-cli --spec=draft2020 validate -s schema.json -d "./examples/*.json"
+
     - name: Run example migrations
       run: |
         if [ "$PGROLL_SCHEMA" != "public" ]; then


### PR DESCRIPTION
Add a CI step to validate that the example migrations are valid according to the JSON schema.

This would have caught the problem where the JSON schema was not fully updated in https://github.com/xataio/pgroll/pull/293 and had to be updated in a follow-up PR https://github.com/xataio/pgroll/pull/300 despite #293 including an example migration.

Use [ajv-cli](https://ajv.js.org/packages/ajv-cli.html) to perform schema validation.

Here is an [example run](https://github.com/xataio/pgroll/actions/runs/8113707179/job/22177613982) where the check fails.