### PR TITLE
Dont duplicate `CHECK` constraints and `DEFAULT`s when altering column type

### DIFF
--- a/pkg/migrations/duplicate.go
+++ b/pkg/migrations/duplicate.go
@@ -49,8 +49,8 @@ func (d *Duplicator) WithoutNotNull() *Duplicator {
 	return d
 }
 
-// Duplicate creates a new column with the same type and foreign key
-// constraints as the original column.
+// Duplicate duplicates a column in the table, including all constraints and
+// comments.
 func (d *Duplicator) Duplicate(ctx context.Context) error {
 	const (
 		cAlterTableSQL         = `ALTER TABLE %s ADD COLUMN %s %s`


### PR DESCRIPTION
When a column is duplicated with a new type, check constraints and defaults defined on the column *may* be incompatible with the new type.

In this case column duplication should not fail, but rather the incompatible constraints and defaults should be ignored and not be duplicated to the new column.

This PR changes column duplication to ignore errors on `DEFAULT` and `CHECK` constraint duplication that look as though they are caused by a change of column type.

Fixes https://github.com/xataio/pgroll/issues/348