### PR TITLE
Remove `BeforeBackfill` hook

### DIFF
--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -20,12 +20,6 @@ func (m *Roll) Start(ctx context.Context, migration *migrations.Migration, cbs .
 		return err
 	}
 
-	if m.migrationHooks.BeforeBackfill != nil {
-		if err := m.migrationHooks.BeforeBackfill(m); err != nil {
-			return fmt.Errorf("failed to execute BeforeBackfill hook: %w", err)
-		}
-	}
-
 	// perform backfills for the tables that require it
 	return m.performBackfills(ctx, tablesToBackfill)
 }

--- a/pkg/roll/options.go
+++ b/pkg/roll/options.go
@@ -21,8 +21,6 @@ type MigrationHooks struct {
 	BeforeStartDDL func(*Roll) error
 	// AfterStartDDL is called after the DDL phase of migration start is complete
 	AfterStartDDL func(*Roll) error
-	// BeforeBackfill is called before the backfill phase of migration start
-	BeforeBackfill func(*Roll) error
 }
 
 type Option func(*options)


### PR DESCRIPTION
Remove the `BeforeBackfill` hook.

The `BeforeBackfill` hook was added along with the `BeforeStartDDL` and `AfterStartDDL` hooks in #290, but is of limited use as a hook that runs only after successful execution of start phase DDL. Prefer a simpler API with fewer hooks until there is a demonstrated need for it.