### PR TITLE
Small cleanups

### DIFF
--- a/pkg/migrations/duplicate.go
+++ b/pkg/migrations/duplicate.go
@@ -291,7 +291,7 @@ func (d *duplicatorStmtBuilder) duplicateComment(column *schema.Column, asName s
 	)
 }
 
-// DiplicationName returns the name of a duplicated column.
+// DuplicationName returns the name of a duplicated column.
 func DuplicationName(name string) string {
 	return "_pgroll_dup_" + name
 }

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	_ "github.com/lib/pq"
+
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
@@ -37,13 +38,15 @@ type Operation interface {
 // IsolatedOperation is an operation that cannot be executed with other operations
 // in the same migration.
 type IsolatedOperation interface {
-	// this operation is isolated when executed on start, cannot be executed with other operations.
+	// IsIsolated defines where this operation is isolated when executed on start, cannot be executed
+	// with other operations.
 	IsIsolated() bool
 }
 
 // RequiresSchemaRefreshOperation is an operation that requires the resulting schema to be refreshed.
 type RequiresSchemaRefreshOperation interface {
-	// this operation requires the resulting schema to be refreshed when executed on start
+	// RequiresSchemaRefresh defines if this operation requires the resulting schema to be refreshed when
+	// executed on start.
 	RequiresSchemaRefresh()
 }
 

--- a/pkg/migrations/op_common.go
+++ b/pkg/migrations/op_common.go
@@ -27,6 +27,7 @@ const (
 	OpCreateConstraintName   OpName = "create_constraint"
 
 	// Internal operation types used by `alter_column`
+
 	OpNameRenameColumn       OpName = "rename_column"
 	OpNameSetUnique          OpName = "set_unique"
 	OpNameSetNotNull         OpName = "set_not_null"

--- a/pkg/migrations/op_create_constraint_test.go
+++ b/pkg/migrations/op_create_constraint_test.go
@@ -49,12 +49,12 @@ func TestCreateConstraint(t *testing.T) {
 							Table:   "users",
 							Type:    "unique",
 							Columns: []string{"name"},
-							Up: migrations.OpCreateConstraintUp(map[string]string{
+							Up: map[string]string{
 								"name": "name || random()",
-							}),
-							Down: migrations.OpCreateConstraintDown(map[string]string{
+							},
+							Down: map[string]string{
 								"name": "name",
-							}),
+							},
 						},
 					},
 				},
@@ -131,12 +131,12 @@ func TestCreateConstraint(t *testing.T) {
 							Type:    "check",
 							Check:   ptr("name ~ '^[a-zA-Z]+$'"),
 							Columns: []string{"name"},
-							Up: migrations.OpCreateConstraintUp(map[string]string{
+							Up: map[string]string{
 								"name": "regexp_replace(name, '\\d+', '', 'g')",
-							}),
-							Down: migrations.OpCreateConstraintDown(map[string]string{
+							},
+							Down: map[string]string{
 								"name": "name",
-							}),
+							},
 						},
 					},
 				},
@@ -209,14 +209,14 @@ func TestCreateConstraint(t *testing.T) {
 							Table:   "users",
 							Type:    "unique",
 							Columns: []string{"name", "email"},
-							Up: migrations.OpCreateConstraintUp(map[string]string{
+							Up: map[string]string{
 								"name":  "name || random()",
 								"email": "email || random()",
-							}),
-							Down: migrations.OpCreateConstraintDown(map[string]string{
+							},
+							Down: map[string]string{
 								"name":  "name",
 								"email": "email",
-							}),
+							},
 						},
 					},
 				},
@@ -294,14 +294,14 @@ func TestCreateConstraint(t *testing.T) {
 							Type:    "check",
 							Check:   ptr("name != email"),
 							Columns: []string{"name", "email"},
-							Up: migrations.OpCreateConstraintUp(map[string]string{
+							Up: map[string]string{
 								"name":  "name",
 								"email": "(SELECT CASE WHEN email ~ '@' THEN email ELSE email || '@example.com' END)",
-							}),
-							Down: migrations.OpCreateConstraintDown(map[string]string{
+							},
+							Down: map[string]string{
 								"name":  "name",
 								"email": "email",
-							}),
+							},
 						},
 					},
 				},
