### PR TITLE
Add extra validation for the `rename_constraint` operation

### DIFF
--- a/pkg/migrations/op_rename_constraint.go
+++ b/pkg/migrations/op_rename_constraint.go
@@ -35,6 +35,10 @@ func (o *OpRenameConstraint) Rollback(ctx context.Context, conn *sql.DB) error {
 func (o *OpRenameConstraint) Validate(ctx context.Context, s *schema.Schema) error {
 	table := s.GetTable(o.Table)
 
+	if table == nil {
+		return TableDoesNotExistError{Name: o.Table}
+	}
+
 	if !table.ConstraintExists(o.From) {
 		return ConstraintDoesNotExistError{Table: o.Table, Constraint: o.From}
 	}


### PR DESCRIPTION
* Add an extra step to the validation for the `rename_constraint` operation to ensure that the referenced table exists.
* Add validation tests for the operation.

Fixes #302 