### PR TITLE
Add complete phase hooks

### DIFF
--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -151,6 +151,18 @@ func (m *Roll) Complete(ctx context.Context) error {
 		return fmt.Errorf("unable to read schema: %w", err)
 	}
 
+	// run any BeforeCompleteDDL hooks
+	if m.migrationHooks.BeforeCompleteDDL != nil {
+		if err := m.migrationHooks.BeforeCompleteDDL(m); err != nil {
+			return fmt.Errorf("failed to execute BeforeCompleteDDL hook: %w", err)
+		}
+	}
+
+	// defer execution of any AfterCompleteDDL hooks
+	if m.migrationHooks.AfterCompleteDDL != nil {
+		defer m.migrationHooks.AfterCompleteDDL(m)
+	}
+
 	// execute operations
 	refreshViews := false
 	for _, op := range migration.Operations {

--- a/pkg/roll/execute_test.go
+++ b/pkg/roll/execute_test.go
@@ -565,6 +565,14 @@ func TestMigrationHooksAreInvoked(t *testing.T) {
 			_, err := m.PgConn().ExecContext(context.Background(), "CREATE TABLE after_start_ddl (id integer)")
 			return err
 		},
+		BeforeCompleteDDL: func(m *roll.Roll) error {
+			_, err := m.PgConn().ExecContext(context.Background(), "CREATE TABLE before_complete_ddl (id integer)")
+			return err
+		},
+		AfterCompleteDDL: func(m *roll.Roll) error {
+			_, err := m.PgConn().ExecContext(context.Background(), "CREATE TABLE after_complete_ddl (id integer)")
+			return err
+		},
 	})}
 
 	testutils.WithMigratorInSchemaAndConnectionToContainerWithOptions(t, "public", options, func(mig *roll.Roll, db *sql.DB) {
@@ -584,6 +592,10 @@ func TestMigrationHooksAreInvoked(t *testing.T) {
 		// Complete the migration
 		err = mig.Complete(ctx)
 		assert.NoError(t, err)
+
+		// Ensure that both the before_complete_ddl and after_complete_ddl tables were created
+		assert.True(t, tableExists(t, db, "public", "before_complete_ddl"))
+		assert.True(t, tableExists(t, db, "public", "after_complete_ddl"))
 	})
 }
 

--- a/pkg/roll/options.go
+++ b/pkg/roll/options.go
@@ -28,6 +28,10 @@ type MigrationHooks struct {
 	BeforeStartDDL func(*Roll) error
 	// AfterStartDDL is called after the DDL phase of migration start is complete
 	AfterStartDDL func(*Roll) error
+	// BeforeCompleteDDL is called before the DDL phase of migration complete
+	BeforeCompleteDDL func(*Roll) error
+	// AfterCompleteDDL is called after the DDL phase of migration complete is complete
+	AfterCompleteDDL func(*Roll) error
 }
 
 type Option func(*options)


### PR DESCRIPTION
Extend `MigrationHooks` with two new hooks:

* `BeforeCompleteDDL` - run before any DDL operations on migration completion.
* `AfterCompleteDDL` - guaranteed to run after DDL operations on migration complete are finished.

These hooks can be used, for example, to temporarily switch off schema replication until all DDL has completed.