### PR TITLE
Add `roll.WithSearchPath` option

### DIFF
--- a/pkg/roll/options.go
+++ b/pkg/roll/options.go
@@ -22,6 +22,9 @@ type options struct {
 	// disable creation of version schema for raw SQL migrations
 	noVersionSchemaForRawSQL bool
 
+	// additional entries to add to the search_path during migration execution
+	searchPath []string
+
 	migrationHooks MigrationHooks
 }
 
@@ -84,5 +87,14 @@ func WithMigrationHooks(hooks MigrationHooks) Option {
 func WithSQLTransformer(transformer migrations.SQLTransformer) Option {
 	return func(o *options) {
 		o.sqlTransformer = transformer
+	}
+}
+
+// WithSearchPath sets the search_path to use during migration execution. The
+// schema in which the migration is run is always included in the search path,
+// regardless of this setting.
+func WithSearchPath(schemas ...string) Option {
+	return func(o *options) {
+		o.searchPath = schemas
 	}
 }

--- a/pkg/roll/roll.go
+++ b/pkg/roll/roll.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/lib/pq"
 
@@ -78,7 +79,8 @@ func setupConn(ctx context.Context, pgURL, schema string, options options) (*sql
 		dsn = pgURL
 	}
 
-	dsn += " search_path=" + schema
+	searchPath := append([]string{schema}, options.searchPath...)
+	dsn += " search_path=" + strings.Join(searchPath, ",")
 
 	conn, err := sql.Open("postgres", dsn)
 	if err != nil {


### PR DESCRIPTION
Add a `roll.WithSearchPath` option to allow widening of the search path during migration execution.

By default, the session that executes a migration has its search path restricted to the schema in which the migration is applied.  By using `WithSearchPath` the search path can include arbitrarily many other schema.