### PR TITLE
Upgrade to Go 1.23

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         # Require: The version of golangci-lint to use.
         # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
         # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-        version: v1.54.2
+        version: v1.61.0
 
         # Optional: golangci-lint command line arguments.
         #

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,6 @@ generate:
 	# Add the license header
 	echo "// SPDX-License-Identifier: Apache-2.0" | cat - pkg/migrations/types.go > pkg/migrations/types.go.tmp
 	mv pkg/migrations/types.go.tmp pkg/migrations/types.go
+
+lint:
+	golangci-lint --config=.golangci.yml run

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To install `pgroll` from the source, run the following command:
 go install github.com/xataio/pgroll@latest
 ```
 
-Note: requires [Go 1.21](https://golang.org/doc/install) or later.
+Note: requires [Go 1.23](https://golang.org/doc/install) or later.
 ### From package manager - Homebrew
 
 To install `pgroll` with homebrew, run the following command:

--- a/docs/README.md
+++ b/docs/README.md
@@ -104,7 +104,7 @@ To install `pgroll` from source, run the following command:
 go install github.com/xataio/pgroll@latest
 ```
 
-Note: requires [Go 1.21](https://golang.org/doc/install) or later.
+Note: requires [Go 1.23](https://golang.org/doc/install) or later.
 
 ### From package manager - Homebrew
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.33.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.33.0
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/xataio/pgroll
 
-go 1.21
+go 1.23
 
 require (
 	github.com/cloudflare/backoff v0.0.0-20240920015135-e46b80a3a7d0

--- a/go.sum
+++ b/go.sum
@@ -380,8 +380,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
-golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=
+golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/jsonschema/jsonschema_test.go
+++ b/pkg/jsonschema/jsonschema_test.go
@@ -29,8 +29,6 @@ func TestJSONSchemaValidation(t *testing.T) {
 	assert.NoError(t, err)
 
 	for _, file := range files {
-		file := file
-
 		t.Run(file.Name(), func(t *testing.T) {
 			ac, err := txtar.ParseFile(filepath.Join(testDataDir, file.Name()))
 			assert.NoError(t, err)

--- a/pkg/migrations/op_common_test.go
+++ b/pkg/migrations/op_common_test.go
@@ -7,14 +7,14 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"testing"
 
 	"github.com/lib/pq"
 	"github.com/xataio/pgroll/pkg/migrations"
 	"github.com/xataio/pgroll/pkg/roll"
 	"github.com/xataio/pgroll/pkg/testutils"
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 type TestCase struct {
@@ -573,7 +573,7 @@ func insert(t *testing.T, db *sql.DB, schema, version, table string, record map[
 
 	mustSetSearchPath(t, db, versionSchema)
 
-	cols := maps.Keys(record)
+	cols := slices.Collect(maps.Keys(record))
 	slices.Sort(cols)
 
 	recordStr := "("
@@ -633,7 +633,7 @@ func delete(t *testing.T, db *sql.DB, schema, version, table string, record map[
 	t.Helper()
 	versionSchema := roll.VersionedSchemaName(schema, version)
 
-	cols := maps.Keys(record)
+	cols := slices.Collect(maps.Keys(record))
 	slices.Sort(cols)
 
 	recordStr := ""


### PR DESCRIPTION
This also allows us to remove the dependency on golang.org/x/exp