### PR TITLE
Add support for creating unique indexes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -973,12 +973,14 @@ A create index operation creates a new index on a set of columns.
 
 The field `method` can be `btree`, `hash`, `gist`, `spgist`, `gin`, `brin`.
 You can also specify storage parameters for the index in `storage_parameters`.
+To create a unique index set `unique` to `true`.
 
 Example **create index** migrations:
 
 * [10_create_index.json](../examples/10_create_index.json)
 * [37_create_partial_index.json](../examples/37_create_partial_index.json)
 * [38_create_hash_index_with_fillfactor.json](../examples/38_create_hash_index_with_fillfactor.json)
+* [39_create_unique_index.json](../examples/39_create_unique_index.json)
 
 ### Create table
 

--- a/examples/39_create_unique_index.json
+++ b/examples/39_create_unique_index.json
@@ -3,7 +3,7 @@
   "operations": [
     {
       "create_index": {
-        "name": "idx_fruits_name",
+        "name": "idx_fruits_unique_name",
         "table": "fruits",
         "columns": [
           "name"

--- a/examples/39_create_unique_index.json
+++ b/examples/39_create_unique_index.json
@@ -1,0 +1,15 @@
+{
+  "name": "38_create_hash_index_with_fillfactor",
+  "operations": [
+    {
+      "create_index": {
+        "name": "idx_fruits_name",
+        "table": "fruits",
+        "columns": [
+          "name"
+        ],
+        "unique": true,
+      }
+    }
+  ]
+}

--- a/examples/39_create_unique_index.json
+++ b/examples/39_create_unique_index.json
@@ -1,5 +1,5 @@
 {
-  "name": "38_create_hash_index_with_fillfactor",
+  "name": "39_create_unique_index",
   "operations": [
     {
       "create_index": {
@@ -8,7 +8,7 @@
         "columns": [
           "name"
         ],
-        "unique": true,
+        "unique": true
       }
     }
   ]

--- a/pkg/migrations/op_create_index.go
+++ b/pkg/migrations/op_create_index.go
@@ -17,7 +17,11 @@ var _ Operation = (*OpCreateIndex)(nil)
 
 func (o *OpCreateIndex) Start(ctx context.Context, conn db.DB, latestSchema string, tr SQLTransformer, s *schema.Schema, cbs ...CallbackFn) (*schema.Table, error) {
 	// create index concurrently
-	stmt := fmt.Sprintf("CREATE INDEX CONCURRENTLY %s ON %s",
+	stmtFmt := "CREATE INDEX CONCURRENTLY %s ON %s (%s)"
+	if o.Unique != nil {
+		stmtFmt = "CREATE UNIQUE INDEX CONCURRENTLY %s ON %s (%s)"
+	}
+	stmt := fmt.Sprintf(stmtFmt,
 		pq.QuoteIdentifier(o.Name),
 		pq.QuoteIdentifier(o.Table))
 

--- a/pkg/migrations/op_create_index.go
+++ b/pkg/migrations/op_create_index.go
@@ -17,9 +17,9 @@ var _ Operation = (*OpCreateIndex)(nil)
 
 func (o *OpCreateIndex) Start(ctx context.Context, conn db.DB, latestSchema string, tr SQLTransformer, s *schema.Schema, cbs ...CallbackFn) (*schema.Table, error) {
 	// create index concurrently
-	stmtFmt := "CREATE INDEX CONCURRENTLY %s ON %s (%s)"
-	if o.Unique != nil {
-		stmtFmt = "CREATE UNIQUE INDEX CONCURRENTLY %s ON %s (%s)"
+	stmtFmt := "CREATE INDEX CONCURRENTLY %s ON %s"
+	if o.Unique != nil && *o.Unique {
+		stmtFmt = "CREATE UNIQUE INDEX CONCURRENTLY %s ON %s"
 	}
 	stmt := fmt.Sprintf(stmtFmt,
 		pq.QuoteIdentifier(o.Name),

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -138,6 +138,9 @@ type OpCreateIndex struct {
 
 	// Name of table on which to define the index
 	Table string `json:"table"`
+
+	// Unique index
+	Unique *bool `json:"unique,omitempty"`
 }
 
 type OpCreateIndexMethod string

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -139,7 +139,7 @@ type OpCreateIndex struct {
 	// Name of table on which to define the index
 	Table string `json:"table"`
 
-	// Unique index
+	// Indicates if the index is unique
 	Unique *bool `json:"unique,omitempty"`
 }
 

--- a/schema.json
+++ b/schema.json
@@ -236,6 +236,10 @@
         "storage_parameters": {
           "description": "Storage parameters for the index",
           "type": "string"
+        },
+        "unique": {
+          "description": "Indicates if the index is unique",
+          "type": "boolean"
         }
       },
       "required": ["columns", "name", "table"],


### PR DESCRIPTION
This PR adds a new attribute to `create_index` operation.
From now on it is possible to create a unique index on one or more
columns in a table.
