### PR TITLE
Avoid running all CI steps twice

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
 permissions:
-  # Push test
   contents: write
   packages: write
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: Build
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 permissions:
   contents: write
   packages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
 permissions:
+  # Push test
   contents: write
   packages: write
 jobs:


### PR DESCRIPTION
Separate `push` and `pull_request` triggers so that pushing to a PR branch doesn't trigger everything twice.