### PR TITLE
Don't add series for missing row count

### DIFF
--- a/dev/benchmark-results/build.go
+++ b/dev/benchmark-results/build.go
@@ -177,6 +177,9 @@ func generateCharts(reports []BenchmarkReports) []*charts.Line {
 
 		for _, rowCount := range sortedRowCounts {
 			s := series[rowCount]
+			if len(s) == 0 {
+				continue
+			}
 
 			name := fmt.Sprintf("%d", rowCount)
 			data := make([]opts.LineData, len(series[rowCount]))


### PR DESCRIPTION
Some bechmarks don't include a series for all row count values. Don't add a chart if there is no data for the row count.

Fixes an issue with the `ReadSchema` benchmark where we see multiple row count values even though we only populate one of them:

<img width="828" alt="Screenshot 2024-11-20 at 12 33 13" src="https://github.com/user-attachments/assets/f129ebb3-46ae-43bc-864a-7dc404ff7a1c">
