### PR TITLE
Support dropping default for a column

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -862,7 +862,7 @@ A change default operation changes the default value of a column.
   "alter_column": {
     "table": "table name",
     "column": "column name",
-    "default": "new default value",
+    "default": "new default value (or null)",
     "up": "SQL expression",
     "down": "SQL expression"
   }
@@ -872,6 +872,7 @@ A change default operation changes the default value of a column.
 Example **change default** migrations:
 
 * [35_alter_column_multiple.json](../examples/35_alter_column_multiple.json)
+* [46_alter_column_drop_default](../examples/46_alter_column_drop_default.json)
 
 #### Change comment
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -862,7 +862,7 @@ A change default operation changes the default value of a column.
   "alter_column": {
     "table": "table name",
     "column": "column name",
-    "default": "new default value (or null)",
+    "default": "new default value" | null,
     "up": "SQL expression",
     "down": "SQL expression"
   }
@@ -885,7 +885,7 @@ A change comment operation changes the comment on a column.
   "alter_column": {
     "table": "table name",
     "column": "column name",
-    "comment": "new comment for column" or null,
+    "comment": "new comment for column" | null,
     "up": "SQL expression",
     "down": "SQL expression"
   }

--- a/examples/.ledger
+++ b/examples/.ledger
@@ -43,3 +43,4 @@
 43_create_tickets_table.json
 44_add_table_unique_constraint.json
 45_add_table_check_constraint.json
+46_alter_column_drop_default.json

--- a/examples/43_create_tickets_table.json
+++ b/examples/43_create_tickets_table.json
@@ -17,6 +17,11 @@
           {
             "name": "sellers_zip",
             "type": "integer"
+          },
+          {
+            "name": "ticket_type",
+            "type": "varchar(255)",
+            "default": "'paper'"
           }
         ]
       }

--- a/examples/46_alter_column_drop_default.json
+++ b/examples/46_alter_column_drop_default.json
@@ -5,7 +5,9 @@
       "alter_column": {
         "table": "tickets",
         "column": "ticket_type",
-        "default": null
+        "default": null,
+        "up": "",
+        "down": ""
       }
     }
   ]

--- a/examples/46_alter_column_drop_default.json
+++ b/examples/46_alter_column_drop_default.json
@@ -1,0 +1,12 @@
+{
+  "name": "46_alter_column_drop_default",
+  "operations": [
+    {
+      "alter_column": {
+        "table": "tickets",
+        "column": "ticket_type",
+        "default": null
+      }
+    }
+  ]
+}

--- a/examples/46_alter_column_drop_default.json
+++ b/examples/46_alter_column_drop_default.json
@@ -6,8 +6,8 @@
         "table": "tickets",
         "column": "ticket_type",
         "default": null,
-        "up": "",
-        "down": ""
+        "up": "ticket_type",
+        "down": "ticket_type"
       }
     }
   ]

--- a/pkg/migrations/comment.go
+++ b/pkg/migrations/comment.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/lib/pq"
+
 	"github.com/xataio/pgroll/pkg/db"
 )
 

--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -302,11 +302,17 @@ func (o *OpAlterColumn) subOperations() []Operation {
 			Down:   o.Down,
 		})
 	}
-	if o.Default != nil {
+	if o.Default.IsSpecified() {
+		// o.Default is either a valid value or `null`.
+		var defaultPtr *string
+		if d, err := o.Default.Get(); err == nil {
+			defaultPtr = &d
+		}
+
 		ops = append(ops, &OpSetDefault{
 			Table:   o.Table,
 			Column:  o.Column,
-			Default: *o.Default,
+			Default: defaultPtr,
 			Up:      o.Up,
 			Down:    o.Down,
 		})

--- a/pkg/migrations/op_alter_column_test.go
+++ b/pkg/migrations/op_alter_column_test.go
@@ -204,7 +204,7 @@ func TestAlterColumnMultipleSubOperations(t *testing.T) {
 							Table:    "events",
 							Column:   "name",
 							Nullable: ptr(false),
-							Default:  ptr("'default'"),
+							Default:  nullable.NewNullableWithValue("'default'"),
 							Up:       "(SELECT CASE WHEN name IS NULL THEN 'rewritten by up SQL' ELSE name END)",
 						},
 					},

--- a/pkg/migrations/op_set_default_test.go
+++ b/pkg/migrations/op_set_default_test.go
@@ -6,7 +6,9 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/oapi-codegen/nullable"
 	"github.com/stretchr/testify/assert"
+
 	"github.com/xataio/pgroll/pkg/migrations"
 )
 
@@ -43,7 +45,7 @@ func TestSetDefault(t *testing.T) {
 						&migrations.OpAlterColumn{
 							Table:   "users",
 							Column:  "name",
-							Default: ptr("'unknown user'"),
+							Default: nullable.NewNullableWithValue("'unknown user'"),
 						},
 					},
 				},
