### PR TITLE
Add missing group by

### DIFF
--- a/pkg/state/init.sql
+++ b/pkg/state/init.sql
@@ -170,7 +170,7 @@ BEGIN
                                                JOIN pg_am am
                                                     ON am.oid = cls.relam
                                       WHERE indrelid = t.oid::regclass
-                                      GROUP BY pi.indexrelid, pi.indisunique, am.amname) as ix_details),
+                                      GROUP BY pi.indexrelid, pi.indisunique, pi.indpred, am.amname) as ix_details),
                     'checkConstraints', (SELECT COALESCE(json_object_agg(cc_details.conname, json_build_object(
                             'name', cc_details.conname,
                             'columns', cc_details.columns,


### PR DESCRIPTION
This may get us past the `pgroll.Init` step in older version of Postgres (<= 13)