### PR TITLE
Allow configuration of batch delay

### DIFF
--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -3,6 +3,8 @@
 package flags
 
 import (
+	"time"
+
 	"github.com/spf13/viper"
 )
 
@@ -23,6 +25,8 @@ func LockTimeout() int {
 }
 
 func BackfillBatchSize() int { return viper.GetInt("BACKFILL_BATCH_SIZE") }
+
+func BackfillBatchDelay() time.Duration { return viper.GetDuration("BACKFILL_BATCH_DELAY") }
 
 func Role() string {
 	return viper.GetString("ROLE")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ func init() {
 	rootCmd.PersistentFlags().String("pgroll-schema", "pgroll", "Postgres schema to use for pgroll internal state")
 	rootCmd.PersistentFlags().Int("lock-timeout", 500, "Postgres lock timeout in milliseconds for pgroll DDL operations")
 	rootCmd.PersistentFlags().Int("backfill-batch-size", roll.DefaultBackfillBatchSize, "Number of rows backfilled in each batch")
+	rootCmd.PersistentFlags().Duration("backfill-batch-delay", roll.DefaultBackfillDelay, "Duration of delay between batch backfills (eg. 1s, 1000ms)")
 	rootCmd.PersistentFlags().String("role", "", "Optional postgres role to set when executing migrations")
 
 	viper.BindPFlag("PG_URL", rootCmd.PersistentFlags().Lookup("postgres-url"))
@@ -32,6 +33,7 @@ func init() {
 	viper.BindPFlag("STATE_SCHEMA", rootCmd.PersistentFlags().Lookup("pgroll-schema"))
 	viper.BindPFlag("LOCK_TIMEOUT", rootCmd.PersistentFlags().Lookup("lock-timeout"))
 	viper.BindPFlag("BACKFILL_BATCH_SIZE", rootCmd.PersistentFlags().Lookup("backfill-batch-size"))
+	viper.BindPFlag("BACKFILL_BATCH_DELAY", rootCmd.PersistentFlags().Lookup("backfill-batch-delay"))
 	viper.BindPFlag("ROLE", rootCmd.PersistentFlags().Lookup("role"))
 }
 
@@ -48,6 +50,7 @@ func NewRoll(ctx context.Context) (*roll.Roll, error) {
 	lockTimeout := flags.LockTimeout()
 	role := flags.Role()
 	backfillBatchSize := flags.BackfillBatchSize()
+	backfillBatchDelay := flags.BackfillBatchDelay()
 
 	state, err := state.New(ctx, pgURL, stateSchema)
 	if err != nil {
@@ -58,6 +61,7 @@ func NewRoll(ctx context.Context) (*roll.Roll, error) {
 		roll.WithLockTimeoutMs(lockTimeout),
 		roll.WithRole(role),
 		roll.WithBackfillBatchSize(backfillBatchSize),
+		roll.WithBackfillBatchDelay(backfillBatchDelay),
 	)
 }
 

--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -277,7 +277,7 @@ func (m *Roll) ensureView(ctx context.Context, version, name string, table schem
 
 func (m *Roll) performBackfills(ctx context.Context, tables []*schema.Table, cbs ...migrations.CallbackFn) error {
 	for _, table := range tables {
-		if err := migrations.Backfill(ctx, m.pgConn, table, m.backfillBatchSize, cbs...); err != nil {
+		if err := migrations.Backfill(ctx, m.pgConn, table, m.backfillBatchSize, m.backfillBatchDelay, cbs...); err != nil {
 			errRollback := m.Rollback(ctx)
 
 			return errors.Join(

--- a/pkg/roll/options.go
+++ b/pkg/roll/options.go
@@ -3,6 +3,8 @@
 package roll
 
 import (
+	"time"
+
 	"github.com/xataio/pgroll/pkg/migrations"
 )
 
@@ -27,6 +29,9 @@ type options struct {
 
 	// the number of rows to backfill in each batch
 	backfillBatchSize int
+
+	// the duration to delay after each batch is run
+	backfillBatchDelay time.Duration
 
 	migrationHooks MigrationHooks
 }
@@ -107,5 +112,12 @@ func WithSearchPath(schemas ...string) Option {
 func WithBackfillBatchSize(batchSize int) Option {
 	return func(o *options) {
 		o.backfillBatchSize = batchSize
+	}
+}
+
+// WithBackfillBatchDelay sets the delay after each batch is run.
+func WithBackfillBatchDelay(delay time.Duration) Option {
+	return func(o *options) {
+		o.backfillBatchDelay = delay
 	}
 }


### PR DESCRIPTION
You can now configure a delay after each batch has completed. It can be configured in three ways:

* The `--backfill-batch-delay` CLI parameter
* The `PGROLL_BACKFILL_BATCH_DELAY` environment variable
* The `roll.WithBackfillBatchDelay` functional option

It defaults to 0 if not set and all values should be provided using the Go [duration format](https://pkg.go.dev/time#ParseDuration). 

Closes https://github.com/xataio/pgroll/issues/168