### PR TITLE
Preserve comments on column duplication

### DIFF
--- a/pkg/migrations/op_common_test.go
+++ b/pkg/migrations/op_common_test.go
@@ -484,7 +484,7 @@ func columnHasType(t *testing.T, db *sql.DB, schema, table, column, expectedType
 func columnHasComment(t *testing.T, db *sql.DB, schema, table, column, expectedComment string) bool {
 	t.Helper()
 
-	var actualComment string
+	var actualComment *string
 	err := db.QueryRow(fmt.Sprintf(`
     SELECT col_description(
       %[1]s::regclass,
@@ -497,7 +497,7 @@ func columnHasComment(t *testing.T, db *sql.DB, schema, table, column, expectedC
 		t.Fatal(err)
 	}
 
-	return expectedComment == actualComment
+	return actualComment != nil && *actualComment == expectedComment
 }
 
 func tableHasComment(t *testing.T, db *sql.DB, schema, table, expectedComment string) bool {

--- a/pkg/migrations/op_set_notnull_test.go
+++ b/pkg/migrations/op_set_notnull_test.go
@@ -496,6 +496,53 @@ func TestSetNotNull(t *testing.T) {
 				})
 			},
 		},
+		{
+			name: "setting a column to not null retains any comment defined on the column",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   ptr(true),
+								},
+								{
+									Name:     "name",
+									Type:     "text",
+									Nullable: ptr(true),
+									Comment:  ptr("the name of the user"),
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_set_not_null",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:    "users",
+							Column:   "name",
+							Nullable: ptr(false),
+							Up:       ptr("(SELECT CASE WHEN name IS NULL THEN 'anonymous' ELSE name END)"),
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
+				// The duplicated column has a comment defined on it
+				ColumnMustHaveComment(t, db, schema, "users", migrations.TemporaryName("name"), "the name of the user")
+			},
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
+			},
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+				// The final column has a comment defined on it
+				ColumnMustHaveComment(t, db, schema, "users", "name", "the name of the user")
+			},
+		},
 	})
 }
 

--- a/pkg/migrations/op_set_unique_test.go
+++ b/pkg/migrations/op_set_unique_test.go
@@ -463,6 +463,64 @@ func TestSetColumnUnique(t *testing.T) {
 				}, testutils.NotNullViolationErrorCode)
 			},
 		},
+		{
+			name: "comments are preserved when adding a unique constraint",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "reviews",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   ptr(true),
+								},
+								{
+									Name:     "username",
+									Type:     "text",
+									Nullable: ptr(false),
+									Comment:  ptr("the name of the user"),
+								},
+								{
+									Name: "product",
+									Type: "text",
+								},
+								{
+									Name: "review",
+									Type: "text",
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_set_unique",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:  "reviews",
+							Column: "username",
+							Unique: &migrations.UniqueConstraint{
+								Name: "reviews_username_unique",
+							},
+							Up:   ptr("username"),
+							Down: ptr("username"),
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
+				// The duplicated column has a comment defined on it
+				ColumnMustHaveComment(t, db, schema, "reviews", migrations.TemporaryName("username"), "the name of the user")
+			},
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
+			},
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+				// The final column has a comment defined on it
+				ColumnMustHaveComment(t, db, schema, "reviews", "username", "the name of the user")
+			},
+		},
 		// It should be possible to add multiple unique constraints to a column
 		// once unique constraints covering multiple columns are supported.
 		//


### PR DESCRIPTION
Ensure that column comments are preserved when a column is duplicated.

Part of #227 