### PR TITLE
Chore: Add migration start message with schema name

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -32,7 +32,7 @@ func startCmd() *cobra.Command {
 			}
 			defer m.Close()
 
-			file, err := os.Open(args[0])
+			file, err := os.Open(fileName)
 			if err != nil {
 				return fmt.Errorf("opening migration file: %w", err)
 			}
@@ -61,7 +61,10 @@ func startCmd() *cobra.Command {
 				}
 			}
 
-			version := strings.TrimSuffix(filepath.Base(fileName), filepath.Ext(fileName))
+			version := migration.Name
+			if version == "" {
+				version = strings.TrimSuffix(filepath.Base(fileName), filepath.Ext(fileName))
+			}
 			viewName := roll.VersionedSchemaName(flags.Schema(), version)
 			msg := fmt.Sprintf("New version of the schema available under the postgres %q schema", viewName)
 			sp.Success(msg)


### PR DESCRIPTION
Hi, I noticed an issue that seemed like a quick fix, so I went ahead and made the changes.
The related issue is here: 
- https://github.com/xataio/pgroll/issues/368

In this PR, I made changes to prioritize using the `name` property in migration file. If `name` is empty, we fall back to using the filename.

I'd appreciate it if you could take a look when you have some time.