### PR TITLE
Update schema during create table validation

### DIFF
--- a/pkg/migrations/op_add_column_test.go
+++ b/pkg/migrations/op_add_column_test.go
@@ -1524,6 +1524,7 @@ func TestAddColumnToATableCreatedInTheSameMigration(t *testing.T) {
 								Name:     "age",
 								Type:     "integer",
 								Nullable: ptr(false),
+								Default:  ptr("18"),
 								Check: &migrations.CheckConstraint{
 									Name:       "age_check",
 									Constraint: "age >= 18",
@@ -1559,7 +1560,7 @@ func TestAddColumnToATableCreatedInTheSameMigration(t *testing.T) {
 				}, testutils.CheckViolationErrorCode)
 			},
 		},
-	}, roll.WithSkipValidation(true)) // TODO: remove once this migration can be validated
+	})
 }
 
 func TestAddColumnInvalidNameLength(t *testing.T) {

--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -75,6 +75,13 @@ func (m *Roll) StartDDLOperations(ctx context.Context, migration *migrations.Mig
 	}
 	latestSchema := VersionedSchemaName(m.schema, *latestVersion)
 
+	// Reread the latest schema as validation may have updated the schema object
+	// in memory.
+	newSchema, err = m.state.ReadSchema(ctx, m.schema)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read schema: %w", err)
+	}
+
 	// execute operations
 	var tablesToBackfill []*schema.Table
 	for _, op := range migration.Operations {


### PR DESCRIPTION
Update the schema during `create_table` operation validation so that validation of subsequent operations in the same migration can see the new table.

This means that migrations that add a new table and then perform some other operation, like adding a column, on that table can be validated because the new table is visible to the `add_column` operation during it's validation phase.

This means that the following migration is now able to validate:

```json
{
  "name": "43_multiple_ops",
  "operations": [
    {
      "create_table": {
        "name": "players",
        "columns": [
          {
            "name": "id",
            "type": "serial",
            "pk": true
          },
          {
            "name": "name",
            "type": "varchar(255)",
            "check": {
              "name": "name_length_check",
              "constraint": "length(name) > 2"
            }
          }
        ]
      }
    },
    {
      "add_column": {
        "table": "players",
        "column": {
          "name": "rating",
          "type": "integer",
          "comment": "hello world",
          "check": {
            "name": "rating_check",
            "constraint": "rating > 0 AND rating < 100"
          },
          "nullable": false
        }
      }
    }
  ]
}
```

Previously, the new table would not have been visible to the `add_column` operation and its validation would have failed.

In order to make this work the schema needs to be re-read from the target database in between validation and migration start, as the previous assumption that validation would not make changes to the in-memory schema representation no longer holds.

Part of https://github.com/xataio/pgroll/issues/239