### PR TITLE
Add pgroll binary to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ bin/license-header-checker
 # misc
 .DS_Store
 .env
+pgroll
 
 dist/


### PR DESCRIPTION
So we don't check in the binary by mistake after running `go build`