### PR TITLE
Speed up `make examples`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,14 @@ lint:
 	golangci-lint --config=.golangci.yml run
 
 examples:
-	@go run . init
+	@go build
+	@./pgroll init
 	@for file in examples/*.json; do \
 	    if [ -f $$file ]; then \
-	        go run . start --complete $$file; \
+	        ./pgroll start --complete $$file; \
 	    fi \
 	done
+	@go clean
 
 test:
 	go test ./...


### PR DESCRIPTION
The previous versionw was building the pgroll command before every example run. Instead, build the command once at the beginning and remove it at the end.