### PR TITLE
Rewrite raw SQL operations using a SQL transformer

### DIFF
--- a/pkg/migrations/op_common_test.go
+++ b/pkg/migrations/op_common_test.go
@@ -32,12 +32,12 @@ func TestMain(m *testing.M) {
 	testutils.SharedTestMain(m)
 }
 
-func ExecuteTests(t *testing.T, tests TestCases) {
+func ExecuteTests(t *testing.T, tests TestCases, opts ...roll.Option) {
 	testSchema := testutils.TestSchema()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			testutils.WithMigratorInSchemaAndConnectionToContainer(t, testSchema, func(mig *roll.Roll, db *sql.DB) {
+			testutils.WithMigratorInSchemaAndConnectionToContainerWithOptions(t, testSchema, opts, func(mig *roll.Roll, db *sql.DB) {
 				ctx := context.Background()
 
 				// run all migrations except the last one

--- a/pkg/migrations/op_raw_sql.go
+++ b/pkg/migrations/op_raw_sql.go
@@ -12,27 +12,45 @@ import (
 var _ Operation = (*OpRawSQL)(nil)
 
 func (o *OpRawSQL) Start(ctx context.Context, conn *sql.DB, stateSchema string, tr SQLTransformer, s *schema.Schema, cbs ...CallbackFn) (*schema.Table, error) {
-	if !o.OnComplete {
-		_, err := conn.ExecContext(ctx, o.Up)
+	if o.OnComplete {
+		return nil, nil
+	}
+
+	up, err := tr.TransformSQL(o.Up)
+	if err != nil {
 		return nil, err
 	}
-	return nil, nil
+
+	_, err = conn.ExecContext(ctx, up)
+	return nil, err
 }
 
 func (o *OpRawSQL) Complete(ctx context.Context, conn *sql.DB, tr SQLTransformer, s *schema.Schema) error {
-	if o.OnComplete {
-		_, err := conn.ExecContext(ctx, o.Up)
+	if !o.OnComplete {
+		return nil
+	}
+
+	up, err := tr.TransformSQL(o.Up)
+	if err != nil {
 		return err
 	}
-	return nil
+
+	_, err = conn.ExecContext(ctx, up)
+	return err
 }
 
 func (o *OpRawSQL) Rollback(ctx context.Context, conn *sql.DB, tr SQLTransformer) error {
-	if o.Down != "" {
-		_, err := conn.ExecContext(ctx, o.Down)
+	if o.Down == "" {
+		return nil
+	}
+
+	down, err := tr.TransformSQL(o.Down)
+	if err != nil {
 		return err
 	}
-	return nil
+
+	_, err = conn.ExecContext(ctx, down)
+	return err
 }
 
 func (o *OpRawSQL) Validate(ctx context.Context, s *schema.Schema) error {


### PR DESCRIPTION
Use the SQL transformer to transform the `up` and `down` fields of a raw SQL migration.

Builds on https://github.com/xataio/pgroll/pull/329 which added a `SQLTransformer` option to rewrite user-supplied SQL.

