### PR TITLE
Duplicate unique and check constraints correctly

### DIFF
--- a/pkg/migrations/duplicate.go
+++ b/pkg/migrations/duplicate.go
@@ -14,12 +14,10 @@ import (
 	"github.com/xataio/pgroll/pkg/schema"
 )
 
-// Duplicator duplicates a column in a table, including all constraints and
+// ColumnDuplicator duplicates a column in a table, including all constraints and
 // comments.
-// Column must be set with WithColumn before calling Duplicate.
-type Duplicator struct {
-	conn              db.DB
-	table             *schema.Table
+type ColumnDuplicator struct {
+	duplicator        *duplicator
 	column            *schema.Column
 	asName            string
 	withoutNotNull    bool
@@ -28,34 +26,62 @@ type Duplicator struct {
 	duplicatedUnique  map[string]schema.UniqueConstraint
 }
 
+type ColumnGroupDuplicator struct {
+	duplicator *duplicator
+	columns    []*schema.Column
+}
+
+type duplicator struct {
+	conn  db.DB
+	table *schema.Table
+}
+
 const (
 	dataTypeMismatchErrorCode  pq.ErrorCode = "42804"
 	undefinedFunctionErrorCode pq.ErrorCode = "42883"
+
+	cCreateUniqueIndexSQL            = `CREATE UNIQUE INDEX CONCURRENTLY %s ON %s (%s)`
+	cSetDefaultSQL                   = `ALTER TABLE %s ALTER COLUMN %s SET DEFAULT %s`
+	cAlterTableAddCheckConstraintSQL = `ALTER TABLE %s ADD CONSTRAINT %s %s NOT VALID`
 )
 
 // NewColumnDuplicator creates a new Duplicator for a column.
-func NewColumnDuplicator(conn db.DB, table *schema.Table) *Duplicator {
-	return &Duplicator{
-		conn:             conn,
-		table:            table,
-		duplicatedUnique: make(map[string]schema.UniqueConstraint),
+func NewColumnDuplicator(conn db.DB, table *schema.Table, column *schema.Column) *ColumnDuplicator {
+	return &ColumnDuplicator{
+		duplicator: &duplicator{
+			conn:  conn,
+			table: table,
+		},
+		column:   column,
+		asName:   TemporaryName(column.Name),
+		withType: column.Type,
+	}
+}
+
+func NewColumnGroupDuplicator(conn db.DB, table *schema.Table, columns []*schema.Column) *ColumnGroupDuplicator {
+	return &ColumnGroupDuplicator{
+		duplicator: &duplicator{
+			conn:  conn,
+			table: table,
+		},
+		columns: columns,
 	}
 }
 
 // WithType sets the type of the new column.
-func (d *Duplicator) WithType(t string) *Duplicator {
+func (d *ColumnDuplicator) WithType(t string) *ColumnDuplicator {
 	d.withType = t
 	return d
 }
 
 // WithoutConstraint excludes a constraint from being duplicated.
-func (d *Duplicator) WithoutConstraint(c string) *Duplicator {
+func (d *ColumnDuplicator) WithoutConstraint(c string) *ColumnDuplicator {
 	d.withoutConstraint = c
 	return d
 }
 
 // WithoutNotNull excludes the NOT NULL constraint from being duplicated.
-func (d *Duplicator) WithoutNotNull() *Duplicator {
+func (d *ColumnDuplicator) WithoutNotNull() *ColumnDuplicator {
 	d.withoutNotNull = true
 	return d
 }
@@ -69,88 +95,34 @@ func (d *Duplicator) WithColumn(c *schema.Column) *Duplicator {
 
 // Duplicate duplicates a column in the table, including all constraints and
 // comments.
-func (d *Duplicator) Duplicate(ctx context.Context) error {
-	if d.column == nil {
-		return errors.New("column not set")
-	}
-
-	const (
-		cAlterTableSQL                   = `ALTER TABLE %s ADD COLUMN %s %s`
-		cAddForeignKeySQL                = `ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s) ON DELETE %s`
-		cAddCheckConstraintSQL           = `ADD CONSTRAINT %s %s NOT VALID`
-		cCreateUniqueIndexSQL            = `CREATE UNIQUE INDEX CONCURRENTLY %s ON %s (%s)`
-		cSetDefaultSQL                   = `ALTER TABLE %s ALTER COLUMN %s SET DEFAULT %s`
-		cAlterTableAddCheckConstraintSQL = `ALTER TABLE %s ADD CONSTRAINT %s %s NOT VALID`
-		cCommentOnColumnSQL              = `COMMENT ON COLUMN %s.%s IS %s`
-	)
-
-	// Generate SQL to duplicate the column's name and type
-	sql := fmt.Sprintf(cAlterTableSQL,
-		pq.QuoteIdentifier(d.table.Name),
-		pq.QuoteIdentifier(d.asName),
-		d.withType)
-
-	// Generate SQL to add an unchecked NOT NULL constraint if the original column
-	// is NOT NULL. The constraint will be validated on migration completion.
-	if !d.column.Nullable && !d.withoutNotNull {
-		sql += fmt.Sprintf(", "+cAddCheckConstraintSQL,
-			pq.QuoteIdentifier(DuplicationName(NotNullConstraintName(d.column.Name))),
-			fmt.Sprintf("CHECK (%s IS NOT NULL)", pq.QuoteIdentifier(d.asName)),
-		)
-	}
-
-	// Generate SQL to duplicate any foreign key constraints on the column
-	for _, fk := range d.table.ForeignKeys {
-		if fk.Name == d.withoutConstraint {
-			continue
-		}
-
-		if slices.Contains(fk.Columns, d.column.Name) {
-			sql += fmt.Sprintf(", "+cAddForeignKeySQL,
-				pq.QuoteIdentifier(DuplicationName(fk.Name)),
-				strings.Join(quoteColumnNames(copyAndReplace(fk.Columns, d.column.Name, d.asName)), ", "),
-				pq.QuoteIdentifier(fk.ReferencedTable),
-				strings.Join(quoteColumnNames(fk.ReferencedColumns), ", "),
-				fk.OnDelete,
-			)
-		}
-	}
-
-	_, err := d.conn.ExecContext(ctx, sql)
-	if err != nil {
+func (d *ColumnDuplicator) Duplicate(ctx context.Context) error {
+	// Duplicate the column with the new type
+	// and check and fk constraints
+	if err := d.duplicator.duplicateColumn(ctx, d.column, d.asName, d.withoutNotNull, d.withType, d.withoutConstraint); err != nil {
 		return err
 	}
 
-	// Generate SQL to duplicate any default value on the column. This may fail
-	// if the default value is not valid for the new column type, in which case
-	// the error is ignored.
-	if d.column.Default != nil {
-		sql := fmt.Sprintf(cSetDefaultSQL, pq.QuoteIdentifier(d.table.Name), d.asName, *d.column.Default)
-
-		_, err := d.conn.ExecContext(ctx, sql)
-
-		err = errorIgnoringErrorCode(err, dataTypeMismatchErrorCode)
-		if err != nil {
-			return err
-		}
+	// Duplicate the column's default value
+	if err := d.duplicator.duplicateDefault(ctx, d.column, d.asName); err != nil {
+		return err
 	}
 
 	// Generate SQL to duplicate any check constraints on the column. This may faile
 	// if the check constraint is not valid for the new column type, in which case
 	// the error is ignored.
-	for _, cc := range d.table.CheckConstraints {
+	for _, cc := range d.duplicator.table.CheckConstraints {
 		if cc.Name == d.withoutConstraint {
 			continue
 		}
 
 		if slices.Contains(cc.Columns, d.column.Name) {
 			sql := fmt.Sprintf(cAlterTableAddCheckConstraintSQL,
-				pq.QuoteIdentifier(d.table.Name),
+				pq.QuoteIdentifier(d.duplicator.table.Name),
 				pq.QuoteIdentifier(DuplicationName(cc.Name)),
 				rewriteCheckExpression(cc.Definition, d.column.Name, d.asName),
 			)
 
-			_, err := d.conn.ExecContext(ctx, sql)
+			_, err := d.duplicator.conn.ExecContext(ctx, sql)
 
 			err = errorIgnoringErrorCode(err, undefinedFunctionErrorCode)
 			if err != nil {
@@ -159,46 +131,26 @@ func (d *Duplicator) Duplicate(ctx context.Context) error {
 		}
 	}
 
-	// Generate SQL to duplicate the column's comment
-	if d.column.Comment != "" {
-		sql = fmt.Sprintf(cCommentOnColumnSQL,
-			pq.QuoteIdentifier(d.table.Name),
-			pq.QuoteIdentifier(d.asName),
-			pq.QuoteLiteral(d.column.Comment),
-		)
-
-		_, err = d.conn.ExecContext(ctx, sql)
-		if err != nil {
-			return err
-		}
+	if err := d.duplicator.duplicateComment(ctx, d.column, d.asName); err != nil {
+		return err
 	}
 
 	// Generate SQL to duplicate any unique constraints on the column
 	// The constraint is duplicated by adding a unique index on the column concurrently.
 	// The index is converted into a unique constraint on migration completion.
-	for _, uc := range d.table.UniqueConstraints {
+	for _, uc := range d.duplicator.table.UniqueConstraints {
 		if uc.Name == d.withoutConstraint {
 			continue
 		}
 
 		if slices.Contains(uc.Columns, d.column.Name) {
-			cols := uc.Columns
-			// Drop the existing unique index if it is a duplicated unique constraint
-			if existingConstraint, ok := d.duplicatedUnique[DuplicationName(uc.Name)]; ok {
-				dropIndex := fmt.Sprintf("DROP INDEX CONCURRENTLY %s", pq.QuoteIdentifier(DuplicationName(uc.Name)))
-				_, err := d.conn.ExecContext(ctx, dropIndex)
-				if err != nil {
-					return err
-				}
-				cols = existingConstraint.Columns
-			}
-			sql = fmt.Sprintf(cCreateUniqueIndexSQL,
+			sql := fmt.Sprintf(cCreateUniqueIndexSQL,
 				pq.QuoteIdentifier(DuplicationName(uc.Name)),
-				pq.QuoteIdentifier(d.table.Name),
-				strings.Join(quoteColumnNames(copyAndReplace(cols, d.column.Name, d.asName)), ", "),
+				pq.QuoteIdentifier(d.duplicator.table.Name),
+				strings.Join(quoteColumnNames(copyAndReplace(uc.Columns, d.column.Name, d.asName)), ", "),
 			)
 
-			_, err = d.conn.ExecContext(ctx, sql)
+			_, err := d.duplicator.conn.ExecContext(ctx, sql)
 			if err != nil {
 				return err
 			}
@@ -210,6 +162,165 @@ func (d *Duplicator) Duplicate(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (cg *ColumnGroupDuplicator) Duplicate(ctx context.Context) error {
+	for _, column := range cg.columns {
+		asName := TemporaryName(column.Name)
+		notNull := false
+		withoutConstraint := ""
+		// Duplicate the column with the new type
+		// and check and fk constraints
+		if err := cg.duplicator.duplicateColumn(ctx, column, asName, notNull, column.Type, withoutConstraint); err != nil {
+			return err
+		}
+
+		// Duplicate the column's default value
+		if err := cg.duplicator.duplicateDefault(ctx, column, asName); err != nil {
+			return err
+		}
+
+		// Duplicate the column's comment
+		if err := cg.duplicator.duplicateComment(ctx, column, asName); err != nil {
+			return err
+		}
+	}
+
+	// Generate SQL to duplicate any check constraints on the column group.
+	for _, cc := range cg.duplicator.table.CheckConstraints {
+		sameColumns := true
+		colNames := make([]string, len(cg.columns))
+		for i, column := range cg.columns {
+			if !slices.Contains(cc.Columns, column.Name) {
+				sameColumns = false
+				break
+			}
+			colNames[i] = column.Name
+		}
+
+		if sameColumns {
+			sql := fmt.Sprintf(cAlterTableAddCheckConstraintSQL,
+				pq.QuoteIdentifier(cg.duplicator.table.Name),
+				pq.QuoteIdentifier(DuplicationName(cc.Name)),
+				rewriteCheckExpression(cc.Definition, colNames...),
+			)
+
+			if _, err := cg.duplicator.conn.ExecContext(ctx, sql); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Generate SQL to duplicate any unique constraints on the column group.
+	for _, uc := range cg.duplicator.table.UniqueConstraints {
+		sameColumns := true
+		for _, column := range cg.columns {
+			if !slices.Contains(uc.Columns, column.Name) {
+				sameColumns = false
+				break
+			}
+		}
+
+		if sameColumns {
+			sql := fmt.Sprintf(cCreateUniqueIndexSQL,
+				pq.QuoteIdentifier(DuplicationName(uc.Name)),
+				pq.QuoteIdentifier(cg.duplicator.table.Name),
+				strings.Join(quotedTemporaryNames(uc.Columns), ", "),
+			)
+
+			if _, err := cg.duplicator.conn.ExecContext(ctx, sql); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (d *duplicator) duplicateColumn(
+	ctx context.Context,
+	column *schema.Column,
+	asName string,
+	withoutNotNull bool,
+	withType string,
+	withoutConstraint string,
+) error {
+	const (
+		cAlterTableSQL         = `ALTER TABLE %s ADD COLUMN %s %s`
+		cAddForeignKeySQL      = `ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s) ON DELETE %s`
+		cAddCheckConstraintSQL = `ADD CONSTRAINT %s %s NOT VALID`
+	)
+
+	// Generate SQL to duplicate the column's name and type
+	sql := fmt.Sprintf(cAlterTableSQL,
+		pq.QuoteIdentifier(d.table.Name),
+		pq.QuoteIdentifier(asName),
+		withType)
+
+	// Generate SQL to add an unchecked NOT NULL constraint if the original column
+	// is NOT NULL. The constraint will be validated on migration completion.
+	if !column.Nullable && !withoutNotNull {
+		sql += fmt.Sprintf(", "+cAddCheckConstraintSQL,
+			pq.QuoteIdentifier(DuplicationName(NotNullConstraintName(column.Name))),
+			fmt.Sprintf("CHECK (%s IS NOT NULL)", pq.QuoteIdentifier(asName)),
+		)
+	}
+
+	// Generate SQL to duplicate any foreign key constraints on the column
+	for _, fk := range d.table.ForeignKeys {
+		if fk.Name == withoutConstraint {
+			continue
+		}
+
+		if slices.Contains(fk.Columns, column.Name) {
+			sql += fmt.Sprintf(", "+cAddForeignKeySQL,
+				pq.QuoteIdentifier(DuplicationName(fk.Name)),
+				strings.Join(quoteColumnNames(copyAndReplace(fk.Columns, column.Name, asName)), ", "),
+				pq.QuoteIdentifier(fk.ReferencedTable),
+				strings.Join(quoteColumnNames(fk.ReferencedColumns), ", "),
+				fk.OnDelete,
+			)
+		}
+	}
+
+	_, err := d.conn.ExecContext(ctx, sql)
+	return err
+}
+
+func (d *duplicator) duplicateDefault(ctx context.Context, column *schema.Column, asName string) error {
+	if column.Default == nil {
+		return nil
+	}
+
+	const cSetDefaultSQL = `ALTER TABLE %s ALTER COLUMN %s SET DEFAULT %s`
+
+	// Generate SQL to duplicate any default value on the column. This may fail
+	// if the default value is not valid for the new column type, in which case
+	// the error is ignored.
+	sql := fmt.Sprintf(cSetDefaultSQL, pq.QuoteIdentifier(d.table.Name), asName, *column.Default)
+
+	_, err := d.conn.ExecContext(ctx, sql)
+
+	return errorIgnoringErrorCode(err, dataTypeMismatchErrorCode)
+}
+
+func (d *duplicator) duplicateComment(ctx context.Context, column *schema.Column, asName string) error {
+	if column.Comment == "" {
+		return nil
+	}
+
+	const cCommentOnColumnSQL = `COMMENT ON COLUMN %s.%s IS %s`
+
+	// Generate SQL to duplicate the column's comment
+	sql := fmt.Sprintf(cCommentOnColumnSQL,
+		pq.QuoteIdentifier(d.table.Name),
+		pq.QuoteIdentifier(asName),
+		pq.QuoteLiteral(column.Comment),
+	)
+
+	_, err := d.conn.ExecContext(ctx, sql)
+	return err
 }
 
 // DiplicationName returns the name of a duplicated column.

--- a/pkg/migrations/duplicate.go
+++ b/pkg/migrations/duplicate.go
@@ -46,24 +46,7 @@ const (
 )
 
 // NewColumnDuplicator creates a new Duplicator for a column.
-func NewColumnDuplicator(conn db.DB, table *schema.Table, column *schema.Column) *Duplicator {
-	return &Duplicator{
-		stmtBuilder: &duplicatorStmtBuilder{
-			table: table,
-		},
-		conn: conn,
-		columns: map[string]*columnToDuplicate{
-			column.Name: {
-				column:   column,
-				asName:   TemporaryName(column.Name),
-				withType: column.Type,
-			},
-		},
-		withoutConstraint: make([]string, 0),
-	}
-}
-
-func NewColumnGroupDuplicator(conn db.DB, table *schema.Table, columns []*schema.Column) *Duplicator {
+func NewColumnDuplicator(conn db.DB, table *schema.Table, columns ...*schema.Column) *Duplicator {
 	cols := make(map[string]*columnToDuplicate, len(columns))
 	for _, column := range columns {
 		cols[column.Name] = &columnToDuplicate{
@@ -76,8 +59,9 @@ func NewColumnGroupDuplicator(conn db.DB, table *schema.Table, columns []*schema
 		stmtBuilder: &duplicatorStmtBuilder{
 			table: table,
 		},
-		conn:    conn,
-		columns: cols,
+		conn:              conn,
+		columns:           cols,
+		withoutConstraint: make([]string, 0),
 	}
 }
 

--- a/pkg/migrations/duplicate.go
+++ b/pkg/migrations/duplicate.go
@@ -34,6 +34,8 @@ type ColumnGroupDuplicator struct {
 	columns    []*schema.Column
 }
 
+// duplicatorStmtBuilder is a helper for building SQL statements to duplicate
+// columns and constraints in a table.
 type duplicatorStmtBuilder struct {
 	table *schema.Table
 }

--- a/pkg/migrations/duplicate.go
+++ b/pkg/migrations/duplicate.go
@@ -23,9 +23,10 @@ type ColumnDuplicator struct {
 	withoutNotNull    bool
 	withType          string
 	withoutConstraint string
-	duplicatedUnique  map[string]schema.UniqueConstraint
 }
 
+// ColumnGroupDuplicator duplicates a group of columns in a table, including all constraints and
+// comments.
 type ColumnGroupDuplicator struct {
 	duplicator *duplicator
 	columns    []*schema.Column
@@ -146,10 +147,6 @@ func (d *ColumnDuplicator) Duplicate(ctx context.Context) error {
 			_, err := d.duplicator.conn.ExecContext(ctx, sql)
 			if err != nil {
 				return err
-			}
-			d.duplicatedUnique[DuplicationName(uc.Name)] = schema.UniqueConstraint{
-				Name:    DuplicationName(uc.Name),
-				Columns: copyAndReplace(uc.Columns, d.column.Name, d.asName),
 			}
 		}
 	}

--- a/pkg/migrations/duplicate.go
+++ b/pkg/migrations/duplicate.go
@@ -157,7 +157,7 @@ func (d *ColumnDuplicator) Duplicate(ctx context.Context) error {
 func (cg *ColumnGroupDuplicator) Duplicate(ctx context.Context) error {
 	for _, column := range cg.columns {
 		asName := TemporaryName(column.Name)
-		notNull := false
+		withoutNotNull := false
 		withoutConstraint := ""
 		// Duplicate the column with the new type
 		// and check and fk constraints

--- a/pkg/migrations/duplicate.go
+++ b/pkg/migrations/duplicate.go
@@ -161,7 +161,7 @@ func (cg *ColumnGroupDuplicator) Duplicate(ctx context.Context) error {
 		withoutConstraint := ""
 		// Duplicate the column with the new type
 		// and check and fk constraints
-		if err := cg.duplicator.duplicateColumn(ctx, column, asName, notNull, column.Type, withoutConstraint); err != nil {
+		if err := cg.duplicator.duplicateColumn(ctx, column, asName, withoutNotNull, column.Type, withoutConstraint); err != nil {
 			return err
 		}
 
@@ -222,7 +222,6 @@ func (cg *ColumnGroupDuplicator) Duplicate(ctx context.Context) error {
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/pkg/migrations/duplicate.go
+++ b/pkg/migrations/duplicate.go
@@ -113,7 +113,7 @@ func (d *ColumnDuplicator) Duplicate(ctx context.Context) error {
 			sql := fmt.Sprintf(cAlterTableAddCheckConstraintSQL,
 				pq.QuoteIdentifier(d.duplicator.table.Name),
 				pq.QuoteIdentifier(DuplicationName(cc.Name)),
-				rewriteCheckExpression(cc.Definition, d.column.Name, d.asName),
+				rewriteCheckExpression(cc.Definition, d.column.Name),
 			)
 
 			_, err := d.duplicator.conn.ExecContext(ctx, sql)

--- a/pkg/migrations/duplicate.go
+++ b/pkg/migrations/duplicate.go
@@ -105,6 +105,7 @@ func (d *ColumnDuplicator) Duplicate(ctx context.Context) error {
 	// Duplicate the column's default value
 	if sql := d.duplicator.duplicateDefault(d.column, d.asName); sql != "" {
 		_, err := d.conn.ExecContext(ctx, sql)
+		err = errorIgnoringErrorCode(err, dataTypeMismatchErrorCode)
 		if err != nil {
 			return err
 		}

--- a/pkg/migrations/duplicate.go
+++ b/pkg/migrations/duplicate.go
@@ -86,13 +86,6 @@ func (d *ColumnDuplicator) WithoutNotNull() *ColumnDuplicator {
 	return d
 }
 
-func (d *Duplicator) WithColumn(c *schema.Column) *Duplicator {
-	d.column = c
-	d.asName = TemporaryName(c.Name)
-	d.withType = c.Type
-	return d
-}
-
 // Duplicate duplicates a column in the table, including all constraints and
 // comments.
 func (d *ColumnDuplicator) Duplicate(ctx context.Context) error {
@@ -156,7 +149,7 @@ func (d *ColumnDuplicator) Duplicate(ctx context.Context) error {
 			}
 			d.duplicatedUnique[DuplicationName(uc.Name)] = schema.UniqueConstraint{
 				Name:    DuplicationName(uc.Name),
-				Columns: copyAndReplace(cols, d.column.Name, d.asName),
+				Columns: copyAndReplace(uc.Columns, d.column.Name, d.asName),
 			}
 		}
 	}

--- a/pkg/migrations/duplicate_test.go
+++ b/pkg/migrations/duplicate_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package migrations
 
 import (

--- a/pkg/migrations/duplicate_test.go
+++ b/pkg/migrations/duplicate_test.go
@@ -11,31 +11,28 @@ import (
 	"github.com/xataio/pgroll/pkg/schema"
 )
 
-var (
-	table = &schema.Table{
-		Name: "test_table",
-		Columns: map[string]schema.Column{
-			"id":          {Name: "id", Type: "serial"},
-			"name":        {Name: "name", Type: "text"},
-			"nick":        {Name: "nick", Type: "text"},
-			"age":         {Name: "age", Type: "integer"},
-			"email":       {Name: "email", Type: "text"},
-			"city":        {Name: "city", Type: "text"},
-			"description": {Name: "description", Type: "text"},
-		},
-		UniqueConstraints: map[string]schema.UniqueConstraint{
-			"unique_email":     {Name: "unique_email", Columns: []string{"email"}},
-			"unique_name_nick": {Name: "unique_name_nick", Columns: []string{"name", "nick"}},
-		},
-		CheckConstraints: map[string]schema.CheckConstraint{
-			"email_at":        {Name: "email_at", Columns: []string{"email"}, Definition: `"email" ~ '@'`},
-			"adults":          {Name: "adults", Columns: []string{"age"}, Definition: `"age" > 18`},
-			"new_york_adults": {Name: "new_york_adults", Columns: []string{"city", "age"}, Definition: `"city" = 'New York' AND "age" > 21`},
-			"different_nick":  {Name: "different_nick", Columns: []string{"name", "nick"}, Definition: `"name" != "nick"`},
-		},
-	}
-	withoutConstraint = ""
-)
+var table = &schema.Table{
+	Name: "test_table",
+	Columns: map[string]schema.Column{
+		"id":          {Name: "id", Type: "serial"},
+		"name":        {Name: "name", Type: "text"},
+		"nick":        {Name: "nick", Type: "text"},
+		"age":         {Name: "age", Type: "integer"},
+		"email":       {Name: "email", Type: "text"},
+		"city":        {Name: "city", Type: "text"},
+		"description": {Name: "description", Type: "text"},
+	},
+	UniqueConstraints: map[string]schema.UniqueConstraint{
+		"unique_email":     {Name: "unique_email", Columns: []string{"email"}},
+		"unique_name_nick": {Name: "unique_name_nick", Columns: []string{"name", "nick"}},
+	},
+	CheckConstraints: map[string]schema.CheckConstraint{
+		"email_at":        {Name: "email_at", Columns: []string{"email"}, Definition: `"email" ~ '@'`},
+		"adults":          {Name: "adults", Columns: []string{"age"}, Definition: `"age" > 18`},
+		"new_york_adults": {Name: "new_york_adults", Columns: []string{"city", "age"}, Definition: `"city" = 'New York' AND "age" > 21`},
+		"different_nick":  {Name: "different_nick", Columns: []string{"name", "nick"}, Definition: `"name" != "nick"`},
+	},
+}
 
 func TestDuplicateStmtBuilderCheckConstraints(t *testing.T) {
 	d := &duplicatorStmtBuilder{table}
@@ -75,7 +72,7 @@ func TestDuplicateStmtBuilderCheckConstraints(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			stmts := d.duplicateCheckConstraints(withoutConstraint, testCases.columns...)
+			stmts := d.duplicateCheckConstraints(nil, testCases.columns...)
 			assert.Equal(t, len(testCases.expectedStmts), len(stmts))
 			for _, stmt := range stmts {
 				assert.True(t, slices.Contains(testCases.expectedStmts, stmt))
@@ -116,7 +113,7 @@ func TestDuplicateStmtBuilderUniqueConstraints(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			stmts := d.duplicateUniqueConstraints(withoutConstraint, testCases.columns...)
+			stmts := d.duplicateUniqueConstraints(nil, testCases.columns...)
 			assert.Equal(t, len(testCases.expectedStmts), len(stmts))
 			for _, stmt := range stmts {
 				assert.True(t, slices.Contains(testCases.expectedStmts, stmt))

--- a/pkg/migrations/duplicate_test.go
+++ b/pkg/migrations/duplicate_test.go
@@ -1,0 +1,124 @@
+package migrations
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/xataio/pgroll/pkg/schema"
+)
+
+var (
+	table = &schema.Table{
+		Name: "test_table",
+		Columns: map[string]schema.Column{
+			"id":          {Name: "id", Type: "serial"},
+			"name":        {Name: "name", Type: "text"},
+			"nick":        {Name: "nick", Type: "text"},
+			"age":         {Name: "age", Type: "integer"},
+			"email":       {Name: "email", Type: "text"},
+			"city":        {Name: "city", Type: "text"},
+			"description": {Name: "description", Type: "text"},
+		},
+		UniqueConstraints: map[string]schema.UniqueConstraint{
+			"unique_email":     {Name: "unique_email", Columns: []string{"email"}},
+			"unique_name_nick": {Name: "unique_name_nick", Columns: []string{"name", "nick"}},
+		},
+		CheckConstraints: map[string]schema.CheckConstraint{
+			"email_at":        {Name: "email_at", Columns: []string{"email"}, Definition: `"email" ~ '@'`},
+			"adults":          {Name: "adults", Columns: []string{"age"}, Definition: `"age" > 18`},
+			"new_york_adults": {Name: "new_york_adults", Columns: []string{"city", "age"}, Definition: `"city" = 'New York' AND "age" > 21`},
+			"different_nick":  {Name: "different_nick", Columns: []string{"name", "nick"}, Definition: `"name" != "nick"`},
+		},
+	}
+	withoutConstraint = ""
+)
+
+func TestDuplicateStmtBuilderCheckConstraints(t *testing.T) {
+	d := &duplicatorStmtBuilder{table}
+	for name, testCases := range map[string]struct {
+		columns       []string
+		expectedStmts []string
+	}{
+		"single column duplicated with no constraint": {
+			columns:       []string{"description"},
+			expectedStmts: []string{},
+		},
+		"single-column check constraint with single column duplicated": {
+			columns:       []string{"email"},
+			expectedStmts: []string{`ALTER TABLE "test_table" ADD CONSTRAINT "_pgroll_dup_email_at" "_pgroll_new_email" ~ '@' NOT VALID`},
+		},
+		"multiple multi and single column check constraint with single column duplicated": {
+			columns: []string{"age"},
+			expectedStmts: []string{
+				`ALTER TABLE "test_table" ADD CONSTRAINT "_pgroll_dup_adults" "_pgroll_new_age" > 18 NOT VALID`,
+				`ALTER TABLE "test_table" ADD CONSTRAINT "_pgroll_dup_new_york_adults" "city" = 'New York' AND "_pgroll_new_age" > 21 NOT VALID`,
+			},
+		},
+		"multiple multi and single column check constraint with multiple column duplicated": {
+			columns: []string{"age", "description"},
+			expectedStmts: []string{
+				`ALTER TABLE "test_table" ADD CONSTRAINT "_pgroll_dup_adults" "_pgroll_new_age" > 18 NOT VALID`,
+				`ALTER TABLE "test_table" ADD CONSTRAINT "_pgroll_dup_new_york_adults" "city" = 'New York' AND "_pgroll_new_age" > 21 NOT VALID`,
+			},
+		},
+		"multi-column check constraint with multiple columns with single column duplicated": {
+			columns:       []string{"name"},
+			expectedStmts: []string{`ALTER TABLE "test_table" ADD CONSTRAINT "_pgroll_dup_different_nick" "_pgroll_new_name" != "nick" NOT VALID`},
+		},
+		"multi-column check constraint with multiple columns duplicated": {
+			columns:       []string{"name", "nick"},
+			expectedStmts: []string{`ALTER TABLE "test_table" ADD CONSTRAINT "_pgroll_dup_different_nick" "_pgroll_new_name" != "_pgroll_new_nick" NOT VALID`},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			stmts := d.duplicateCheckConstraints(withoutConstraint, testCases.columns...)
+			assert.Equal(t, len(testCases.expectedStmts), len(stmts))
+			for _, stmt := range stmts {
+				assert.True(t, slices.Contains(testCases.expectedStmts, stmt))
+			}
+		})
+	}
+}
+
+func TestDuplicateStmtBuilderUniqueConstraints(t *testing.T) {
+	d := &duplicatorStmtBuilder{table}
+	for name, testCases := range map[string]struct {
+		columns       []string
+		expectedStmts []string
+	}{
+		"single column duplicated": {
+			columns:       []string{"city"},
+			expectedStmts: []string{},
+		},
+		"single-column constraint with single column duplicated": {
+			columns:       []string{"email"},
+			expectedStmts: []string{`CREATE UNIQUE INDEX CONCURRENTLY "_pgroll_dup_unique_email" ON "test_table" ("_pgroll_new_email")`},
+		},
+		"single-column constraint with multiple column duplicated": {
+			columns:       []string{"email", "description"},
+			expectedStmts: []string{`CREATE UNIQUE INDEX CONCURRENTLY "_pgroll_dup_unique_email" ON "test_table" ("_pgroll_new_email")`},
+		},
+		"multi-column constraint with single column duplicated": {
+			columns:       []string{"name"},
+			expectedStmts: []string{`CREATE UNIQUE INDEX CONCURRENTLY "_pgroll_dup_unique_name_nick" ON "test_table" ("_pgroll_new_name", "nick")`},
+		},
+		"multi-column constraint with multiple unrelated column duplicated": {
+			columns:       []string{"name", "description"},
+			expectedStmts: []string{`CREATE UNIQUE INDEX CONCURRENTLY "_pgroll_dup_unique_name_nick" ON "test_table" ("_pgroll_new_name", "nick")`},
+		},
+		"multi-column constraint with multiple columns": {
+			columns:       []string{"name", "nick"},
+			expectedStmts: []string{`CREATE UNIQUE INDEX CONCURRENTLY "_pgroll_dup_unique_name_nick" ON "test_table" ("_pgroll_new_name", "_pgroll_new_nick")`},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			stmts := d.duplicateUniqueConstraints(withoutConstraint, testCases.columns...)
+			assert.Equal(t, len(testCases.expectedStmts), len(stmts))
+			for _, stmt := range stmts {
+				assert.True(t, slices.Contains(testCases.expectedStmts, stmt))
+			}
+		})
+	}
+}

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -241,7 +241,7 @@ func (o *OpAddColumn) addCheckConstraint(ctx context.Context, tableName string, 
 	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s CHECK (%s) NOT VALID",
 		pq.QuoteIdentifier(tableName),
 		pq.QuoteIdentifier(o.Column.Check.Name),
-		rewriteCheckExpression(o.Column.Check.Constraint, o.Column.Name, TemporaryName(o.Column.Name)),
+		rewriteCheckExpression(o.Column.Check.Constraint, o.Column.Name),
 	))
 	return err
 }

--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -330,15 +330,15 @@ func (o *OpAlterColumn) subOperations() []Operation {
 }
 
 // duplicatorForOperations returns a Duplicator for the given operations
-func duplicatorForOperations(ops []Operation, conn db.DB, table *schema.Table, column *schema.Column) *ColumnDuplicator {
+func duplicatorForOperations(ops []Operation, conn db.DB, table *schema.Table, column *schema.Column) *Duplicator {
 	d := NewColumnDuplicator(conn, table, column)
 
 	for _, op := range ops {
 		switch op := (op).(type) {
 		case *OpDropNotNull:
-			d = d.WithoutNotNull()
+			d = d.WithoutNotNull(column.Name)
 		case *OpChangeType:
-			d = d.WithType(op.Type)
+			d = d.WithType(column.Name, op.Type)
 		}
 	}
 	return d

--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -330,8 +330,8 @@ func (o *OpAlterColumn) subOperations() []Operation {
 }
 
 // duplicatorForOperations returns a Duplicator for the given operations
-func duplicatorForOperations(ops []Operation, conn db.DB, table *schema.Table, column *schema.Column) *Duplicator {
-	d := NewColumnDuplicator(conn, table).WithColumn(column)
+func duplicatorForOperations(ops []Operation, conn db.DB, table *schema.Table, column *schema.Column) *ColumnDuplicator {
+	d := NewColumnDuplicator(conn, table, column)
 
 	for _, op := range ops {
 		switch op := (op).(type) {

--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -331,7 +331,7 @@ func (o *OpAlterColumn) subOperations() []Operation {
 
 // duplicatorForOperations returns a Duplicator for the given operations
 func duplicatorForOperations(ops []Operation, conn db.DB, table *schema.Table, column *schema.Column) *Duplicator {
-	d := NewColumnDuplicator(conn, table, column)
+	d := NewColumnDuplicator(conn, table).WithColumn(column)
 
 	for _, op := range ops {
 		switch op := (op).(type) {

--- a/pkg/migrations/op_create_constraint.go
+++ b/pkg/migrations/op_create_constraint.go
@@ -22,7 +22,7 @@ func (o *OpCreateConstraint) Start(ctx context.Context, conn db.DB, latestSchema
 		columns[i] = table.GetColumn(colName)
 	}
 
-	d := NewColumnGroupDuplicator(conn, table, columns)
+	d := NewColumnDuplicator(conn, table, columns...)
 	if err := d.Duplicate(ctx); err != nil {
 		return nil, fmt.Errorf("failed to duplicate columns for new constraint: %w", err)
 	}

--- a/pkg/migrations/op_drop_constraint.go
+++ b/pkg/migrations/op_drop_constraint.go
@@ -22,7 +22,7 @@ func (o *OpDropConstraint) Start(ctx context.Context, conn db.DB, latestSchema s
 	column := table.GetColumn(table.GetConstraintColumns(o.Name)[0])
 
 	// Create a copy of the column on the underlying table.
-	d := NewColumnDuplicator(conn, table, column).WithoutConstraint(o.Name)
+	d := NewColumnDuplicator(conn, table).WithColumn(column).WithoutConstraint(o.Name)
 	if err := d.Duplicate(ctx); err != nil {
 		return nil, fmt.Errorf("failed to duplicate column: %w", err)
 	}

--- a/pkg/migrations/op_drop_constraint.go
+++ b/pkg/migrations/op_drop_constraint.go
@@ -22,7 +22,7 @@ func (o *OpDropConstraint) Start(ctx context.Context, conn db.DB, latestSchema s
 	column := table.GetColumn(table.GetConstraintColumns(o.Name)[0])
 
 	// Create a copy of the column on the underlying table.
-	d := NewColumnDuplicator(conn, table).WithColumn(column).WithoutConstraint(o.Name)
+	d := NewColumnDuplicator(conn, table, column).WithoutConstraint(o.Name)
 	if err := d.Duplicate(ctx); err != nil {
 		return nil, fmt.Errorf("failed to duplicate column: %w", err)
 	}

--- a/pkg/migrations/op_set_check.go
+++ b/pkg/migrations/op_set_check.go
@@ -86,7 +86,7 @@ func (o *OpSetCheckConstraint) addCheckConstraint(ctx context.Context, conn db.D
 	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s CHECK (%s) NOT VALID",
 		pq.QuoteIdentifier(o.Table),
 		pq.QuoteIdentifier(o.Check.Name),
-		rewriteCheckExpression(o.Check.Constraint, o.Column, TemporaryName(o.Column)),
+		rewriteCheckExpression(o.Check.Constraint, o.Column),
 	))
 
 	return err
@@ -97,6 +97,9 @@ func (o *OpSetCheckConstraint) addCheckConstraint(ctx context.Context, conn db.D
 // On migration start, however, the check is actually applied to the new (temporary)
 // column.
 // This function naively rewrites the check expression to apply to the new column.
-func rewriteCheckExpression(check string, oldColumn, newColumn string) string {
-	return strings.ReplaceAll(check, oldColumn, newColumn)
+func rewriteCheckExpression(check string, columns ...string) string {
+	for _, col := range columns {
+		check = strings.ReplaceAll(check, col, TemporaryName(col))
+	}
+	return check
 }

--- a/pkg/migrations/rename.go
+++ b/pkg/migrations/rename.go
@@ -151,6 +151,7 @@ func RenameDuplicatedColumn(ctx context.Context, conn db.DB, table *schema.Table
 			if err != nil {
 				return fmt.Errorf("failed to create unique constraint from index %q: %w", ui.Name, err)
 			}
+			delete(table.Indexes, ui.Name)
 		}
 	}
 

--- a/pkg/migrations/rename.go
+++ b/pkg/migrations/rename.go
@@ -151,6 +151,7 @@ func RenameDuplicatedColumn(ctx context.Context, conn db.DB, table *schema.Table
 			if err != nil {
 				return fmt.Errorf("failed to create unique constraint from index %q: %w", ui.Name, err)
 			}
+			// Index no longer exists, remove it from the table
 			delete(table.Indexes, ui.Name)
 		}
 	}


### PR DESCRIPTION
Previously, unique and check constraints with multiple columns were not duplicated correctly.

We had two issues:
1. Pgroll tried to create the same duplicated index for each renamed column. From now on pgroll creates the index once with the new column names.
2. Pgroll tried to convert the unique index to a constraint multiple times. From now on, the index is only converted once.

Required by https://github.com/xataio/pgroll/pull/464