### PR TITLE
New command: `bootstrap`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,7 @@ lint:
 examples:
 	@go build
 	@./pgroll init
-	@for file in examples/*.json; do \
-	    if [ -f $$file ]; then \
-	        ./pgroll start --complete $$file; \
-	    fi \
-	done
+	@./pgroll bootstrap examples
 	@go clean
 
 test:

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+
+	"github.com/xataio/pgroll/cmd/flags"
+	"github.com/xataio/pgroll/pkg/migrations"
+	"github.com/xataio/pgroll/pkg/roll"
+)
+
+var bootstrapCmd = &cobra.Command{
+	Use:   "bootstrap <folder>",
+	Short: "Bootstrap a new database from a directory of migration files",
+	Long: `Bootstrap a new database from a directory of migration files. All files in the directory will be executed
+in alphabetical order. All migrations are completed.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		migrationsDir := args[0]
+
+		m, err := NewRoll(cmd.Context())
+		if err != nil {
+			return err
+		}
+		defer m.Close()
+
+		// open folder and read all json files
+		files, err := os.ReadDir(migrationsDir)
+		if err != nil {
+			return fmt.Errorf("reading migration directory: %w", err)
+		}
+		migrationFiles := []string{}
+		for _, file := range files {
+			if file.IsDir() || filepath.Ext(file.Name()) != ".json" {
+				continue
+			}
+			migrationFiles = append(migrationFiles, filepath.Join(migrationsDir, file.Name()))
+		}
+		slices.Sort(migrationFiles)
+
+		for _, fileName := range migrationFiles {
+			file, err := os.Open(fileName)
+			if err != nil {
+				return fmt.Errorf("opening migration file: %w", err)
+			}
+			migration, err := migrations.ReadMigration(file)
+			if err != nil {
+				file.Close()
+				return fmt.Errorf("reading migration file: %w", err)
+			}
+
+			sp, _ := pterm.DefaultSpinner.WithText("Starting migration...").Start()
+			cb := func(n int64) {
+				sp.UpdateText(fmt.Sprintf("%d records complete...", n))
+			}
+
+			err = m.Start(cmd.Context(), migration, cb)
+			if err != nil {
+				sp.Fail(fmt.Sprintf("Failed to start migration: %s", err))
+				file.Close()
+				return err
+			}
+			file.Close()
+
+			if err = m.Complete(cmd.Context()); err != nil {
+				sp.Fail(fmt.Sprintf("Failed to complete migration: %s", err))
+				return err
+			}
+
+			version := migration.Name
+			if version == "" {
+				version = strings.TrimSuffix(filepath.Base(fileName), filepath.Ext(fileName))
+			}
+			viewName := roll.VersionedSchemaName(flags.Schema(), version)
+			msg := fmt.Sprintf("New version of the schema available under the postgres %q schema", viewName)
+			sp.Success(msg)
+		}
+
+		return nil
+	},
+}

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -21,7 +21,7 @@ var bootstrapCmd = &cobra.Command{
 	Use:   "bootstrap <folder>",
 	Short: "Bootstrap a new database from a directory of migration files",
 	Long: `Bootstrap a new database from a directory of migration files. All files in the directory will be executed
-in alphabetical order. All migrations are completed.`,
+in lexicographical order. All migrations are completed.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		migrationsDir := args[0]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,6 +74,7 @@ func Execute() error {
 	rootCmd.AddCommand(analyzeCmd)
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(statusCmd)
+	rootCmd.AddCommand(bootstrapCmd)
 
 	return rootCmd.Execute()
 }


### PR DESCRIPTION
This PR adds a new command called `bootstrap`. It runs all the migrations in the specified folder. Migration files are JSON files, ordered alphabetically.

Help:
```
> go run . bootstrap -h
Bootstrap a new database from a directory of migration files. All files in the directory will be executed
in alphabetical order. All migrations are completed.

Usage:
  pgroll bootstrap <folder> [flags]

Flags:
  -h, --help   help for bootstrap
```

Closes https://github.com/xataio/pgroll/issues/269