### PR TITLE
Strengthen SQL transformation tests

### DIFF
--- a/pkg/migrations/op_common_test.go
+++ b/pkg/migrations/op_common_test.go
@@ -22,6 +22,7 @@ type TestCase struct {
 	migrations      []migrations.Migration
 	wantStartErr    error
 	wantRollbackErr error
+	wantCompleteErr error
 	afterStart      func(t *testing.T, db *sql.DB, schema string)
 	afterComplete   func(t *testing.T, db *sql.DB, schema string)
 	afterRollback   func(t *testing.T, db *sql.DB, schema string)
@@ -92,7 +93,14 @@ func ExecuteTests(t *testing.T, tests TestCases, opts ...roll.Option) {
 				}
 
 				// complete the last migration
-				if err := mig.Complete(ctx); err != nil {
+				err = mig.Complete(ctx)
+				if tt.wantCompleteErr != nil {
+					if !errors.Is(err, tt.wantCompleteErr) {
+						t.Fatalf("Expected error %q, got %q", tt.wantCompleteErr, err)
+					}
+					return
+				}
+				if err != nil {
 					t.Fatalf("Failed to complete migration: %v", err)
 				}
 

--- a/pkg/testutils/sql_transformer.go
+++ b/pkg/testutils/sql_transformer.go
@@ -25,8 +25,8 @@ func NewMockSQLTransformer(ts map[string]string) *MockSQLTransformer {
 // provided to the MockSQLTransformer. If the input SQL is not in the transformations
 // map, the input SQL is returned unchanged.
 func (s *MockSQLTransformer) TransformSQL(sql string) (string, error) {
-	out, ok := s.transformations[sql]
-	if !ok {
+	out, found := s.transformations[sql]
+	if !found {
 		return sql, nil
 	}
 

--- a/pkg/testutils/sql_transformer.go
+++ b/pkg/testutils/sql_transformer.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package testutils
+
+import "errors"
+
+type MockSQLTransformer struct {
+	transformations map[string]string
+}
+
+const MockSQLTransformerError = "ERROR"
+
+var ErrMockSQLTransformer = errors.New("SQL transformer error")
+
+// NewMockSQLTransformer creates a MockSQLTransformer with the given transformations.
+// The transformations map is a map of input SQL to output SQL. If the output
+// SQL is "ERROR", the transformer will return an error on that input.
+func NewMockSQLTransformer(ts map[string]string) *MockSQLTransformer {
+	return &MockSQLTransformer{
+		transformations: ts,
+	}
+}
+
+// TransformSQL transforms the given SQL string according to the transformations
+// provided to the MockSQLTransformer. If the input SQL is not in the transformations
+// map, the input SQL is returned unchanged.
+func (s *MockSQLTransformer) TransformSQL(sql string) (string, error) {
+	out, ok := s.transformations[sql]
+	if !ok {
+		return sql, nil
+	}
+
+	if out == MockSQLTransformerError {
+		return "", ErrMockSQLTransformer
+	}
+
+	return out, nil
+}


### PR DESCRIPTION
Improve the existing tests around SQL transformation by adding a `MockSQLTransformer` type and using it in the existing SQL transformation tests. 

Also add several new testcases for transformation of raw SQL operations to ensure that when transformation fails the operation fails.