### PR TITLE
Fix `read_schema` function for multi-column foreign key constaints

### DIFF
--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -817,7 +817,7 @@ func TestReadSchema(t *testing.T) {
 								"fk_customer_product": {
 									Name:              "fk_customer_product",
 									Columns:           []string{"customer_id", "product_id"},
-									ReferencedTable:   "public.products",
+									ReferencedTable:   "products",
 									ReferencedColumns: []string{"customer_id", "product_id"},
 									OnDelete:          "NO ACTION",
 								},

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -756,6 +756,79 @@ func TestReadSchema(t *testing.T) {
 				},
 			},
 			{
+				name: "multicolumn foreign key constraint",
+				createStmt: `CREATE TABLE products(
+          customer_id INT NOT NULL, 
+          product_id INT NOT NULL, 
+          PRIMARY KEY(customer_id, product_id));
+
+          CREATE TABLE orders(
+            customer_id INT NOT NULL, 
+            product_id INT NOT NULL, 
+            CONSTRAINT fk_customer_product FOREIGN KEY (customer_id, product_id) REFERENCES products (customer_id, product_id));`,
+				wantSchema: &schema.Schema{
+					Name: "public",
+					Tables: map[string]schema.Table{
+						"products": {
+							Name: "products",
+							Columns: map[string]schema.Column{
+								"customer_id": {
+									Name:     "customer_id",
+									Type:     "integer",
+									Nullable: false,
+								},
+								"product_id": {
+									Name:     "product_id",
+									Type:     "integer",
+									Nullable: false,
+								},
+							},
+							PrimaryKey: []string{"customer_id", "product_id"},
+							Indexes: map[string]schema.Index{
+								"products_pkey": {
+									Name:       "products_pkey",
+									Unique:     true,
+									Columns:    []string{"customer_id", "product_id"},
+									Method:     string(migrations.OpCreateIndexMethodBtree),
+									Definition: "CREATE UNIQUE INDEX products_pkey ON public.products USING btree (customer_id, product_id)",
+								},
+							},
+							ForeignKeys:       map[string]schema.ForeignKey{},
+							CheckConstraints:  map[string]schema.CheckConstraint{},
+							UniqueConstraints: map[string]schema.UniqueConstraint{},
+						},
+						"orders": {
+							Name: "orders",
+							Columns: map[string]schema.Column{
+								"customer_id": {
+									Name:     "customer_id",
+									Type:     "integer",
+									Nullable: false,
+								},
+								"product_id": {
+									Name:     "product_id",
+									Type:     "integer",
+									Nullable: false,
+								},
+							},
+							PrimaryKey: []string{},
+							Indexes:    map[string]schema.Index{},
+							ForeignKeys: map[string]schema.ForeignKey{
+								"fk_customer_product": {
+									Name:              "fk_customer_product",
+									Columns:           []string{"customer_id", "product_id"},
+									ReferencedTable:   "public.products",
+									ReferencedColumns: []string{"customer_id", "product_id"},
+									OnDelete:          "NO ACTION",
+								},
+							},
+							CheckConstraints:  map[string]schema.CheckConstraint{},
+							UniqueConstraints: map[string]schema.UniqueConstraint{},
+						},
+					},
+				},
+			},
+			{
 				name:       "multi-column index",
 				createStmt: "CREATE TABLE public.table1 (a text, b text); CREATE INDEX idx_ab ON public.table1 (a, b);",
 				wantSchema: &schema.Schema{


### PR DESCRIPTION
Update the query used by `read_schema` to fetch foreign key information. This fixes the problem of `columns` and `referencedColumns` containing duplicate entries for multi-column foreign keys.

For a foreign key defined like `"fk_sellers" FOREIGN KEY (sellers_name, sellers_zip) REFERENCES sellers(name, zip)` the change in behaviour is as follows:

Before:

```json
{
      ...
      "foreignKeys": {
        "fk_sellers": {
          "name": "fk_sellers",
          "columns": [
            "sellers_name",
            "sellers_zip",
            "sellers_name",
            "sellers_zip"
          ],
          "referencedTable": "sellers",
          "referencedColumns": [
            "name",
            "zip",
            "name",
            "zip"
          ],
          "onDelete": "NO ACTION"
        }
      },
}
```

After:

```json
{
      ...
      "foreignKeys": {
        "fk_sellers": {
          "name": "fk_sellers",
          "columns": [
            "sellers_name",
            "sellers_zip"
          ],
          "referencedTable": "sellers",
          "referencedColumns": [
            "name",
            "zip"
          ],
          "onDelete": "NO ACTION"
        }
      },
}
```

The solution here is to perform grouping and array aggregation of the referencing table's columns before the join to the referenced table's columns.

Fixes https://github.com/xataio/pgroll/issues/475