@@ -425,14 +425,14 @@ func TestCreateConstraint(t *testing.T) {
 								Table:   "users",
 								Columns: []string{"id", "zip"},
 							},
-							Up: migrations.OpCreateConstraintUp(map[string]string{
+							Up: map[string]string{
 								"users_id":  "1",
 								"users_zip": "12345",
-							}),
-							Down: migrations.OpCreateConstraintDown(map[string]string{
+							},
+							Down: map[string]string{
 								"users_id":  "users_id",
 								"users_zip": "users_zip",
-							}),
+							},
 						},
 					},
 				},
@@ -572,10 +572,10 @@ func TestCreateConstraint(t *testing.T) {
 							Table:   "users",
 							Columns: []string{"name"},
 							Type:    "unique",
-							Up:      migrations.OpCreateConstraintUp(map[string]string{}),
-							Down: migrations.OpCreateConstraintDown(map[string]string{
+							Up:      map[string]string{},
+							Down: map[string]string{
 								"name": "name",
-							}),
+							},
 						},
 					},
 				},
@@ -616,12 +616,12 @@ func TestCreateConstraint(t *testing.T) {
 							Table:   "users",
 							Columns: []string{"name"},
 							Type:    "check",
-							Up: migrations.OpCreateConstraintUp(map[string]string{
+							Up: map[string]string{
 								"name": "name",
-							}),
-							Down: migrations.OpCreateConstraintDown(map[string]string{
+							},
+							Down: map[string]string{
 								"name": "name",
-							}),
+							},
 						},
 					},
 				},
@@ -666,12 +666,12 @@ func TestCreateConstraint(t *testing.T) {
 								Table:   "missing_table",
 								Columns: []string{"id"},
 							},
-							Up: migrations.OpCreateConstraintUp(map[string]string{
+							Up: map[string]string{
 								"name": "name",
-							}),
-							Down: migrations.OpCreateConstraintDown(map[string]string{
+							},
+							Down: map[string]string{
 								"name": "name",
-							}),
+							},
 						},
 					},
 				},

--- a/pkg/migrations/op_set_fk_test.go
+++ b/pkg/migrations/op_set_fk_test.go
@@ -1341,7 +1341,7 @@ func TestSetForeignKeyValidation(t *testing.T) {
 								Name:     "fk_users_doesntexist",
 								Table:    "users",
 								Column:   "id",
-								OnDelete: migrations.ForeignKeyReferenceOnDelete("invalid"),
+								OnDelete: "invalid",
 							},
 							Up:   "(SELECT CASE WHEN EXISTS (SELECT 1 FROM users WHERE users.id = user_id) THEN user_id ELSE NULL END)",
 							Down: "user_id",

--- a/pkg/migrations/rename.go
+++ b/pkg/migrations/rename.go
@@ -13,7 +13,7 @@ import (
 	"github.com/xataio/pgroll/pkg/schema"
 )
 
-// RenameDuplicatedColumn:
+// RenameDuplicatedColumn
 // * renames a duplicated column to its original name
 // * renames any foreign keys on the duplicated column to their original name.
 // * Validates and renames any temporary `CHECK` constraints on the duplicated column.

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -253,7 +253,7 @@ func (t *Table) RenameColumn(from, to string) {
 	delete(t.Columns, from)
 }
 
-// PhysicalColumnNames returns the physical column names for the given virtual
+// PhysicalColumnNamesFor returns the physical column names for the given virtual
 // column names
 func (t *Table) PhysicalColumnNamesFor(columnNames ...string) []string {
 	physicalNames := make([]string, 0, len(columnNames))


### PR DESCRIPTION
* Remove redundant type conversions
* Make doc comments follow Go conventions