### PR TITLE
Respect foreign key `ON DELETE` in add column and create table operations

### DIFF
--- a/pkg/migrations/errors.go
+++ b/pkg/migrations/errors.go
@@ -184,15 +184,13 @@ func (e InvalidReplicaIdentityError) Error() string {
 }
 
 type InvalidOnDeleteSettingError struct {
-	Table   string
-	Column  string
+	Name    string
 	Setting string
 }
 
 func (e InvalidOnDeleteSettingError) Error() string {
-	return fmt.Sprintf("foreign key on_delete setting on column %q, table %q must be one of: %q, %q, %q, %q or %q, not %q",
-		e.Column,
-		e.Table,
+	return fmt.Sprintf("foreign key %q on_delete setting must be one of: %q, %q, %q, %q or %q, not %q",
+		e.Name,
 		ForeignKeyReferenceOnDeleteNOACTION,
 		ForeignKeyReferenceOnDeleteRESTRICT,
 		ForeignKeyReferenceOnDeleteSETDEFAULT,

--- a/pkg/migrations/fk_reference.go
+++ b/pkg/migrations/fk_reference.go
@@ -2,7 +2,11 @@
 
 package migrations
 
-import "github.com/xataio/pgroll/pkg/schema"
+import (
+	"strings"
+
+	"github.com/xataio/pgroll/pkg/schema"
+)
 
 func (f *ForeignKeyReference) Validate(s *schema.Schema) error {
 	if f.Name == "" {
@@ -17,6 +21,18 @@ func (f *ForeignKeyReference) Validate(s *schema.Schema) error {
 	column := table.GetColumn(f.Column)
 	if column == nil {
 		return ColumnDoesNotExistError{Table: f.Table, Name: f.Column}
+	}
+
+	switch strings.ToUpper(string(f.OnDelete)) {
+	case string(ForeignKeyReferenceOnDeleteNOACTION):
+	case string(ForeignKeyReferenceOnDeleteRESTRICT):
+	case string(ForeignKeyReferenceOnDeleteSETDEFAULT):
+	case string(ForeignKeyReferenceOnDeleteSETNULL):
+	case string(ForeignKeyReferenceOnDeleteCASCADE):
+	case "":
+		break
+	default:
+		return InvalidOnDeleteSettingError{Name: f.Name, Setting: string(f.OnDelete)}
 	}
 
 	return nil

--- a/pkg/migrations/op_add_column_test.go
+++ b/pkg/migrations/op_add_column_test.go
@@ -361,6 +361,117 @@ func TestAddForeignKeyColumn(t *testing.T) {
 				}, testutils.FKViolationErrorCode)
 			},
 		},
+		{
+			name: "add foreign key column with default ON DELETE NO ACTION",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_create_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   ptr(true),
+								},
+								{
+									Name: "name",
+									Type: "varchar(255)",
+								},
+							},
+						},
+						&migrations.OpCreateTable{
+							Name: "orders",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   ptr(true),
+								},
+								{
+									Name: "quantity",
+									Type: "integer",
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_add_column",
+					Operations: migrations.Operations{
+						&migrations.OpAddColumn{
+							Table: "orders",
+							Column: migrations.Column{
+								Name:     "user_id",
+								Type:     "integer",
+								Nullable: ptr(true),
+								References: &migrations.ForeignKeyReference{
+									Name:   "fk_users_id",
+									Table:  "users",
+									Column: "id",
+								},
+							},
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
+				// The foreign key constraint exists on the new table.
+				ValidatedForeignKeyMustExist(t, db, schema, "orders", "fk_users_id")
+
+				// Inserting a row into the referenced table succeeds.
+				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
+					"name": "alice",
+				})
+
+				// Inserting a row into the referencing table succeeds as the referenced row exists.
+				MustInsert(t, db, schema, "02_add_column", "orders", map[string]string{
+					"user_id":  "1",
+					"quantity": "100",
+				})
+
+				// Inserting a row into the referencing table fails as the referenced row does not exist.
+				MustNotInsert(t, db, schema, "02_add_column", "orders", map[string]string{
+					"user_id":  "2",
+					"quantity": "200",
+				}, testutils.FKViolationErrorCode)
+
+				// Deleting a row in the referenced table fails as a referencing row exists.
+				MustNotDelete(t, db, schema, "02_add_column", "users", map[string]string{
+					"name": "alice",
+				}, testutils.FKViolationErrorCode)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
+				// The new column has been dropped, so the foreign key constraint is gone.
+			},
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+				// The foreign key constraint still exists on the new table
+				ValidatedForeignKeyMustExist(t, db, schema, "orders", "fk_users_id")
+
+				// Inserting a row into the referenced table succeeds.
+				MustInsert(t, db, schema, "02_add_column", "users", map[string]string{
+					"name": "bob",
+				})
+
+				// Inserting a row into the referencing table succeeds as the referenced row exists.
+				MustInsert(t, db, schema, "02_add_column", "orders", map[string]string{
+					"user_id":  "2",
+					"quantity": "200",
+				})
+
+				// Inserting a row into the referencing table fails as the referenced row does not exist.
+				MustNotInsert(t, db, schema, "02_add_column", "orders", map[string]string{
+					"user_id":  "3",
+					"quantity": "300",
+				}, testutils.FKViolationErrorCode)
+
+				// Deleting a row in the referenced table fails as a referencing row exists.
+				MustNotDelete(t, db, schema, "02_add_column", "users", map[string]string{
+					"name": "bob",
+				}, testutils.FKViolationErrorCode)
+			},
+		},
 	})
 }
 

