### PR TITLE
Add `WithNoVersionSchemaForRawSQL` option

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -85,3 +85,13 @@ func (m *Migration) Validate(ctx context.Context, s *schema.Schema) error {
 
 	return nil
 }
+
+// ContainsRawSQLOperation returns true if the migration contains a raw SQL operation
+func (m *Migration) ContainsRawSQLOperation() bool {
+	for _, op := range m.Operations {
+		if _, ok := op.(*OpRawSQL); ok {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/roll/options.go
+++ b/pkg/roll/options.go
@@ -18,7 +18,11 @@ type options struct {
 
 	// disable pgroll version schemas creation and deletion
 	disableVersionSchemas bool
-	migrationHooks        MigrationHooks
+
+	// disable creation of version schema for raw SQL migrations
+	noVersionSchemaForRawSQL bool
+
+	migrationHooks MigrationHooks
 }
 
 // MigrationHooks defines hooks that can be set to be called at various points
@@ -55,6 +59,12 @@ func WithRole(role string) Option {
 func WithDisableViewsManagement() Option {
 	return func(o *options) {
 		o.disableVersionSchemas = true
+	}
+}
+
+func WithNoVersionSchemaForRawSQL() Option {
+	return func(o *options) {
+		o.noVersionSchemaForRawSQL = true
 	}
 }
 

--- a/pkg/roll/roll.go
+++ b/pkg/roll/roll.go
@@ -27,6 +27,9 @@ type Roll struct {
 	// disable pgroll version schemas creation and deletion
 	disableVersionSchemas bool
 
+	// disable creation of version schema for raw SQL migrations
+	noVersionSchemaForRawSQL bool
+
 	migrationHooks MigrationHooks
 	state          *state.State
 	pgVersion      PGVersion
@@ -58,13 +61,14 @@ func New(ctx context.Context, pgURL, schema string, state *state.State, opts ...
 	}
 
 	return &Roll{
-		pgConn:                &db.RDB{DB: conn},
-		schema:                schema,
-		state:                 state,
-		pgVersion:             PGVersion(pgMajorVersion),
-		disableVersionSchemas: rollOpts.disableVersionSchemas,
-		migrationHooks:        rollOpts.migrationHooks,
-		sqlTransformer:        sqlTransformer,
+		pgConn:                   &db.RDB{DB: conn},
+		schema:                   schema,
+		state:                    state,
+		pgVersion:                PGVersion(pgMajorVersion),
+		disableVersionSchemas:    rollOpts.disableVersionSchemas,
+		noVersionSchemaForRawSQL: rollOpts.noVersionSchemaForRawSQL,
+		migrationHooks:           rollOpts.migrationHooks,
+		sqlTransformer:           sqlTransformer,
 	}, nil
 }
 


### PR DESCRIPTION
Add a new `WithNoVersionSchemaForRawSQL` option to control whether or not version schema should be created for raw SQL migrations.

With the option set, a raw SQL migration:
* Has no version schema created on migration start.
* Leaves the previous version schema in place on migration completion.