### PR TITLE
Fix duplicate inferred migrations when dropping columns outside of a migration

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -268,7 +268,7 @@ BEGIN
 		RETURN;
 	END IF;
 
-	IF tg_event = 'sql_drop' THEN
+	IF tg_event = 'sql_drop' and tg_tag != 'ALTER TABLE' THEN
 		-- Guess the schema from drop commands
 		SELECT schema_name INTO schemaname FROM pg_catalog.pg_event_trigger_dropped_objects() WHERE schema_name IS NOT NULL;
 
@@ -324,7 +324,6 @@ CREATE EVENT TRIGGER pg_roll_handle_ddl ON ddl_command_end
 DROP EVENT TRIGGER IF EXISTS pg_roll_handle_drop;
 CREATE EVENT TRIGGER pg_roll_handle_drop ON sql_drop
 	EXECUTE FUNCTION %[1]s.raw_migration();
-
 `
 
 type State struct {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -78,7 +78,7 @@ func TestInferredMigration(t *testing.T) {
 				},
 			},
 			{
-				name: "drop table",
+				name: "create/drop table",
 				sqlStmts: []string{
 					"CREATE TABLE table1 (id int)",
 					"DROP TABLE table1",
@@ -97,7 +97,7 @@ func TestInferredMigration(t *testing.T) {
 				},
 			},
 			{
-				name: "drop column",
+				name: "create/drop column",
 				sqlStmts: []string{
 					"CREATE TABLE table1 (id int, b text)",
 					"ALTER TABLE table1 DROP COLUMN b",
@@ -116,7 +116,7 @@ func TestInferredMigration(t *testing.T) {
 				},
 			},
 			{
-				name: "drop check constraint",
+				name: "create/drop check constraint",
 				sqlStmts: []string{
 					"CREATE TABLE table1 (id int, age integer, CONSTRAINT check_age CHECK (age > 0))",
 					"ALTER TABLE table1 DROP CONSTRAINT check_age",
@@ -135,7 +135,7 @@ func TestInferredMigration(t *testing.T) {
 				},
 			},
 			{
-				name: "drop unique constraint",
+				name: "create/drop unique constraint",
 				sqlStmts: []string{
 					"CREATE TABLE table1 (id int, b text, CONSTRAINT unique_b UNIQUE(b))",
 					"ALTER TABLE table1 DROP CONSTRAINT unique_b",
@@ -154,7 +154,7 @@ func TestInferredMigration(t *testing.T) {
 				},
 			},
 			{
-				name: "drop index",
+				name: "create/drop index",
 				sqlStmts: []string{
 					"CREATE TABLE table1 (id int, b text)",
 					"CREATE INDEX idx_b ON table1(b)",
@@ -179,7 +179,7 @@ func TestInferredMigration(t *testing.T) {
 				},
 			},
 			{
-				name: "drop function",
+				name: "create/drop function",
 				sqlStmts: []string{
 					"CREATE FUNCTION foo() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql",
 					"DROP FUNCTION foo",

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -115,6 +115,25 @@ func TestInferredMigration(t *testing.T) {
 					},
 				},
 			},
+			{
+				name: "drop constraint",
+				sqlStmts: []string{
+					"CREATE TABLE table1 (id int, b text, CONSTRAINT unique_b UNIQUE(b))",
+					"ALTER TABLE table1 DROP CONSTRAINT unique_b",
+				},
+				wantMigrations: []migrations.Migration{
+					{
+						Operations: migrations.Operations{
+							&migrations.OpRawSQL{Up: "CREATE TABLE table1 (id int, b text, CONSTRAINT unique_b UNIQUE(b))"},
+						},
+					},
+					{
+						Operations: migrations.Operations{
+							&migrations.OpRawSQL{Up: "ALTER TABLE table1 DROP CONSTRAINT unique_b"},
+						},
+					},
+				},
+			},
 		}
 
 		for _, tt := range tests {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -159,6 +159,25 @@ func TestInferredMigration(t *testing.T) {
 					},
 				},
 			},
+			{
+				name: "drop function",
+				sqlStmts: []string{
+					"CREATE FUNCTION foo() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql",
+					"DROP FUNCTION foo",
+				},
+				wantMigrations: []migrations.Migration{
+					{
+						Operations: migrations.Operations{
+							&migrations.OpRawSQL{Up: "CREATE FUNCTION foo() RETURNS void AS $$ BEGIN END; $$ LANGUAGE plpgsql"},
+						},
+					},
+					{
+						Operations: migrations.Operations{
+							&migrations.OpRawSQL{Up: "DROP FUNCTION foo"},
+						},
+					},
+				},
+			},
 		}
 
 		for _, tt := range tests {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -116,6 +116,25 @@ func TestInferredMigration(t *testing.T) {
 				},
 			},
 			{
+				name: "drop check constraint",
+				sqlStmts: []string{
+					"CREATE TABLE table1 (id int, age integer, CONSTRAINT check_age CHECK (age > 0))",
+					"ALTER TABLE table1 DROP CONSTRAINT check_age",
+				},
+				wantMigrations: []migrations.Migration{
+					{
+						Operations: migrations.Operations{
+							&migrations.OpRawSQL{Up: "CREATE TABLE table1 (id int, age integer, CONSTRAINT check_age CHECK (age > 0))"},
+						},
+					},
+					{
+						Operations: migrations.Operations{
+							&migrations.OpRawSQL{Up: "ALTER TABLE table1 DROP CONSTRAINT check_age"},
+						},
+					},
+				},
+			},
+			{
 				name: "drop unique constraint",
 				sqlStmts: []string{
 					"CREATE TABLE table1 (id int, b text, CONSTRAINT unique_b UNIQUE(b))",

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -116,7 +116,7 @@ func TestInferredMigration(t *testing.T) {
 				},
 			},
 			{
-				name: "drop constraint",
+				name: "drop unique constraint",
 				sqlStmts: []string{
 					"CREATE TABLE table1 (id int, b text, CONSTRAINT unique_b UNIQUE(b))",
 					"ALTER TABLE table1 DROP CONSTRAINT unique_b",
@@ -130,6 +130,31 @@ func TestInferredMigration(t *testing.T) {
 					{
 						Operations: migrations.Operations{
 							&migrations.OpRawSQL{Up: "ALTER TABLE table1 DROP CONSTRAINT unique_b"},
+						},
+					},
+				},
+			},
+			{
+				name: "drop index",
+				sqlStmts: []string{
+					"CREATE TABLE table1 (id int, b text)",
+					"CREATE INDEX idx_b ON table1(b)",
+					"DROP INDEX idx_b",
+				},
+				wantMigrations: []migrations.Migration{
+					{
+						Operations: migrations.Operations{
+							&migrations.OpRawSQL{Up: "CREATE TABLE table1 (id int, b text)"},
+						},
+					},
+					{
+						Operations: migrations.Operations{
+							&migrations.OpRawSQL{Up: "CREATE INDEX idx_b ON table1(b)"},
+						},
+					},
+					{
+						Operations: migrations.Operations{
+							&migrations.OpRawSQL{Up: "DROP INDEX idx_b"},
 						},
 					},
 				},


### PR DESCRIPTION
Ensure that only one `inferred` migration is created in the `pgroll.migrations` table when a column is dropped outside of a migration.

From the Postgres [docs](https://www.postgresql.org/docs/current/event-trigger-definition.html):
> The sql_drop event occurs just before the ddl_command_end event trigger for any operation that drops database objects

This means that when the `raw_migration` function is run in response to `sql_drop` and `ddl_command_end`, duplicate entries will be created in `pgroll.migrations`; once as the function is run for `sql_drop` and again when it's run for `ddl_command_end`. 

Change the definition of the `pg_roll_handle_drop` event trigger to only run on those kinds of drops that won't result in duplicates when the `pg_roll_handle_ddl` trigger runs for the same change. `DROP TABLE` and `DROP VIEW` won't result in duplicate migrations because their schema can't be inferred by the `ddl_command_event` trigger because the object has already been dropped when the trigger runs.

Update the inferred migration tests with two new testcases covering dropping tables and columns.

Fixes #304 