### PR TITLE
Disallow unknown fields in migration JSON

### DIFF
--- a/pkg/migrations/op_common.go
+++ b/pkg/migrations/op_common.go
@@ -46,9 +46,11 @@ func ReadMigration(r io.Reader) (*Migration, error) {
 		return nil, err
 	}
 
+	dec := json.NewDecoder(bytes.NewReader(byteValue))
+	dec.DisallowUnknownFields()
+
 	mig := Migration{}
-	err = json.Unmarshal(byteValue, &mig)
-	if err != nil {
+	if err = dec.Decode(&mig); err != nil {
 		return nil, err
 	}
 

--- a/pkg/migrations/op_common.go
+++ b/pkg/migrations/op_common.go
@@ -124,7 +124,9 @@ func (v *Operations) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("unknown migration type: %v", opName)
 		}
 
-		if err := json.Unmarshal(logBody, item); err != nil {
+		dec := json.NewDecoder(bytes.NewReader(logBody))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(item); err != nil {
 			return fmt.Errorf("decode migration [%v]: %w", opName, err)
 		}
 


### PR DESCRIPTION
Change JSON decoding of migrations to disallow unknown fields.