### PR TITLE
Add `--skip-validation` flag to `start` command

### DIFF
--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -28,6 +28,8 @@ func BackfillBatchSize() int { return viper.GetInt("BACKFILL_BATCH_SIZE") }
 
 func BackfillBatchDelay() time.Duration { return viper.GetDuration("BACKFILL_BATCH_DELAY") }
 
+func SkipValidation() bool { return viper.GetBool("SKIP_VALIDATION") }
+
 func Role() string {
 	return viper.GetString("ROLE")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,6 +51,7 @@ func NewRoll(ctx context.Context) (*roll.Roll, error) {
 	role := flags.Role()
 	backfillBatchSize := flags.BackfillBatchSize()
 	backfillBatchDelay := flags.BackfillBatchDelay()
+	skipValidation := flags.SkipValidation()
 
 	state, err := state.New(ctx, pgURL, stateSchema)
 	if err != nil {
@@ -62,6 +63,7 @@ func NewRoll(ctx context.Context) (*roll.Roll, error) {
 		roll.WithRole(role),
 		roll.WithBackfillBatchSize(backfillBatchSize),
 		roll.WithBackfillBatchDelay(backfillBatchDelay),
+		roll.WithSkipValidation(skipValidation),
 	)
 }
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/xataio/pgroll/cmd/flags"
 	"github.com/xataio/pgroll/pkg/migrations"
@@ -38,6 +39,9 @@ func startCmd() *cobra.Command {
 	}
 
 	startCmd.Flags().BoolVarP(&complete, "complete", "c", false, "Mark the migration as complete")
+
+	startCmd.Flags().BoolP("skip-validation", "s", false, "skip migration validation")
+	viper.BindPFlag("SKIP_VALIDATION", startCmd.Flags().Lookup("skip-validation"))
 
 	return startCmd
 }

--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -43,12 +43,14 @@ func (m *Roll) StartDDLOperations(ctx context.Context, migration *migrations.Mig
 	}
 
 	// validate migration
-	err = migration.Validate(ctx, newSchema)
-	if err != nil {
-		if err := m.state.Rollback(ctx, m.schema, migration.Name); err != nil {
-			fmt.Printf("failed to rollback migration: %s\n", err)
+	if !m.skipValidation {
+		err = migration.Validate(ctx, newSchema)
+		if err != nil {
+			if err := m.state.Rollback(ctx, m.schema, migration.Name); err != nil {
+				fmt.Printf("failed to rollback migration: %s\n", err)
+			}
+			return nil, fmt.Errorf("migration is invalid: %w", err)
 		}
-		return nil, fmt.Errorf("migration is invalid: %w", err)
 	}
 
 	// run any BeforeStartDDL hooks

--- a/pkg/roll/options.go
+++ b/pkg/roll/options.go
@@ -33,6 +33,9 @@ type options struct {
 	// the duration to delay after each batch is run
 	backfillBatchDelay time.Duration
 
+	// whether to skip validation
+	skipValidation bool
+
 	migrationHooks MigrationHooks
 }
 
@@ -119,5 +122,13 @@ func WithBackfillBatchSize(batchSize int) Option {
 func WithBackfillBatchDelay(delay time.Duration) Option {
 	return func(o *options) {
 		o.backfillBatchDelay = delay
+	}
+}
+
+// WithSkipValidation controls whether or not to perform validation on
+// migrations. If set to true, validation will be skipped.
+func WithSkipValidation(skip bool) Option {
+	return func(o *options) {
+		o.skipValidation = skip
 	}
 }

--- a/pkg/roll/roll.go
+++ b/pkg/roll/roll.go
@@ -43,6 +43,7 @@ type Roll struct {
 
 	backfillBatchSize  int
 	backfillBatchDelay time.Duration
+	skipValidation     bool
 }
 
 // New creates a new Roll instance
@@ -84,6 +85,7 @@ func New(ctx context.Context, pgURL, schema string, state *state.State, opts ...
 		migrationHooks:           rollOpts.migrationHooks,
 		backfillBatchSize:        rollOpts.backfillBatchSize,
 		backfillBatchDelay:       rollOpts.backfillBatchDelay,
+		skipValidation:           rollOpts.skipValidation,
 	}, nil
 }
 


### PR DESCRIPTION
Add a `--skip-validation` flag to the `start` command.

If set, migration validation is skipped.

For example, this table has a `NOT NULL` `name` field:

```json
{
  "name": "01_create_table",
  "operations": [
    {
      "create_table": {
        "name": "products",
        "columns": [
          {
            "name": "id",
            "type": "serial",
            "pk": true
          },
          {
            "name": "name",
            "type": "varchar(255)",
            "nullable": false
          }
        ]
      }
    }
  ]
}
```

starting this migration will fail as the `name` field is already `NOT NULL`:

```json
{
  "name": "02_set_nullable",
  "operations": [
    {
      "alter_column": {
        "table": "products",
        "column": "name",
        "nullable": false,
        "up": "name",
        "down": "name"
      }
    }
  ]
}
```

```
Error: migration is invalid: column "name" on table "products" is NOT NULL
```

But if the start command is invoked with `--skip-validation` then the start command succeeds.

This is part of https://github.com/xataio/pgroll/issues/239