### PR TITLE
Allow adding an index to a table created in the same migration

### DIFF
--- a/pkg/migrations/op_create_index.go
+++ b/pkg/migrations/op_create_index.go
@@ -16,6 +16,8 @@ import (
 var _ Operation = (*OpCreateIndex)(nil)
 
 func (o *OpCreateIndex) Start(ctx context.Context, conn db.DB, latestSchema string, tr SQLTransformer, s *schema.Schema, cbs ...CallbackFn) (*schema.Table, error) {
+	table := s.GetTable(o.Table)
+
 	// create index concurrently
 	stmtFmt := "CREATE INDEX CONCURRENTLY %s ON %s"
 	if o.Unique != nil && *o.Unique {
@@ -23,7 +25,7 @@ func (o *OpCreateIndex) Start(ctx context.Context, conn db.DB, latestSchema stri
 	}
 	stmt := fmt.Sprintf(stmtFmt,
 		pq.QuoteIdentifier(o.Name),
-		pq.QuoteIdentifier(o.Table))
+		pq.QuoteIdentifier(table.Name))
 
 	if o.Method != nil {
 		stmt += fmt.Sprintf(" USING %s", string(*o.Method))


### PR DESCRIPTION
Allow the `create_index` operation to add an index to a table that was created by an operation earlier in the same migration.

The following migration would previously have failed to start:

```json
{
  "name": "43_multiple_ops",
  "operations": [
    {
      "create_table": {
        "name": "players",
        "columns": [
          {
            "name": "id",
            "type": "serial",
            "pk": true
          },
          {
            "name": "name",
            "type": "varchar(255)",
            "check": {
              "name": "name_length_check",
              "constraint": "length(name) > 2"
            }
          }
        ]
      }
    },
    {
      "create_index": {
        "name": "idx_player_name",
        "table": "players",
        "columns": [
          "name"
        ]
      }
    }
  ]
}
```

As of this PR the migration can be started.

The above migration does not validate yet, but it can be started successfully with the --skip-validation flag to the start command.

Part of https://github.com/xataio/pgroll/issues/239
