### PR TITLE
Remove direct dependency on golang.org/x/exp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.33.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.33.0
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d
 )
 
@@ -81,6 +80,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.28.0 // indirect
 	go.opentelemetry.io/otel/trace v1.28.0 // indirect
 	golang.org/x/crypto v0.25.0 // indirect
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/sys v0.22.0 // indirect
 	golang.org/x/term v0.22.0 // indirect
 	golang.org/x/text v0.16.0 // indirect

--- a/pkg/migrations/op_common_test.go
+++ b/pkg/migrations/op_common_test.go
@@ -7,14 +7,13 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/lib/pq"
 	"github.com/xataio/pgroll/pkg/migrations"
 	"github.com/xataio/pgroll/pkg/roll"
 	"github.com/xataio/pgroll/pkg/testutils"
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 type TestCase struct {
@@ -573,7 +572,7 @@ func insert(t *testing.T, db *sql.DB, schema, version, table string, record map[
 
 	mustSetSearchPath(t, db, versionSchema)
 
-	cols := maps.Keys(record)
+	cols := mapKeys(record)
 	slices.Sort(cols)
 
 	recordStr := "("
@@ -633,7 +632,7 @@ func delete(t *testing.T, db *sql.DB, schema, version, table string, record map[
 	t.Helper()
 	versionSchema := roll.VersionedSchemaName(schema, version)
 
-	cols := maps.Keys(record)
+	cols := mapKeys(record)
 	slices.Sort(cols)
 
 	recordStr := ""
@@ -704,3 +703,11 @@ func mustSetSearchPath(t *testing.T, db *sql.DB, schema string) {
 }
 
 func ptr[T any](x T) *T { return &x }
+
+func mapKeys[M ~map[K]V, K comparable, V any](m M) []K {
+	r := make([]K, 0, len(m))
+	for k := range m {
+		r = append(r, k)
+	}
+	return r
+}


### PR DESCRIPTION
Most of what we need is already in the stdlib.