### PR TITLE
Infer `CREATE/DROP SCHEMA` migrations

### DIFF
--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -197,6 +197,25 @@ func TestInferredMigration(t *testing.T) {
 					},
 				},
 			},
+			{
+				name: "create/drop schema",
+				sqlStmts: []string{
+					"CREATE SCHEMA foo",
+					"DROP SCHEMA foo",
+				},
+				wantMigrations: []migrations.Migration{
+					{
+						Operations: migrations.Operations{
+							&migrations.OpRawSQL{Up: "CREATE SCHEMA foo"},
+						},
+					},
+					{
+						Operations: migrations.Operations{
+							&migrations.OpRawSQL{Up: "DROP SCHEMA foo"},
+						},
+					},
+				},
+			},
 		}
 
 		for _, tt := range tests {


### PR DESCRIPTION
Update the `raw_migation` event trigger function to capture `CREATE SCHEMA` and `DROP SCHEMA` statements.