--- a/pkg/migrations/op_add_column_test.go
+++ b/pkg/migrations/op_add_column_test.go
@@ -472,6 +472,126 @@ func TestAddForeignKeyColumn(t *testing.T) {
 				}, testutils.FKViolationErrorCode)
 			},
 		},
+		{
+			name: "add foreign key column with ON DELETE CASCADE",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_create_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   ptr(true),
+								},
+								{
+									Name: "name",
+									Type: "varchar(255)",
+								},
+							},
+						},
+						&migrations.OpCreateTable{
+							Name: "orders",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   ptr(true),
+								},
+								{
+									Name: "quantity",
+									Type: "integer",
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_add_column",
+					Operations: migrations.Operations{
+						&migrations.OpAddColumn{
+							Table: "orders",
+							Column: migrations.Column{
+								Name:     "user_id",
+								Type:     "integer",
+								Nullable: ptr(true),
+								References: &migrations.ForeignKeyReference{
+									Name:     "fk_users_id",
+									Table:    "users",
+									Column:   "id",
+									OnDelete: "CASCADE",
+								},
+							},
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
+				// The foreign key constraint exists on the new table.
+				ValidatedForeignKeyMustExist(t, db, schema, "orders", "fk_users_id")
+
+				// Inserting a row into the referenced table succeeds.
+				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
+					"name": "alice",
+				})
+
+				// Inserting a row into the referencing table succeeds as the referenced row exists.
+				MustInsert(t, db, schema, "02_add_column", "orders", map[string]string{
+					"user_id":  "1",
+					"quantity": "100",
+				})
+
+				// Inserting a row into the referencing table fails as the referenced row does not exist.
+				MustNotInsert(t, db, schema, "02_add_column", "orders", map[string]string{
+					"user_id":  "2",
+					"quantity": "200",
+				}, testutils.FKViolationErrorCode)
+
+				// Deleting a row in the referenced table succeeds due to the ON DELETE CASCADE.
+				MustDelete(t, db, schema, "02_add_column", "users", map[string]string{
+					"name": "alice",
+				})
+
+				// The row in the referencing table has been deleted by the ON DELETE CASCADE.
+				rows := MustSelect(t, db, schema, "02_add_column", "orders")
+				assert.Empty(t, rows)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
+				// The new column has been dropped, so the foreign key constraint is gone.
+			},
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+				// The foreign key constraint still exists on the new table
+				ValidatedForeignKeyMustExist(t, db, schema, "orders", "fk_users_id")
+
+				// Inserting a row into the referenced table succeeds.
+				MustInsert(t, db, schema, "02_add_column", "users", map[string]string{
+					"name": "bob",
+				})
+
+				// Inserting a row into the referencing table succeeds as the referenced row exists.
+				MustInsert(t, db, schema, "02_add_column", "orders", map[string]string{
+					"user_id":  "2",
+					"quantity": "200",
+				})
+
+				// Inserting a row into the referencing table fails as the referenced row does not exist.
+				MustNotInsert(t, db, schema, "02_add_column", "orders", map[string]string{
+					"user_id":  "3",
+					"quantity": "300",
+				}, testutils.FKViolationErrorCode)
+
+				// Deleting a row in the referenced table succeeds due to the ON DELETE CASCADE.
+				MustDelete(t, db, schema, "02_add_column", "users", map[string]string{
+					"name": "bob",
+				})
+
+				// The row in the referencing table has been deleted by the ON DELETE CASCADE.
+				rows := MustSelect(t, db, schema, "02_add_column", "orders")
+				assert.Empty(t, rows)
+			},
+		},
 	})
 }
 

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/lib/pq"
 	"github.com/xataio/pgroll/pkg/schema"
