### PR TITLE
Make `down` SQL in rename column operations use the new name of the column

### DIFF
--- a/examples/35_alter_column_multiple.json
+++ b/examples/35_alter_column_multiple.json
@@ -18,7 +18,7 @@
           "constraint": "length(name) > 3"
         },
         "up": "(SELECT CASE WHEN name IS NULL OR LENGTH(name) <= 3 THEN 'placeholder' ELSE name END)",
-        "down": "name"
+        "down": "event_name"
       }
     }
   ]

--- a/pkg/migrations/op_alter_column_test.go
+++ b/pkg/migrations/op_alter_column_test.go
@@ -46,7 +46,7 @@ func TestAlterColumnMultipleSubOperations(t *testing.T) {
 							Table:    "events",
 							Column:   "name",
 							Up:       "(SELECT CASE WHEN name IS NULL OR LENGTH(name) <= 3 THEN 'placeholder' ELSE name END)",
-							Down:     "name",
+							Down:     "event_name",
 							Name:     ptr("event_name"),
 							Type:     ptr("text"),
 							Comment:  nullable.NewNullableWithValue("the name of the event"),
@@ -319,7 +319,7 @@ func TestAlterColumnMultipleSubOperations(t *testing.T) {
 							Table:  "events",
 							Column: "name",
 							Up:     "name || '-' || random()*999::int",
-							Down:   "name",
+							Down:   "event_name",
 							Name:   ptr("event_name"),
 							Unique: &migrations.UniqueConstraint{
 								Name: "events_event_name_unique",


### PR DESCRIPTION
Ensure that 'alter column' operations that rename a column and also specify `down` SQL (such as those that alter some other column attribute at the time of the rename) must use the new name of the column in the `down` SQL.

Without this change, the `down` SQL would require the use of the old column name.

Fixes #350 