### PR TITLE
Validate that unique constraint name is unique

### DIFF
--- a/pkg/migrations/op_common_test.go
+++ b/pkg/migrations/op_common_test.go
@@ -11,9 +11,9 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/xataio/pgroll/internal/testutils"
-
 	"github.com/lib/pq"
+
+	"github.com/xataio/pgroll/internal/testutils"
 	"github.com/xataio/pgroll/pkg/migrations"
 	"github.com/xataio/pgroll/pkg/roll"
 )

--- a/pkg/migrations/op_set_unique.go
+++ b/pkg/migrations/op_set_unique.go
@@ -63,6 +63,13 @@ func (o *OpSetUnique) Validate(ctx context.Context, s *schema.Schema) error {
 		return ColumnDoesNotExistError{Table: o.Table, Name: o.Column}
 	}
 
+	if table.ConstraintExists(o.Name) {
+		return ConstraintAlreadyExistsError{
+			Table:      table.Name,
+			Constraint: o.Name,
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/migrations/op_set_unique_test.go
+++ b/pkg/migrations/op_set_unique_test.go
@@ -527,5 +527,63 @@ func TestSetColumnUnique(t *testing.T) {
 		//
 		// In that case it should be possible to test that existing unique constraints are
 		// preserved when adding a new unique constraint covering the same column.
+		{
+			name: "validate that the constraint name is not already taken",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "reviews",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   ptr(true),
+								},
+								{
+									Name:     "username",
+									Type:     "text",
+									Nullable: ptr(false),
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_set_unique",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:  "reviews",
+							Column: "username",
+							Unique: &migrations.UniqueConstraint{
+								Name: "reviews_username_key",
+							},
+						},
+					},
+				},
+				{
+					Name: "03_set_unique_again",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:  "reviews",
+							Column: "username",
+							Unique: &migrations.UniqueConstraint{
+								Name: "reviews_username_key",
+							},
+						},
+					},
+				},
+			},
+			wantStartErr: migrations.ConstraintAlreadyExistsError{
+				Table:      "reviews",
+				Constraint: "reviews_username_key",
+			},
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
+				IndexMustExist(t, db, schema, "reviews", "reviews_username_key")
+			},
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {},
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {},
+		},
 	})
 }

--- a/pkg/migrations/op_set_unique_test.go
+++ b/pkg/migrations/op_set_unique_test.go
@@ -579,9 +579,7 @@ func TestSetColumnUnique(t *testing.T) {
 				Table:      "reviews",
 				Constraint: "reviews_username_key",
 			},
-			afterStart: func(t *testing.T, db *sql.DB, schema string) {
-				IndexMustExist(t, db, schema, "reviews", "reviews_username_key")
-			},
+			afterStart:    func(t *testing.T, db *sql.DB, schema string) {},
 			afterRollback: func(t *testing.T, db *sql.DB, schema string) {},
 			afterComplete: func(t *testing.T, db *sql.DB, schema string) {},
 		},


### PR DESCRIPTION
I'm not sure this is exactly what we want, but putting it up here for review.

This will now catch the case when a unique constraint is added with a name that already exists on the table.
All this really does in shift the check to the `Start` operation instead of the `Complete` operation.

Before this changed we get this error:

```
Failed to complete migration: unable to execute complete operation: pq: index "reviews_username_key" is already associated with a constraint
```

Afterwards we get this:

```
Failed to start migration: migration is invalid: constraint "reviews_username_key" on table "reviews" already exists
```

Part of https://github.com/xataio/pgroll/issues/105