### PR TITLE
Add missing doc comments to exported symbols

### DIFF
--- a/pkg/migrations/check.go
+++ b/pkg/migrations/check.go
@@ -2,6 +2,7 @@
 
 package migrations
 
+// Validate checks that the CheckConstraint is valid
 func (c *CheckConstraint) Validate() error {
 	if c.Name == "" {
 		return FieldRequiredError{Name: "name"}

--- a/pkg/migrations/column.go
+++ b/pkg/migrations/column.go
@@ -2,6 +2,7 @@
 
 package migrations
 
+// IsNullable returns true if the column is nullable
 func (c *Column) IsNullable() bool {
 	if c.Nullable != nil {
 		return *c.Nullable
@@ -9,6 +10,7 @@ func (c *Column) IsNullable() bool {
 	return false
 }
 
+// IsUnique returns true if the column values must be unique
 func (c *Column) IsUnique() bool {
 	if c.Unique != nil {
 		return *c.Unique
@@ -16,6 +18,7 @@ func (c *Column) IsUnique() bool {
 	return false
 }
 
+// IsPrimaryKey returns true if the column is part of the primary key
 func (c *Column) IsPrimaryKey() bool {
 	if c.Pk != nil {
 		return *c.Pk

--- a/pkg/migrations/duplicate.go
+++ b/pkg/migrations/duplicate.go
@@ -14,6 +14,8 @@ import (
 	"github.com/xataio/pgroll/pkg/schema"
 )
 
+// Duplicator duplicates a column in a table, including all constraints and
+// comments.
 type Duplicator struct {
 	conn              db.DB
 	table             *schema.Table
@@ -40,16 +42,19 @@ func NewColumnDuplicator(conn db.DB, table *schema.Table, column *schema.Column)
 	}
 }
 
+// WithType sets the type of the new column.
 func (d *Duplicator) WithType(t string) *Duplicator {
 	d.withType = t
 	return d
 }
 
+// WithoutConstraint excludes a constraint from being duplicated.
 func (d *Duplicator) WithoutConstraint(c string) *Duplicator {
 	d.withoutConstraint = c
 	return d
 }
 
+// WithoutNotNull excludes the NOT NULL constraint from being duplicated.
 func (d *Duplicator) WithoutNotNull() *Duplicator {
 	d.withoutNotNull = true
 	return d
@@ -182,14 +187,17 @@ func (d *Duplicator) Duplicate(ctx context.Context) error {
 	return nil
 }
 
+// DiplicationName returns the name of a duplicated column.
 func DuplicationName(name string) string {
 	return "_pgroll_dup_" + name
 }
 
+// IsDuplicatedName returns true if the name is a duplicated column name.
 func IsDuplicatedName(name string) bool {
 	return strings.HasPrefix(name, "_pgroll_dup_")
 }
 
+// StripDuplicationPrefix removes the duplication prefix from a column name.
 func StripDuplicationPrefix(name string) string {
 	return strings.TrimPrefix(name, "_pgroll_dup_")
 }

--- a/pkg/migrations/fk_reference.go
+++ b/pkg/migrations/fk_reference.go
@@ -8,6 +8,7 @@ import (
 	"github.com/xataio/pgroll/pkg/schema"
 )
 
+// Validate checks that the ForeignKeyReference is valid
 func (f *ForeignKeyReference) Validate(s *schema.Schema) error {
 	if f.Name == "" {
 		return FieldRequiredError{Name: "name"}

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -13,6 +13,7 @@ import (
 
 type CallbackFn func(int64)
 
+// Operation is an operation that can be applied to a schema
 type Operation interface {
 	// Start will apply the required changes to enable supporting the new schema
 	// version in the database (through a view)
@@ -22,31 +23,33 @@ type Operation interface {
 
 	// Complete will update the database schema to match the current version
 	// after calling Start.
-	// This method should be called once the previous version is no longer used
+	// This method should be called once the previous version is no longer used.
 	Complete(ctx context.Context, conn db.DB, tr SQLTransformer, s *schema.Schema) error
 
 	// Rollback will revert the changes made by Start. It is not possible to
 	// rollback a completed migration.
 	Rollback(ctx context.Context, conn db.DB, tr SQLTransformer) error
 
-	// Validate returns a descriptive error if the operation cannot be applied to the given schema
+	// Validate returns a descriptive error if the operation cannot be applied to the given schema.
 	Validate(ctx context.Context, s *schema.Schema) error
 }
 
 // IsolatedOperation is an operation that cannot be executed with other operations
-// in the same migration
+// in the same migration.
 type IsolatedOperation interface {
-	// this operation is isolated when executed on start, cannot be executed with other operations
+	// this operation is isolated when executed on start, cannot be executed with other operations.
 	IsIsolated() bool
 }
 
-// RequiresSchemaRefreshOperation is an operation that requires the resulting schema to be refreshed
+// RequiresSchemaRefreshOperation is an operation that requires the resulting schema to be refreshed.
 type RequiresSchemaRefreshOperation interface {
 	// this operation requires the resulting schema to be refreshed when executed on start
 	RequiresSchemaRefresh()
 }
 
+// SQLTransformer is an interface that can be used to transform SQL statements.
 type SQLTransformer interface {
+	// TransformSQL will transform the given SQL statement.
 	TransformSQL(sql string) (string, error)
 }
 

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -234,10 +234,12 @@ func (o *OpAddColumn) addCheckConstraint(ctx context.Context, conn db.DB) error 
 	return err
 }
 
+// NotNullConstraintName returns the name of the NOT NULL constraint for the given column
 func NotNullConstraintName(columnName string) string {
 	return "_pgroll_check_not_null_" + columnName
 }
 
+// IsNotNullConstraintName returns true if the given name is a NOT NULL constraint name
 func IsNotNullConstraintName(name string) bool {
 	return strings.HasPrefix(name, "_pgroll_check_not_null_")
 }

--- a/pkg/migrations/op_common.go
+++ b/pkg/migrations/op_common.go
@@ -36,10 +36,12 @@ const (
 
 const temporaryPrefix = "_pgroll_new_"
 
+// TemporaryName returns a temporary name for a given name.
 func TemporaryName(name string) string {
 	return temporaryPrefix + name
 }
 
+// ReadMigration reads a migration from an io.Reader, like a file.
 func ReadMigration(r io.Reader) (*Migration, error) {
 	byteValue, err := io.ReadAll(r)
 	if err != nil {
@@ -166,6 +168,7 @@ func (v Operations) MarshalJSON() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// OperationName returns the name of the operation.
 func OperationName(op Operation) OpName {
 	switch op.(type) {
 	case *OpCreateTable:

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -126,6 +126,7 @@ func columnsToSQL(cols []Column, tr SQLTransformer) (string, error) {
 	return sql, nil
 }
 
+// ColumnToSQL generates the SQL for a column definition.
 func ColumnToSQL(col Column, tr SQLTransformer) (string, error) {
 	sql := fmt.Sprintf("%s %s", pq.QuoteIdentifier(col.Name), col.Type)
 

--- a/pkg/migrations/op_drop_not_null.go
+++ b/pkg/migrations/op_drop_not_null.go
@@ -9,6 +9,7 @@ import (
 	"github.com/xataio/pgroll/pkg/schema"
 )
 
+// OpDropNotNull is an operation that drops the NOT NULL constraint from a column
 type OpDropNotNull struct {
 	Table  string `json:"table"`
 	Column string `json:"column"`

--- a/pkg/migrations/op_raw_sql.go
+++ b/pkg/migrations/op_raw_sql.go
@@ -65,6 +65,7 @@ func (o *OpRawSQL) Validate(ctx context.Context, s *schema.Schema) error {
 	return nil
 }
 
+// IsIsolated returns true if the operation is isolated and should be run with other operations.
 func (o *OpRawSQL) IsIsolated() bool {
 	return !o.OnComplete
 }

--- a/pkg/migrations/op_set_comment.go
+++ b/pkg/migrations/op_set_comment.go
@@ -9,6 +9,7 @@ import (
 	"github.com/xataio/pgroll/pkg/schema"
 )
 
+// OpSetComment is a operation that sets a comment on a object.
 type OpSetComment struct {
 	Table   string  `json:"table"`
 	Column  string  `json:"column"`

--- a/pkg/migrations/trigger.go
+++ b/pkg/migrations/trigger.go
@@ -71,10 +71,13 @@ func buildTrigger(cfg triggerConfig) (string, error) {
 	return executeTemplate("trigger", templates.Trigger, cfg)
 }
 
+// TriggerFunctionName returns the name of the trigger function
+// for a given table and column.
 func TriggerFunctionName(tableName, columnName string) string {
 	return "_pgroll_trigger_" + tableName + "_" + columnName
 }
 
+// TriggerName returns the name of the trigger for a given table and column.
 func TriggerName(tableName, columnName string) string {
 	return TriggerFunctionName(tableName, columnName)
 }

--- a/pkg/migrations/unique.go
+++ b/pkg/migrations/unique.go
@@ -2,6 +2,7 @@
 
 package migrations
 
+// Validate validates the UniqueConstraint
 func (c *UniqueConstraint) Validate() error {
 	if c.Name == "" {
 		return FieldRequiredError{Name: "name"}

--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -200,6 +200,7 @@ func (m *Roll) Complete(ctx context.Context) error {
 	return nil
 }
 
+// Rollback will revert the changes made by the migration
 func (m *Roll) Rollback(ctx context.Context) error {
 	// get current ongoing migration
 	migration, err := m.state.GetActiveMigration(ctx, m.schema)

--- a/pkg/roll/options.go
+++ b/pkg/roll/options.go
@@ -65,6 +65,7 @@ func WithDisableViewsManagement() Option {
 	}
 }
 
+// WithNoVersionSchemaForRawSQL disables the creation of version schema for raw SQL migrations
 func WithNoVersionSchemaForRawSQL() Option {
 	return func(o *options) {
 		o.noVersionSchemaForRawSQL = true

--- a/pkg/roll/roll.go
+++ b/pkg/roll/roll.go
@@ -37,6 +37,7 @@ type Roll struct {
 	sqlTransformer migrations.SQLTransformer
 }
 
+// New creates a new Roll instance
 func New(ctx context.Context, pgURL, schema string, state *state.State, opts ...Option) (*Roll, error) {
 	rollOpts := &options{}
 	for _, o := range opts {
@@ -113,22 +114,27 @@ func setupConn(ctx context.Context, pgURL, schema string, options options) (*sql
 	return conn, nil
 }
 
+// Init initializes the Roll instance
 func (m *Roll) Init(ctx context.Context) error {
 	return m.state.Init(ctx)
 }
 
+// PGVersion returns the postgres version
 func (m *Roll) PGVersion() PGVersion {
 	return m.pgVersion
 }
 
+// PgConn returns the underlying database connection
 func (m *Roll) PgConn() db.DB {
 	return m.pgConn
 }
 
+// Schema returns the schema the Roll instance is acting on
 func (m *Roll) Schema() string {
 	return m.schema
 }
 
+// Status returns the current migration status
 func (m *Roll) Status(ctx context.Context, schema string) (*state.Status, error) {
 	return m.state.Status(ctx, schema)
 }

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -21,6 +21,7 @@ func New() *Schema {
 	}
 }
 
+// Schema represents a database schema
 type Schema struct {
 	// Name is the name of the schema
 	Name string `json:"name"`
@@ -28,6 +29,7 @@ type Schema struct {
 	Tables map[string]Table `json:"tables"`
 }
 
+// Table represents a table in the schema
 type Table struct {
 	// OID for the table
 	OID string `json:"oid"`
@@ -57,6 +59,7 @@ type Table struct {
 	UniqueConstraints map[string]UniqueConstraint `json:"uniqueConstraints"`
 }
 
+// Column represents a column in a table
 type Column struct {
 	// Name is the actual name in postgres
 	Name string `json:"name"`
@@ -72,6 +75,7 @@ type Column struct {
 	Comment string `json:"comment"`
 }
 
+// Index represents an index on a table
 type Index struct {
 	// Name is the name of the index in postgres
 	Name string `json:"name"`
@@ -83,6 +87,7 @@ type Index struct {
 	Columns []string `json:"columns"`
 }
 
+// ForeignKey represents a foreign key on a table
 type ForeignKey struct {
 	// Name is the name of the foreign key in postgres
 	Name string `json:"name"`
@@ -100,6 +105,7 @@ type ForeignKey struct {
 	OnDelete string `json:"onDelete"`
 }
 
+// CheckConstraint represents a check constraint on a table
 type CheckConstraint struct {
 	// Name is the name of the check constraint in postgres
 	Name string `json:"name"`
@@ -111,6 +117,7 @@ type CheckConstraint struct {
 	Definition string `json:"definition"`
 }
 
+// UniqueConstraint represents a unique constraint on a table
 type UniqueConstraint struct {
 	// Name is the name of the unique constraint in postgres
 	Name string `json:"name"`
@@ -119,6 +126,7 @@ type UniqueConstraint struct {
 	Columns []string `json:"columns"`
 }
 
+// GetTable returns a table by name
 func (s *Schema) GetTable(name string) *Table {
 	if s.Tables == nil {
 		return nil
@@ -130,6 +138,7 @@ func (s *Schema) GetTable(name string) *Table {
 	return &t
 }
 
+// AddTable adds a table to the schema
 func (s *Schema) AddTable(name string, t Table) {
 	if s.Tables == nil {
 		s.Tables = make(map[string]Table)
@@ -138,6 +147,7 @@ func (s *Schema) AddTable(name string, t Table) {
 	s.Tables[name] = t
 }
 
+// RenameTable renames a table in the schema
 func (s *Schema) RenameTable(from, to string) error {
 	if s.GetTable(from) == nil {
 		return fmt.Errorf("table %q does not exist", from)
@@ -152,10 +162,12 @@ func (s *Schema) RenameTable(from, to string) error {
 	return nil
 }
 
+// RemoveTable removes a table from the schema
 func (s *Schema) RemoveTable(name string) {
 	delete(s.Tables, name)
 }
 
+// GetColumn returns a column by name
 func (t *Table) GetColumn(name string) *Column {
 	if t.Columns == nil {
 		return nil
@@ -167,6 +179,7 @@ func (t *Table) GetColumn(name string) *Column {
 	return &c
 }
 
+// ConstraintExists returns true if a constraint with the given name exists
 func (t *Table) ConstraintExists(name string) bool {
 	_, ok := t.CheckConstraints[name]
 	if ok {
@@ -180,6 +193,7 @@ func (t *Table) ConstraintExists(name string) bool {
 	return ok
 }
 
+// GetPrimaryKey returns the columns that make up the primary key
 func (t *Table) GetPrimaryKey() (columns []*Column) {
 	for _, name := range t.PrimaryKey {
 		columns = append(columns, t.GetColumn(name))
@@ -187,6 +201,7 @@ func (t *Table) GetPrimaryKey() (columns []*Column) {
 	return columns
 }
 
+// AddColumn adds a column to the table
 func (t *Table) AddColumn(name string, c Column) {
 	if t.Columns == nil {
 		t.Columns = make(map[string]Column)
@@ -195,10 +210,12 @@ func (t *Table) AddColumn(name string, c Column) {
 	t.Columns[name] = c
 }
 
+// RemoveColumn removes a column from the table
 func (t *Table) RemoveColumn(column string) {
 	delete(t.Columns, column)
 }
 
+// RenameColumn renames a column in the table
 func (t *Table) RenameColumn(from, to string) {
 	t.Columns[to] = t.Columns[from]
 	delete(t.Columns, from)

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -391,6 +391,7 @@ func New(ctx context.Context, pgURL, stateSchema string) (*State, error) {
 	}, nil
 }
 
+// Init initializes the required pg_roll schema to store the state
 func (s *State) Init(ctx context.Context) error {
 	tx, err := s.pgConn.Begin()
 	if err != nil {
@@ -420,6 +421,7 @@ func (s *State) Close() error {
 	return s.pgConn.Close()
 }
 
+// Schema returns the schema name
 func (s *State) Schema() string {
 	return s.schema
 }
@@ -566,6 +568,7 @@ func (s *State) Complete(ctx context.Context, schema, name string) error {
 	return err
 }
 
+// ReadSchema reads the schema for the specified schema name
 func (s *State) ReadSchema(ctx context.Context, schemaName string) (*schema.Schema, error) {
 	var rawSchema []byte
 	err := s.pgConn.QueryRowContext(ctx, fmt.Sprintf("SELECT %s.read_schema($1)", s.schema), schemaName).Scan(&rawSchema)


### PR DESCRIPTION
While going through pgroll codebase I see that it is also really nicely documented overall.

I took this chance to add doc comments to the remaining non-documented exported symbols.