### PR TITLE
Allow rename-only 'alter-column' operations on unbackfillable columns

### DIFF
--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -189,10 +189,12 @@ func (o *OpAlterColumn) Validate(ctx context.Context, s *schema.Schema) error {
 		return ColumnDoesNotExistError{Table: o.Table, Name: o.Column}
 	}
 
-	// Ensure that the column has a primary key defined on exactly one column.
-	err := checkBackfill(table)
-	if err != nil {
-		return err
+	// If the operation requires backfills (ie it isn't a rename-only operation),
+	// ensure that the column meets the requirements for backfilling.
+	if !o.isRenameOnly() {
+		if err := checkBackfill(table); err != nil {
+			return err
+		}
 	}
 
 	// If the column is being renamed, ensure that the target column name does


### PR DESCRIPTION
Allow rename-only 'alter column' operations on unbackfillable columns. Rename operations don't require backfills so there is no reason to impose such a restriction.

Fixes #340