### PR TITLE
Add a benchmark for read_schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,10 @@ For more advanced usage, a tutorial, and detailed options refer to the full [Doc
 
 Some performance benchmarks are run on each commit to `main` in order to track performance over time. Each benchmark is run against Postgres 14.8, 15.3, 16.4, 17.0 and "latest". Each line on the chart represents the number of rows the benchmark was run against, currently 10k, 100k and 300k rows.
 
-* Backfill: Rows/s to backfill a text column with the value `placeholder`. We use our default batching strategy of 10k rows per batch with no backoff.
-* WriteAmplification/NoTrigger: Baseline rows/s when writing data to a table without a `pgroll` trigger.
-* WriteAmplification/WithTrigger: Rows/s when writing data to a table when a `pgroll` trigger has been set up.
-* ReadSchema: Checks the number of executions per second of the `read_schema` function which is a core function executed frequently during migrations.
+* `Backfill:` Rows/s to backfill a text column with the value `placeholder`. We use our default batching strategy of 10k rows per batch with no backoff.
+* `WriteAmplification/NoTrigger:` Baseline rows/s when writing data to a table without a `pgroll` trigger.
+* `WriteAmplification/WithTrigger:` Rows/s when writing data to a table when a `pgroll` trigger has been set up.
+* `ReadSchema:` Checks the number of executions per second of the `read_schema` function which is a core function executed frequently during migrations.
 
 They can be seen [here](https://xataio.github.io/pgroll/benchmarks.html).
 

--- a/README.md
+++ b/README.md
@@ -170,8 +170,9 @@ For more advanced usage, a tutorial, and detailed options refer to the full [Doc
 Some performance benchmarks are run on each commit to `main` in order to track performance over time. Each benchmark is run against Postgres 14.8, 15.3, 16.4, 17.0 and "latest". Each line on the chart represents the number of rows the benchmark was run against, currently 10k, 100k and 300k rows.
 
 * Backfill: Rows/s to backfill a text column with the value `placeholder`. We use our default batching strategy of 10k rows per batch with no backoff.
-* WriteAmplification/NoTrigger: Baselines rows/s when writing data to a table without a `pgroll` trigger.
-* WriteAmplificationWithTrigger: Rows/s when writing data to a table when a `pgroll` trigger has been set up.
+* WriteAmplification/NoTrigger: Baseline rows/s when writing data to a table without a `pgroll` trigger.
+* WriteAmplification/WithTrigger: Rows/s when writing data to a table when a `pgroll` trigger has been set up.
+* ReadSchema: Checks the number of executions per second of the `read_schema` function which is a core function executed frequently during migrations.
 
 They can be seen [here](https://xataio.github.io/pgroll/benchmarks.html).
 

--- a/dev/benchmark-results/build.go
+++ b/dev/benchmark-results/build.go
@@ -226,9 +226,13 @@ func loadData(filename string) (allReports []BenchmarkReports, err error) {
 }
 
 // Benchmarks are grouped by the number of rows they were tested against. We need to trim this off
-// the end.
+// the end if it exists.
 func trimName(name string) string {
-	return strings.TrimPrefix(name[:strings.LastIndex(name, "/")], "Benchmark")
+	name = strings.TrimPrefix(name, "Benchmark")
+	if i := strings.LastIndex(name, "/"); i != -1 {
+		name = name[:i]
+	}
+	return name
 }
 
 // First 7 characters

--- a/dev/benchmark-results/build_test.go
+++ b/dev/benchmark-results/build_test.go
@@ -18,3 +18,9 @@ func TestBuildChartsRegression(t *testing.T) {
 	// 5 versions * 3 benchmarks
 	assert.Len(t, generated, 15)
 }
+
+func TestTrimName(t *testing.T) {
+	assert.Equal(t, "Test1", trimName("BenchmarkTest1/1000"))
+	assert.Equal(t, "Test1/Case2", trimName("BenchmarkTest1/Case2/1000"))
+	assert.Equal(t, "Test1", trimName("BenchmarkTest1"))
+}

--- a/internal/benchmarks/benchmarks_test.go
+++ b/internal/benchmarks/benchmarks_test.go
@@ -173,9 +173,8 @@ func BenchmarkReadSchema(b *testing.B) {
 		// We don't want this benchmark to test the network so instead we run the actual function in a tight
 		// loop within a single execution.
 		executions := 10000
-		// nolint:gosec
-		q := fmt.Sprintf(`SELECT %s.read_schema($1) FROM generate_series(1, %d);`, pq.QuoteIdentifier(mig.State().Schema()), executions)
-		_, err := db.ExecContext(ctx, q, testSchema)
+		q := fmt.Sprintf(`SELECT %s.read_schema($1) FROM generate_series(1, $2);`, pq.QuoteIdentifier(mig.State().Schema()))
+		_, err := db.ExecContext(ctx, q, testSchema, executions)
 		b.StopTimer()
 		require.NoError(b, err)
 		perSecond := float64(executions) / b.Elapsed().Seconds()

--- a/internal/benchmarks/benchmarks_test.go
+++ b/internal/benchmarks/benchmarks_test.go
@@ -173,6 +173,7 @@ func BenchmarkReadSchema(b *testing.B) {
 		// We don't want this benchmark to test the network so instead we run the actual function in a tight
 		// loop within a single execution.
 		executions := 10000
+		// nolint:gosec
 		q := fmt.Sprintf(`SELECT %s.read_schema($1) FROM generate_series(1, %d);`, pq.QuoteIdentifier(mig.State().Schema()), executions)
 		_, err := db.ExecContext(ctx, q, testSchema)
 		b.StopTimer()


### PR DESCRIPTION
Add a benchmark for the `read_schema` function which has caused regressions in the past.

Part of https://github.com/xataio/pgroll/issues/408