### PR TITLE
Add `Upper` and `Downer` interfaces to identify operations that create `up` and `down`  triggers

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -46,6 +46,22 @@ type RequiresSchemaRefreshOperation interface {
 	RequiresSchemaRefresh()
 }
 
+// Upper is implemented by operations that define `up` SQL
+// Implementations should return the user-defined `up` SQL for the operation,
+// and not any default `up` SQL that may apply to the operation.
+type Upper interface {
+	UpSQL() string
+	SetUpSQL(string)
+}
+
+// Downer is implemented by operations that define `down` SQL
+// Implementations should return the user-defined `down` SQL for the operation,
+// and not any default `down` SQL that may apply to the operation.
+type Downer interface {
+	DownSQL() string
+	SetDownSQL(string)
+}
+
 type (
 	Operations []Operation
 	Migration  struct {

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -182,6 +182,9 @@ func (o *OpAddColumn) Validate(ctx context.Context, s *schema.Schema) error {
 	return nil
 }
 
+func (o *OpAddColumn) UpSQL() string      { return o.Up }
+func (o *OpAddColumn) SetUpSQL(up string) { o.Up = up }
+
 func addColumn(ctx context.Context, conn *sql.DB, o OpAddColumn, t *schema.Table) error {
 	// don't add non-nullable columns with no default directly
 	// they are handled by:

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -42,7 +42,7 @@ func (o *OpAddColumn) Start(ctx context.Context, conn *sql.DB, stateSchema strin
 
 	var tableToBackfill *schema.Table
 	if o.Up != "" {
-		err := createTrigger(ctx, conn, triggerConfig{
+		err := createTrigger(ctx, o, conn, triggerConfig{
 			Name:           TriggerName(o.Table, o.Column.Name),
 			Direction:      TriggerDirectionUp,
 			Columns:        s.GetTable(o.Table).Columns,

--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -65,6 +65,11 @@ func (o *OpAlterColumn) Validate(ctx context.Context, s *schema.Schema) error {
 	return op.Validate(ctx, s)
 }
 
+func (o *OpAlterColumn) UpSQL() string          { return o.Up }
+func (o *OpAlterColumn) SetUpSQL(up string)     { o.Up = up }
+func (o *OpAlterColumn) DownSQL() string        { return o.Down }
+func (o *OpAlterColumn) SetDownSQL(down string) { o.Down = down }
+
 func (o *OpAlterColumn) innerOperation() Operation {
 	switch {
 	case o.Name != nil:

--- a/pkg/migrations/op_change_type.go
+++ b/pkg/migrations/op_change_type.go
@@ -130,6 +130,11 @@ func (o *OpChangeType) Rollback(ctx context.Context, conn *sql.DB) error {
 	return err
 }
 
+func (o *OpChangeType) UpSQL() string          { return o.Up }
+func (o *OpChangeType) SetUpSQL(up string)     { o.Up = up }
+func (o *OpChangeType) DownSQL() string        { return o.Down }
+func (o *OpChangeType) SetDownSQL(down string) { o.Down = down }
+
 func (o *OpChangeType) Validate(ctx context.Context, s *schema.Schema) error {
 	if o.Up == "" {
 		return FieldRequiredError{Name: "up"}

--- a/pkg/migrations/op_change_type.go
+++ b/pkg/migrations/op_change_type.go
@@ -32,7 +32,7 @@ func (o *OpChangeType) Start(ctx context.Context, conn *sql.DB, stateSchema stri
 	}
 
 	// Add a trigger to copy values from the old column to the new, rewriting values using the `up` SQL.
-	err := createTrigger(ctx, conn, triggerConfig{
+	err := createTrigger(ctx, o, conn, triggerConfig{
 		Name:           TriggerName(o.Table, o.Column),
 		Direction:      TriggerDirectionUp,
 		Columns:        table.Columns,
@@ -54,7 +54,7 @@ func (o *OpChangeType) Start(ctx context.Context, conn *sql.DB, stateSchema stri
 	})
 
 	// Add a trigger to copy values from the new column to the old, rewriting values using the `down` SQL.
-	err = createTrigger(ctx, conn, triggerConfig{
+	err = createTrigger(ctx, o, conn, triggerConfig{
 		Name:           TriggerName(o.Table, TemporaryName(o.Column)),
 		Direction:      TriggerDirectionDown,
 		Columns:        table.Columns,

--- a/pkg/migrations/op_drop_column.go
+++ b/pkg/migrations/op_drop_column.go
@@ -66,3 +66,6 @@ func (o *OpDropColumn) Validate(ctx context.Context, s *schema.Schema) error {
 	}
 	return nil
 }
+
+func (o *OpDropColumn) DownSQL() string       { return o.Down }
+func (o *OpDropColumn) SetDownSQL(sql string) { o.Down = sql }

--- a/pkg/migrations/op_drop_column.go
+++ b/pkg/migrations/op_drop_column.go
@@ -15,7 +15,7 @@ var _ Operation = (*OpDropColumn)(nil)
 
 func (o *OpDropColumn) Start(ctx context.Context, conn *sql.DB, stateSchema string, s *schema.Schema, cbs ...CallbackFn) (*schema.Table, error) {
 	if o.Down != "" {
-		err := createTrigger(ctx, conn, triggerConfig{
+		err := createTrigger(ctx, o, conn, triggerConfig{
 			Name:           TriggerName(o.Table, o.Column),
 			Direction:      TriggerDirectionDown,
 			Columns:        s.GetTable(o.Table).Columns,

--- a/pkg/migrations/op_drop_constraint.go
+++ b/pkg/migrations/op_drop_constraint.go
@@ -24,7 +24,7 @@ func (o *OpDropConstraint) Start(ctx context.Context, conn *sql.DB, stateSchema 
 	}
 
 	// Add a trigger to copy values from the old column to the new, rewriting values using the `up` SQL.
-	err := createTrigger(ctx, conn, triggerConfig{
+	err := createTrigger(ctx, o, conn, triggerConfig{
 		Name:           TriggerName(o.Table, o.Column),
 		Direction:      TriggerDirectionUp,
 		Columns:        table.Columns,
@@ -46,7 +46,7 @@ func (o *OpDropConstraint) Start(ctx context.Context, conn *sql.DB, stateSchema 
 	})
 
 	// Add a trigger to copy values from the new column to the old, rewriting values using the `down` SQL.
-	err = createTrigger(ctx, conn, triggerConfig{
+	err = createTrigger(ctx, o, conn, triggerConfig{
 		Name:           TriggerName(o.Table, TemporaryName(o.Column)),
 		Direction:      TriggerDirectionDown,
 		Columns:        table.Columns,

--- a/pkg/migrations/op_drop_constraint.go
+++ b/pkg/migrations/op_drop_constraint.go
@@ -32,7 +32,7 @@ func (o *OpDropConstraint) Start(ctx context.Context, conn *sql.DB, stateSchema 
 		TableName:      o.Table,
 		PhysicalColumn: TemporaryName(o.Column),
 		StateSchema:    stateSchema,
-		SQL:            o.upSQL(),
+		SQL:            o.upSQLOrDefault(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create up trigger: %w", err)
@@ -152,7 +152,7 @@ func (o *OpDropConstraint) SetUpSQL(up string)     { o.Up = up }
 func (o *OpDropConstraint) DownSQL() string        { return o.Down }
 func (o *OpDropConstraint) SetDownSQL(down string) { o.Down = down }
 
-func (o *OpDropConstraint) upSQL() string {
+func (o *OpDropConstraint) upSQLOrDefault() string {
 	if o.Up != "" {
 		return o.Up
 	}

--- a/pkg/migrations/op_drop_constraint.go
+++ b/pkg/migrations/op_drop_constraint.go
@@ -147,6 +147,11 @@ func (o *OpDropConstraint) Validate(ctx context.Context, s *schema.Schema) error
 	return nil
 }
 
+func (o *OpDropConstraint) UpSQL() string          { return o.Up }
+func (o *OpDropConstraint) SetUpSQL(up string)     { o.Up = up }
+func (o *OpDropConstraint) DownSQL() string        { return o.Down }
+func (o *OpDropConstraint) SetDownSQL(down string) { o.Down = down }
+
 func (o *OpDropConstraint) upSQL() string {
 	if o.Up != "" {
 		return o.Up

--- a/pkg/migrations/op_drop_not_null.go
+++ b/pkg/migrations/op_drop_not_null.go
@@ -39,7 +39,7 @@ func (o *OpDropNotNull) Start(ctx context.Context, conn *sql.DB, stateSchema str
 		TableName:      o.Table,
 		PhysicalColumn: TemporaryName(o.Column),
 		StateSchema:    stateSchema,
-		SQL:            o.upSQL(),
+		SQL:            o.upSQLOrDefault(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create up trigger: %w", err)
@@ -149,7 +149,7 @@ func (o *OpDropNotNull) SetDownSQL(down string) { o.Down = down }
 
 // When removing `NOT NULL` from a column, up SQL is either user-specified or
 // defaults to copying the value from the old column to the new.
-func (o *OpDropNotNull) upSQL() string {
+func (o *OpDropNotNull) upSQLOrDefault() string {
 	if o.Up == "" {
 		return pq.QuoteIdentifier(o.Column)
 	}

--- a/pkg/migrations/op_drop_not_null.go
+++ b/pkg/migrations/op_drop_not_null.go
@@ -31,7 +31,7 @@ func (o *OpDropNotNull) Start(ctx context.Context, conn *sql.DB, stateSchema str
 	}
 
 	// Add a trigger to copy values from the old column to the new, rewriting values using the `up` SQL.
-	err := createTrigger(ctx, conn, triggerConfig{
+	err := createTrigger(ctx, o, conn, triggerConfig{
 		Name:           TriggerName(o.Table, o.Column),
 		Direction:      TriggerDirectionUp,
 		Columns:        table.Columns,
@@ -53,7 +53,7 @@ func (o *OpDropNotNull) Start(ctx context.Context, conn *sql.DB, stateSchema str
 	})
 
 	// Add a trigger to copy values from the new column to the old.
-	err = createTrigger(ctx, conn, triggerConfig{
+	err = createTrigger(ctx, o, conn, triggerConfig{
 		Name:           TriggerName(o.Table, TemporaryName(o.Column)),
 		Direction:      TriggerDirectionDown,
 		Columns:        table.Columns,

--- a/pkg/migrations/op_drop_not_null.go
+++ b/pkg/migrations/op_drop_not_null.go
@@ -142,6 +142,11 @@ func (o *OpDropNotNull) Validate(ctx context.Context, s *schema.Schema) error {
 	return nil
 }
 
+func (o *OpDropNotNull) UpSQL() string          { return o.Up }
+func (o *OpDropNotNull) SetUpSQL(up string)     { o.Up = up }
+func (o *OpDropNotNull) DownSQL() string        { return o.Down }
+func (o *OpDropNotNull) SetDownSQL(down string) { o.Down = down }
+
 // When removing `NOT NULL` from a column, up SQL is either user-specified or
 // defaults to copying the value from the old column to the new.
 func (o *OpDropNotNull) upSQL() string {

--- a/pkg/migrations/op_set_check.go
+++ b/pkg/migrations/op_set_check.go
@@ -38,7 +38,7 @@ func (o *OpSetCheckConstraint) Start(ctx context.Context, conn *sql.DB, stateSch
 	}
 
 	// Add a trigger to copy values from the old column to the new, rewriting values using the `up` SQL.
-	err := createTrigger(ctx, conn, triggerConfig{
+	err := createTrigger(ctx, o, conn, triggerConfig{
 		Name:           TriggerName(o.Table, o.Column),
 		Direction:      TriggerDirectionUp,
 		Columns:        table.Columns,
@@ -60,7 +60,7 @@ func (o *OpSetCheckConstraint) Start(ctx context.Context, conn *sql.DB, stateSch
 	})
 
 	// Add a trigger to copy values from the new column to the old, rewriting values using the `down` SQL.
-	err = createTrigger(ctx, conn, triggerConfig{
+	err = createTrigger(ctx, o, conn, triggerConfig{
 		Name:           TriggerName(o.Table, TemporaryName(o.Column)),
 		Direction:      TriggerDirectionDown,
 		Columns:        table.Columns,

--- a/pkg/migrations/op_set_check.go
+++ b/pkg/migrations/op_set_check.go
@@ -163,6 +163,11 @@ func (o *OpSetCheckConstraint) Validate(ctx context.Context, s *schema.Schema) e
 	return nil
 }
 
+func (o *OpSetCheckConstraint) UpSQL() string          { return o.Up }
+func (o *OpSetCheckConstraint) SetUpSQL(up string)     { o.Up = up }
+func (o *OpSetCheckConstraint) DownSQL() string        { return o.Down }
+func (o *OpSetCheckConstraint) SetDownSQL(down string) { o.Down = down }
+
 func (o *OpSetCheckConstraint) addCheckConstraint(ctx context.Context, conn *sql.DB) error {
 	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s CHECK (%s) NOT VALID",
 		pq.QuoteIdentifier(o.Table),

--- a/pkg/migrations/op_set_fk.go
+++ b/pkg/migrations/op_set_fk.go
@@ -38,7 +38,7 @@ func (o *OpSetForeignKey) Start(ctx context.Context, conn *sql.DB, stateSchema s
 	}
 
 	// Add a trigger to copy values from the old column to the new, rewriting values using the `up` SQL.
-	err := createTrigger(ctx, conn, triggerConfig{
+	err := createTrigger(ctx, o, conn, triggerConfig{
 		Name:           TriggerName(o.Table, o.Column),
 		Direction:      TriggerDirectionUp,
 		Columns:        table.Columns,
@@ -60,7 +60,7 @@ func (o *OpSetForeignKey) Start(ctx context.Context, conn *sql.DB, stateSchema s
 	})
 
 	// Add a trigger to copy values from the new column to the old, rewriting values using the `down` SQL.
-	err = createTrigger(ctx, conn, triggerConfig{
+	err = createTrigger(ctx, o, conn, triggerConfig{
 		Name:           TriggerName(o.Table, TemporaryName(o.Column)),
 		Direction:      TriggerDirectionDown,
 		Columns:        table.Columns,

--- a/pkg/migrations/op_set_fk.go
+++ b/pkg/migrations/op_set_fk.go
@@ -164,6 +164,11 @@ func (o *OpSetForeignKey) Validate(ctx context.Context, s *schema.Schema) error 
 	return nil
 }
 
+func (o *OpSetForeignKey) UpSQL() string          { return o.Up }
+func (o *OpSetForeignKey) SetUpSQL(up string)     { o.Up = up }
+func (o *OpSetForeignKey) DownSQL() string        { return o.Down }
+func (o *OpSetForeignKey) SetDownSQL(down string) { o.Down = down }
+
 func (o *OpSetForeignKey) addForeignKeyConstraint(ctx context.Context, conn *sql.DB) error {
 	tempColumnName := TemporaryName(o.Column)
 

--- a/pkg/migrations/op_set_notnull.go
+++ b/pkg/migrations/op_set_notnull.go
@@ -36,7 +36,7 @@ func (o *OpSetNotNull) Start(ctx context.Context, conn *sql.DB, stateSchema stri
 	}
 
 	// Add a trigger to copy values from the old column to the new, rewriting values using the `up` SQL.
-	err := createTrigger(ctx, conn, triggerConfig{
+	err := createTrigger(ctx, o, conn, triggerConfig{
 		Name:           TriggerName(o.Table, o.Column),
 		Direction:      TriggerDirectionUp,
 		Columns:        table.Columns,
@@ -58,7 +58,7 @@ func (o *OpSetNotNull) Start(ctx context.Context, conn *sql.DB, stateSchema stri
 	})
 
 	// Add a trigger to copy values from the new column to the old.
-	err = createTrigger(ctx, conn, triggerConfig{
+	err = createTrigger(ctx, o, conn, triggerConfig{
 		Name:           TriggerName(o.Table, TemporaryName(o.Column)),
 		Direction:      TriggerDirectionDown,
 		Columns:        table.Columns,

--- a/pkg/migrations/op_set_notnull.go
+++ b/pkg/migrations/op_set_notnull.go
@@ -66,7 +66,7 @@ func (o *OpSetNotNull) Start(ctx context.Context, conn *sql.DB, stateSchema stri
 		TableName:      o.Table,
 		PhysicalColumn: o.Column,
 		StateSchema:    stateSchema,
-		SQL:            o.downSQL(),
+		SQL:            o.downSQLOrDefault(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create down trigger: %w", err)
@@ -181,7 +181,7 @@ func (o *OpSetNotNull) DownSQL() string        { return o.Down }
 func (o *OpSetNotNull) SetDownSQL(down string) { o.Down = down }
 
 // Down SQL is either user-specified or defaults to copying the value from the new column to the old.
-func (o *OpSetNotNull) downSQL() string {
+func (o *OpSetNotNull) downSQLOrDefault() string {
 	if o.Down == "" {
 		return fmt.Sprintf("NEW.%s", pq.QuoteIdentifier(TemporaryName(o.Column)))
 	}

--- a/pkg/migrations/op_set_notnull.go
+++ b/pkg/migrations/op_set_notnull.go
@@ -175,6 +175,11 @@ func (o *OpSetNotNull) Validate(ctx context.Context, s *schema.Schema) error {
 	return nil
 }
 
+func (o *OpSetNotNull) UpSQL() string          { return o.Up }
+func (o *OpSetNotNull) SetUpSQL(up string)     { o.Up = up }
+func (o *OpSetNotNull) DownSQL() string        { return o.Down }
+func (o *OpSetNotNull) SetDownSQL(down string) { o.Down = down }
+
 // Down SQL is either user-specified or defaults to copying the value from the new column to the old.
 func (o *OpSetNotNull) downSQL() string {
 	if o.Down == "" {

--- a/pkg/migrations/op_set_unique.go
+++ b/pkg/migrations/op_set_unique.go
@@ -163,6 +163,11 @@ func (o *OpSetUnique) Validate(ctx context.Context, s *schema.Schema) error {
 	return nil
 }
 
+func (o *OpSetUnique) UpSQL() string          { return o.Up }
+func (o *OpSetUnique) SetUpSQL(up string)     { o.Up = up }
+func (o *OpSetUnique) DownSQL() string        { return o.Down }
+func (o *OpSetUnique) SetDownSQL(down string) { o.Down = down }
+
 func (o *OpSetUnique) addUniqueIndex(ctx context.Context, conn *sql.DB) error {
 	// create unique index concurrently
 	_, err := conn.ExecContext(ctx, fmt.Sprintf("CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS %s ON %s (%s)",

--- a/pkg/migrations/op_set_unique.go
+++ b/pkg/migrations/op_set_unique.go
@@ -37,7 +37,7 @@ func (o *OpSetUnique) Start(ctx context.Context, conn *sql.DB, stateSchema strin
 	}
 
 	// Add a trigger to copy values from the old column to the new, rewriting values using the `up` SQL.
-	err := createTrigger(ctx, conn, triggerConfig{
+	err := createTrigger(ctx, o, conn, triggerConfig{
 		Name:           TriggerName(o.Table, o.Column),
 		Direction:      TriggerDirectionUp,
 		Columns:        table.Columns,
@@ -59,7 +59,7 @@ func (o *OpSetUnique) Start(ctx context.Context, conn *sql.DB, stateSchema strin
 	})
 
 	// Add a trigger to copy values from the new column to the old, rewriting values using the `down` SQL.
-	err = createTrigger(ctx, conn, triggerConfig{
+	err = createTrigger(ctx, o, conn, triggerConfig{
 		Name:           TriggerName(o.Table, TemporaryName(o.Column)),
 		Direction:      TriggerDirectionDown,
 		Columns:        table.Columns,

--- a/pkg/migrations/op_set_unique.go
+++ b/pkg/migrations/op_set_unique.go
@@ -67,7 +67,7 @@ func (o *OpSetUnique) Start(ctx context.Context, conn *sql.DB, stateSchema strin
 		TableName:      o.Table,
 		PhysicalColumn: o.Column,
 		StateSchema:    stateSchema,
-		SQL:            o.downSQL(),
+		SQL:            o.downSQLOrDefault(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create down trigger: %w", err)
@@ -179,7 +179,7 @@ func (o *OpSetUnique) addUniqueIndex(ctx context.Context, conn *sql.DB) error {
 }
 
 // Down SQL is either user-specified or defaults to copying the value from the new column to the old.
-func (o *OpSetUnique) downSQL() string {
+func (o *OpSetUnique) downSQLOrDefault() string {
 	if o.Down != "" {
 		return o.Down
 	}


### PR DESCRIPTION
Add two new interfaces `Upper` and `Downer`, implemented by operations that create up and down triggers.

Consumers of `pgroll` may wish to identify operations that run arbitrary SQL via `up` and `down` triggers and pre-process them in such a way to ensure that the SQL is safe, or otherwise restricted.

With the new interfaces clients can do something like:

```go
for _, op := range migration.Operations {
  if up, ok := op.(migrations.Upper); ok {
    processedSQL := processSQL(up.UpSQL())
    up.SetUpSQL(processedSQL)
  }
  if down, ok := op.(migrations.Downer); ok {
    processedSQL := processSQL(down.DownSQL())
    down.SetDownSQL(processedSQL)
  }
}
```

to iterate over all operations in a migration and process the `up` or `down` SQL of each operation.

Update the `createTrigger` function to check that the operation creating the trigger implements either `Upper` or `Downer` according to the direction of the trigger. This guards against future operations creating triggers without implementing `Upper` or `Downer`.