### PR TITLE
Run examples against Postgres 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pgVersion: ['14.8', '15.3', '16.0', 'latest']
+        pgVersion: ['14.8', '15.3', '16.4', '17.0' ,'latest']
         testSchema: [ 'public', 'non_public' ]
     services:
       postgres:


### PR DESCRIPTION
Run the examples in CI against Postgres 17.

Tests were updated to run against PG17 in https://github.com/xataio/pgroll/pull/387, but we forgot to update the examples matrix too.