### PR TITLE
Add `WithRawSQLURL` to configure an optional URl for raw sql operations

### DIFF
--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -221,7 +221,7 @@ func (m *Roll) Rollback(ctx context.Context) error {
 }
 
 // connForOp returns the connection to use for the given operation
-// if the operation is a raw SQL operation, it will use the rawSQLConn (if set)
+// If the operation is a raw SQL operation, it will use the rawSQLConn (if set)
 // otherwise it will use the regular pgConn
 func (m *Roll) connForOp(op migrations.Operation) *sql.DB {
 	if m.pgRawSQLConn != nil {

--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -220,7 +220,7 @@ func (m *Roll) Rollback(ctx context.Context) error {
 	return nil
 }
 
-// connForOp returns the connection to use for the given operation
+// connForOp returns the connection to use for the given operation.
 // If the operation is a raw SQL operation, it will use the rawSQLConn (if set)
 // otherwise it will use the regular pgConn
 func (m *Roll) connForOp(op migrations.Operation) *sql.DB {

--- a/pkg/roll/execute_test.go
+++ b/pkg/roll/execute_test.go
@@ -511,23 +511,8 @@ func TestMigrationHooksAreInvoked(t *testing.T) {
 func TestRawSQLURLOption(t *testing.T) {
 	t.Parallel()
 
-	testutils.WithConnectionString(t, func(connStr string) {
+	testutils.WithConnectionString(t, schema, func(st *state.State, connStr string) {
 		ctx := context.Background()
-
-		st, err := state.New(ctx, connStr, schema)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if err := st.Init(ctx); err != nil {
-			t.Fatal(err)
-		}
-
-		t.Cleanup(func() {
-			if err := st.Close(); err != nil {
-				t.Fatal(err)
-			}
-		})
 
 		db, err := sql.Open("postgres", connStr)
 		if err != nil {

--- a/pkg/roll/options.go
+++ b/pkg/roll/options.go
@@ -9,6 +9,9 @@ type options struct {
 	// optional role to set before executing migrations
 	role string
 
+	// optional rawSQLURL to use for raw SQL operations
+	rawSQLURL string
+
 	// disable pgroll version schemas creation and deletion
 	disableVersionSchemas bool
 	migrationHooks        MigrationHooks
@@ -53,5 +56,15 @@ func WithDisableViewsManagement() Option {
 func WithMigrationHooks(hooks MigrationHooks) Option {
 	return func(o *options) {
 		o.migrationHooks = hooks
+	}
+}
+
+// WithRawSQLURL sets the postgres URL to use for raw SQL operations
+// This is useful when the raw SQL operations need to be executed against
+// a different endpoint than the main migration operations (ie with a different user or
+// more security checks)
+func WithRawSQLURL(rawSQLURL string) Option {
+	return func(o *options) {
+		o.rawSQLURL = rawSQLURL
 	}
 }

--- a/pkg/roll/roll.go
+++ b/pkg/roll/roll.go
@@ -33,19 +33,19 @@ type Roll struct {
 }
 
 func New(ctx context.Context, pgURL, schema string, state *state.State, opts ...Option) (*Roll, error) {
-	options := &options{}
+	rollOpts := &options{}
 	for _, o := range opts {
-		o(options)
+		o(rollOpts)
 	}
 
-	conn, err := setupConn(ctx, pgURL, schema, *options)
+	conn, err := setupConn(ctx, pgURL, schema, *rollOpts)
 	if err != nil {
 		return nil, err
 	}
 
 	var rawSQLConn *sql.DB
-	if options.rawSQLURL != "" {
-		rawSQLConn, err = setupConn(ctx, options.rawSQLURL, schema, *options)
+	if rollOpts.rawSQLURL != "" {
+		rawSQLConn, err = setupConn(ctx, rollOpts.rawSQLURL, schema, options{})
 		if err != nil {
 			return nil, err
 		}
@@ -63,8 +63,8 @@ func New(ctx context.Context, pgURL, schema string, state *state.State, opts ...
 		schema:                schema,
 		state:                 state,
 		pgVersion:             PGVersion(pgMajorVersion),
-		disableVersionSchemas: options.disableVersionSchemas,
-		migrationHooks:        options.migrationHooks,
+		disableVersionSchemas: rollOpts.disableVersionSchemas,
+		migrationHooks:        rollOpts.migrationHooks,
 	}, nil
 }
 

--- a/pkg/testutils/util.go
+++ b/pkg/testutils/util.go
@@ -85,6 +85,13 @@ func TestSchema() string {
 	return "public"
 }
 
+func WithConnectionString(t *testing.T, fn func(connStr string)) {
+	t.Helper()
+	_, connStr, _ := setupTestDatabase(t)
+
+	fn(connStr)
+}
+
 func WithStateInSchemaAndConnectionToContainer(t *testing.T, schema string, fn func(*state.State, *sql.DB)) {
 	t.Helper()
 	ctx := context.Background()


### PR DESCRIPTION
This setting comes handy when you need to use a different connection string for raw SQL operations, as they may require some more security checks.