@@ -130,10 +131,16 @@ func ColumnToSQL(col Column) string {
 		sql += fmt.Sprintf(" DEFAULT %s", *col.Default)
 	}
 	if col.References != nil {
-		sql += fmt.Sprintf(" CONSTRAINT %s REFERENCES %s(%s)",
+		onDelete := "NO ACTION"
+		if col.References.OnDelete != "" {
+			onDelete = strings.ToUpper(string(col.References.OnDelete))
+		}
+
+		sql += fmt.Sprintf(" CONSTRAINT %s REFERENCES %s(%s) ON DELETE %s",
 			pq.QuoteIdentifier(col.References.Name),
 			pq.QuoteIdentifier(col.References.Table),
-			pq.QuoteIdentifier(col.References.Column))
+			pq.QuoteIdentifier(col.References.Column),
+			onDelete)
 	}
 	if col.Check != nil {
 		sql += fmt.Sprintf(" CONSTRAINT %s CHECK (%s)",

--- a/pkg/migrations/op_create_table_test.go
+++ b/pkg/migrations/op_create_table_test.go
@@ -76,7 +76,7 @@ func TestCreateTable(t *testing.T) {
 			},
 		},
 		{
-			name: "create table with foreign key",
+			name: "create table with foreign key with default ON DELETE NO ACTION",
 			migrations: []migrations.Migration{
 				{
 					Name: "01_create_table",
@@ -113,9 +113,9 @@ func TestCreateTable(t *testing.T) {
 									Name: "user_id",
 									Type: "integer",
 									References: &migrations.ForeignKeyReference{
+										Column: "id",
 										Name:   "fk_users_id",
 										Table:  "users",
-										Column: "id",
 									},
 								},
 								{
@@ -147,6 +147,11 @@ func TestCreateTable(t *testing.T) {
 					"user_id":  "2",
 					"quantity": "200",
 				}, testutils.FKViolationErrorCode)
+
+				// Deleting a row in the referenced table fails as a referencing row exists.
+				MustNotDelete(t, db, schema, "02_create_table_with_fk", "users", map[string]string{
+					"name": "alice",
+				}, testutils.FKViolationErrorCode)
 			},
 			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// The table has been dropped, so the foreign key constraint is gone.
@@ -169,6 +174,11 @@ func TestCreateTable(t *testing.T) {
 				MustNotInsert(t, db, schema, "02_create_table_with_fk", "orders", map[string]string{
 					"user_id":  "3",
 					"quantity": "300",
+				}, testutils.FKViolationErrorCode)
+
+				// Deleting a row in the referenced table fails as a referencing row exists.
+				MustNotDelete(t, db, schema, "02_create_table_with_fk", "users", map[string]string{
+					"name": "bob",
 				}, testutils.FKViolationErrorCode)
 			},
 		},

--- a/pkg/migrations/op_set_fk.go
+++ b/pkg/migrations/op_set_fk.go
@@ -161,18 +161,6 @@ func (o *OpSetForeignKey) Validate(ctx context.Context, s *schema.Schema) error 
 		return FieldRequiredError{Name: "down"}
 	}
 
-	switch strings.ToUpper(string(o.References.OnDelete)) {
-	case string(ForeignKeyReferenceOnDeleteNOACTION):
-	case string(ForeignKeyReferenceOnDeleteRESTRICT):
-	case string(ForeignKeyReferenceOnDeleteSETDEFAULT):
-	case string(ForeignKeyReferenceOnDeleteSETNULL):
-	case string(ForeignKeyReferenceOnDeleteCASCADE):
-	case "":
-		break
-	default:
-		return InvalidOnDeleteSettingError{Table: o.Table, Column: o.Column, Setting: string(o.References.OnDelete)}
-	}
-
 	return nil
 }
 

--- a/pkg/migrations/op_set_fk_test.go
+++ b/pkg/migrations/op_set_fk_test.go
@@ -1197,8 +1197,7 @@ func TestSetForeignKeyValidation(t *testing.T) {
 				},
 			},
 			wantStartErr: migrations.InvalidOnDeleteSettingError{
-				Table:   "posts",
-				Column:  "user_id",
+				Name:    "fk_users_doesntexist",
 				Setting: "invalid",
 			},
 		},


### PR DESCRIPTION
#297 added the ability to specify the `ON DELETE` behavior of a foreign key when altering an existing column.

Make it so that the `ON DELETE` property of the the FK is respected for FKs on new columns too (ie those created by add column and create table operations).

Fixes #306 