### PR TITLE
Add a `healthcheck` to the `db` service in `docker-compose.yml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,8 @@ services:
       - '5432:5432'
     volumes: 
       - /var/lib/postgresql/data
+    healthcheck:
+      test: "pg_isready -h localhost"
+      interval: 200ms
+      timeout: 5s
+      retries: 10


### PR DESCRIPTION
Add a healthcheck for the `db` service so that scripts can wait for Postgres to be ready to accept connections, eg:

```sh
#! /bin/sh

docker compose up -d --wait
# ... other commands now that Postgres is ready
```