@@ -145,7 +147,7 @@ func TestSetDefault(t *testing.T) {
 						&migrations.OpAlterColumn{
 							Table:   "users",
 							Column:  "name",
-							Default: ptr("'unknown user'"),
+							Default: nullable.NewNullableWithValue("'unknown user'"),
 							Up:      "'rewritten by up SQL'",
 							Down:    "'rewritten by down SQL'",
 						},
@@ -248,7 +250,109 @@ func TestSetDefault(t *testing.T) {
 						&migrations.OpAlterColumn{
 							Table:   "users",
 							Column:  "name",
-							Default: ptr("NULL"),
+							Default: nullable.NewNullableWithValue("NULL"),
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
+				// Inserting a row into the new schema succeeds
+				MustInsert(t, db, schema, "02_set_default", "users", map[string]string{
+					"id": "1",
+				})
+
+				// Inserting a row into the old schema succeeds
+				MustInsert(t, db, schema, "01_add_table", "users", map[string]string{
+					"id": "2",
+				})
+
+				// The new schema has the expected rows:
+				// * The first row is NULL because it was inserted into the new schema which
+				//   does not have a default
+				// * The second has a default value because it was backfilled from the old
+				//   schema which has a default
+				rows := MustSelect(t, db, schema, "02_set_default", "users")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "name": nil},
+					{"id": 2, "name": "unknown user"},
+				}, rows)
+
+				// The old schema has the expected rows:
+				// * The first row is NULL because it was backfilled from the new schema
+				//   which does not have a default
+				// * The second row has a default value because it was inserted without
+				//   a value into the old schema which has a default
+				rows = MustSelect(t, db, schema, "01_add_table", "users")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "name": nil},
+					{"id": 2, "name": "unknown user"},
+				}, rows)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
+				// Inserting a row into the old schema succeeds
+				MustInsert(t, db, schema, "01_add_table", "users", map[string]string{
+					"id": "3",
+				})
+
+				// The old schema has the expected rows
+				rows := MustSelect(t, db, schema, "01_add_table", "users")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "name": nil},
+					{"id": 2, "name": "unknown user"},
+					{"id": 3, "name": "unknown user"},
+				}, rows)
+			},
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+				// Inserting a row into the new schema succeeds
+				MustInsert(t, db, schema, "02_set_default", "users", map[string]string{
+					"id": "4",
+				})
+
+				// The new schema has the expected rows:
+				// * The first row is NULL because it was inserted into the new schema which
+				//   does not have a default
+				// * The second has a default value because it was backfilled from the old
+				//   schema which has a default
+				rows := MustSelect(t, db, schema, "02_set_default", "users")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "name": nil},
+					{"id": 2, "name": "unknown user"},
+					{"id": 3, "name": "unknown user"},
+					{"id": 4, "name": nil},
+				}, rows)
+			},
+		},
+		{
+			name: "set column default: remove the default by setting it null",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   ptr(true),
+								},
+								{
+									Name:     "name",
+									Type:     "text",
+									Nullable: ptr(true),
+									Default:  ptr("'unknown user'"),
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_set_default",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:   "users",
+							Column:  "name",
+							Default: nullable.NewNullNullable[string](),
 						},
 					},
 				},

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -90,8 +90,9 @@ type OpAlterColumn struct {
 	// New comment on the column
 	Comment nullable.Nullable[string] `json:"comment,omitempty"`
 
-	// Default value of the column
-	Default *string `json:"default,omitempty"`
+	// Default value of the column. Setting to null will drop the default if it was
+	// set previously.
+	Default nullable.Nullable[string] `json:"default,omitempty"`
 
 	// SQL expression for down migration
 	Down string `json:"down,omitempty"`

--- a/schema.json
+++ b/schema.json
@@ -134,8 +134,13 @@
           "type": "string"
         },
         "default": {
-          "description": "Default value of the column",
-          "type": "string"
+          "description": "Default value of the column. Setting to null will drop the default if it was set previously.",
+          "type": ["string", "null"],
+          "goJSONSchema": {
+            "imports": ["github.com/oapi-codegen/nullable"],
+            "nillable": true,
+            "type": "nullable.Nullable[string]"
+          }
         },
         "nullable": {
           "description": "Indicates if the column is nullable (for add/remove not null constraint operation)",


### PR DESCRIPTION
We no allow setting the value of `default` to `null` when altering a column. In practice this will cause us to drop the default. It is also possible to set `default` the *value* `NULL` which has a similar effect but is recorded slightly differently in the PG catalogue. (Details [here](https://github.com/xataio/pgroll/issues/450#issuecomment-2490680272))

Closes https://github.com/xataio/pgroll/issues/450