### PR TITLE
Change docker-compose port to 5432

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
     ports:
-      - '6432:5432'
+      - '5432:5432'
     volumes: 
       - /var/lib/postgresql/data


### PR DESCRIPTION
Change the Postgres port number to the default `5432` in `docker-compose.yml`.