### PR TITLE
Use the connection defined by `WithRawSQLURL` for backfill operations

### DIFF
--- a/pkg/roll/execute_test.go
+++ b/pkg/roll/execute_test.go
@@ -601,11 +601,8 @@ func TestRawSQLURLOption(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			// create a user for rawSQLURL
-			_, err = db.Exec(`
-      CREATE USER rawsql WITH PASSWORD 'rawsql';
-      GRANT ALL PRIVILEGES ON SCHEMA public TO rawsql;
-      `)
+			// Grant privileges to the rawsql user
+			_, err = db.Exec(`GRANT ALL PRIVILEGES ON SCHEMA public TO rawsql`)
 			assert.NoError(t, err)
 
 			// init pgroll with a rawSQLURL

--- a/pkg/testutils/util.go
+++ b/pkg/testutils/util.go
@@ -66,6 +66,12 @@ func SharedTestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
+	// create a user for rawSQLURL
+	_, err = db.Exec(`CREATE USER rawsql WITH PASSWORD 'rawsql';`)
+	if err != nil {
+		os.Exit(1)
+	}
+
 	exitCode := m.Run()
 
 	if err := ctr.Terminate(ctx); err != nil {


### PR DESCRIPTION
https://github.com/xataio/pgroll/pull/315 added the option to use a separate connection for raw SQL operations.

The same arguments about using a separate, more restrictive connection to run raw SQL operations also apply to running `up` and `down` SQL during backfill operations.

This PR changes the backfill operation to use the alternative connection if defined.