### PR TITLE
Revert: Add `WithRawSQLURL` to configure an optional URl for raw sql operations

### DIFF
--- a/pkg/roll/execute_test.go
+++ b/pkg/roll/execute_test.go
@@ -7,7 +7,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"net/url"
 	"testing"
 
 	"github.com/lib/pq"
@@ -588,63 +587,6 @@ func TestMigrationHooksAreInvoked(t *testing.T) {
 	})
 }
 
-func TestRawSQLURLOption(t *testing.T) {
-	t.Parallel()
-
-	testutils.WithConnectionString(t, schema, func(st *state.State, connStr string) {
-		ctx := context.Background()
-
-		db, err := sql.Open("postgres", connStr)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// create a user for rawSQLURL
-		_, err = db.Exec(`
-			CREATE USER rawsql WITH PASSWORD 'rawsql';
-			GRANT ALL PRIVILEGES ON SCHEMA public TO rawsql;
-		`)
-		assert.NoError(t, err)
-
-		// init pgroll with a rawSQLURL
-		rawSQL, err := url.Parse(connStr)
-		assert.NoError(t, err)
-		rawSQL.User = url.UserPassword("rawsql", "rawsql")
-
-		mig, err := roll.New(ctx, connStr, schema, st, roll.WithRawSQLURL(rawSQL.String()))
-		assert.NoError(t, err)
-
-		t.Cleanup(func() {
-			if err := mig.Close(); err != nil {
-				t.Fatal(err)
-			}
-		})
-
-		// Start a migration with raw and regular SQL operations
-		err = mig.Start(ctx, &migrations.Migration{
-			Name: "01_create_table",
-			Operations: migrations.Operations{
-				createTableOp("table1"),
-				&migrations.OpRawSQL{
-					Up:         "CREATE TABLE raw_sql_table (id integer)",
-					OnComplete: true,
-				},
-			},
-		})
-		assert.NoError(t, err)
-
-		// Complete the migration
-		err = mig.Complete(ctx)
-		assert.NoError(t, err)
-
-		// Ensure both tables were created
-		assert.True(t, tableExists(t, db, "public", "table1"))
-		assert.True(t, tableExists(t, db, "public", "raw_sql_table"))
-		assert.Equal(t, "rawsql", tableOwner(t, db, "public", "raw_sql_table"))
-		assert.Equal(t, "postgres", tableOwner(t, db, "public", "table1"))
-	})
-}
-
 func TestRollSchemaMethodReturnsCorrectSchema(t *testing.T) {
 	t.Parallel()
 
@@ -873,23 +815,6 @@ func tableExists(t *testing.T, db *sql.DB, schema, table string) bool {
 	}
 
 	return exists
-}
-
-func tableOwner(t *testing.T, db *sql.DB, schema, table string) string {
-	t.Helper()
-
-	var owner string
-	err := db.QueryRow(`
-		SELECT tableowner
-		FROM pg_catalog.pg_tables
-		WHERE schemaname = $1
-			AND tablename = $2`,
-		schema, table).Scan(&owner)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return owner
 }
 
 func ptr[T any](v T) *T {

--- a/pkg/roll/options.go
+++ b/pkg/roll/options.go
@@ -13,9 +13,6 @@ type options struct {
 	// optional role to set before executing migrations
 	role string
 
-	// optional rawSQLURL to use for raw SQL operations
-	rawSQLURL string
-
 	// optional SQL transformer to apply to all user-defined SQL statements
 	sqlTransformer migrations.SQLTransformer
 
@@ -63,16 +60,6 @@ func WithDisableViewsManagement() Option {
 func WithMigrationHooks(hooks MigrationHooks) Option {
 	return func(o *options) {
 		o.migrationHooks = hooks
-	}
-}
-
-// WithRawSQLURL sets the postgres URL to use for raw SQL operations
-// This is useful when the raw SQL operations need to be executed against
-// a different endpoint than the main migration operations (ie with a different user or
-// more security checks)
-func WithRawSQLURL(rawSQLURL string) Option {
-	return func(o *options) {
-		o.rawSQLURL = rawSQLURL
 	}
 }
 

--- a/pkg/testutils/util.go
+++ b/pkg/testutils/util.go
@@ -85,29 +85,6 @@ func TestSchema() string {
 	return "public"
 }
 
-func WithConnectionString(t *testing.T, schema string, fn func(st *state.State, connStr string)) {
-	t.Helper()
-	_, connStr, _ := setupTestDatabase(t)
-
-	ctx := context.Background()
-	st, err := state.New(ctx, connStr, schema)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := st.Init(ctx); err != nil {
-		t.Fatal(err)
-	}
-
-	t.Cleanup(func() {
-		if err := st.Close(); err != nil {
-			t.Fatal(err)
-		}
-	})
-
-	fn(st, connStr)
-}
-
 func WithStateInSchemaAndConnectionToContainer(t *testing.T, schema string, fn func(*state.State, *sql.DB)) {
 	t.Helper()
 	ctx := context.Background()


### PR DESCRIPTION
Revert #315 as there is no longer a demonstrated need for this option.

The `WithSQLTransformer` option was added (#329) and can be used to transform raw SQL operations in #330, removing the need for the `WithRawSQLURL` option.
