### PR TITLE
Revert "Add support to list views (#358)"

### DIFF
--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -26,8 +26,6 @@ type Schema struct {
 	Name string `json:"name"`
 	// Tables is a map of virtual table name -> table mapping
 	Tables map[string]Table `json:"tables"`
-	// Views is a map of virtual view name -> view mapping
-	Views map[string]View `json:"views"`
 }
 
 type Table struct {
@@ -57,23 +55,6 @@ type Table struct {
 
 	// UniqueConstraints is a map of all unique constraints defined on the table
 	UniqueConstraints map[string]UniqueConstraint `json:"uniqueConstraints"`
-}
-
-type View struct {
-	// OID for the view
-	OID string `json:"oid"`
-
-	// Name is the actual name in postgres
-	Name string `json:"name"`
-
-	// Optional comment for the view
-	Comment string `json:"comment"`
-
-	// Definition is the SQL definition of the view
-	Definition string `json:"definition"`
-
-	// Columns is a map of virtual column name -> column mapping
-	Columns map[string]Column `json:"columns"`
 }
 
 type Column struct {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -94,7 +94,7 @@ STABLE;
 CREATE OR REPLACE FUNCTION %[1]s.read_schema(schemaname text) RETURNS jsonb
 LANGUAGE plpgsql AS $$
 DECLARE
-	result jsonb;
+	tables jsonb;
 BEGIN
 	SELECT json_build_object(
 		'name', schemaname,
@@ -255,43 +255,11 @@ BEGIN
 			WHERE
 				ns.nspname = schemaname
 				AND t.relkind IN ('r', 'p') -- tables only (ignores views, materialized views & foreign tables)
-			),
-		'views', (
-			SELECT COALESCE(json_object_agg(v.relname, jsonb_build_object(
-				'name', v.relname,
-				'oid', v.oid,
-				'comment', descr.description,
-				'definition', pg_get_viewdef(v.oid, true),
-				'columns', (
-					SELECT COALESCE(json_object_agg(name, c), '{}'::json) FROM (
-						SELECT
-							attr.attname AS name,
-							format_type(attr.atttypid, attr.atttypmod) AS type,
-							descr.description AS comment
-						FROM
-							pg_attribute AS attr
-							LEFT JOIN pg_description AS descr ON attr.attrelid = descr.objoid
-							AND attr.attnum = descr.objsubid
-						WHERE
-							attr.attnum > 0
-							AND NOT attr.attisdropped
-							AND attr.attrelid = v.oid
-						ORDER BY
-							attr.attnum
-					) c
-				)
-			)), '{}'::json) FROM pg_class AS v
-				INNER JOIN pg_namespace AS ns ON v.relnamespace = ns.oid
-				LEFT JOIN pg_description AS descr ON v.oid = descr.objoid
-				AND descr.objsubid = 0
-			WHERE
-				ns.nspname = schemaname
-				AND v.relkind = 'v' -- views only
 			)
 		)
-	INTO result;
+	INTO tables;
 
-	RETURN result;
+	RETURN tables;
 END;
 $$;
 

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -311,7 +311,6 @@ func TestReadSchema(t *testing.T) {
 				wantSchema: &schema.Schema{
 					Name:   "public",
 					Tables: map[string]schema.Table{},
-					Views:  map[string]schema.View{},
 				},
 			},
 			{
@@ -328,27 +327,6 @@ func TestReadSchema(t *testing.T) {
 							CheckConstraints:  map[string]schema.CheckConstraint{},
 							UniqueConstraints: map[string]schema.UniqueConstraint{},
 							ForeignKeys:       map[string]schema.ForeignKey{},
-						},
-					},
-					Views: map[string]schema.View{},
-				},
-			},
-			{
-				name:       "one view without columns",
-				createStmt: "CREATE VIEW public.view1 AS SELECT 1 AS foo",
-				wantSchema: &schema.Schema{
-					Name:   "public",
-					Tables: map[string]schema.Table{},
-					Views: map[string]schema.View{
-						"view1": {
-							Name:       "view1",
-							Definition: " SELECT 1 AS foo;",
-							Columns: map[string]schema.Column{
-								"foo": {
-									Name: "foo",
-									Type: "integer",
-								},
-							},
 						},
 					},
 				},
@@ -375,7 +353,6 @@ func TestReadSchema(t *testing.T) {
 							ForeignKeys:       map[string]schema.ForeignKey{},
 						},
 					},
-					Views: map[string]schema.View{},
 				},
 			},
 			{
@@ -412,7 +389,6 @@ func TestReadSchema(t *testing.T) {
 							ForeignKeys: map[string]schema.ForeignKey{},
 						},
 					},
-					Views: map[string]schema.View{},
 				},
 			},
 			{
@@ -448,7 +424,6 @@ func TestReadSchema(t *testing.T) {
 							ForeignKeys:       map[string]schema.ForeignKey{},
 						},
 					},
-					Views: map[string]schema.View{},
 				},
 			},
 			{
@@ -503,7 +478,6 @@ func TestReadSchema(t *testing.T) {
 							UniqueConstraints: map[string]schema.UniqueConstraint{},
 						},
 					},
-					Views: map[string]schema.View{},
 				},
 			},
 			{
@@ -558,7 +532,6 @@ func TestReadSchema(t *testing.T) {
 							UniqueConstraints: map[string]schema.UniqueConstraint{},
 						},
 					},
-					Views: map[string]schema.View{},
 				},
 			},
 			{
@@ -601,7 +574,6 @@ func TestReadSchema(t *testing.T) {
 							UniqueConstraints: map[string]schema.UniqueConstraint{},
 						},
 					},
-					Views: map[string]schema.View{},
 				},
 			},
 			{
@@ -649,7 +621,6 @@ func TestReadSchema(t *testing.T) {
 							},
 						},
 					},
-					Views: map[string]schema.View{},
 				},
 			},
 			{
@@ -697,7 +668,6 @@ func TestReadSchema(t *testing.T) {
 							},
 						},
 					},
-					Views: map[string]schema.View{},
 				},
 			},
 			{
@@ -733,7 +703,6 @@ func TestReadSchema(t *testing.T) {
 							UniqueConstraints: map[string]schema.UniqueConstraint{},
 						},
 					},
-					Views: map[string]schema.View{},
 				},
 			},
 			{
@@ -758,7 +727,6 @@ func TestReadSchema(t *testing.T) {
 							UniqueConstraints: map[string]schema.UniqueConstraint{},
 						},
 					},
-					Views: map[string]schema.View{},
 				},
 			},
 		}
@@ -777,7 +745,7 @@ func TestReadSchema(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if diff := cmp.Diff(tt.wantSchema, gotSchema, cmpopts.IgnoreFields(schema.Table{}, "OID"), cmpopts.IgnoreFields(schema.View{}, "OID")); diff != "" {
+				if diff := cmp.Diff(tt.wantSchema, gotSchema, cmpopts.IgnoreFields(schema.Table{}, "OID")); diff != "" {
 					t.Errorf("expected schema mismatch (-want +got):\n%s", diff)
 				}
 			})


### PR DESCRIPTION
The state query changes from #358 are causing performance issues in an upstream integration of `pgroll`.

Revert the PR until the cause of the regression is found and fixed.

This reverts commit f994a421923c979491d8cefb81c8d6238ae50757.