### PR TITLE
Change type of `Column.Pk` from `*bool` to `bool`

### DIFF
--- a/internal/benchmarks/benchmarks_test.go
+++ b/internal/benchmarks/benchmarks_test.go
@@ -235,7 +235,7 @@ var migCreateTable = migrations.Migration{
 				{
 					Name: "id",
 					Type: "serial",
-					Pk:   ptr(true),
+					Pk:   true,
 				},
 				{
 					Name:     "name",

--- a/pkg/migrations/column.go
+++ b/pkg/migrations/column.go
@@ -20,10 +20,7 @@ func (c *Column) IsUnique() bool {
 
 // IsPrimaryKey returns true if the column is part of the primary key
 func (c *Column) IsPrimaryKey() bool {
-	if c.Pk != nil {
-		return *c.Pk
-	}
-	return false
+	return c.Pk
 }
 
 // HasImplicitDefault returns true if the column has an implicit default value

--- a/pkg/migrations/op_add_column_test.go
+++ b/pkg/migrations/op_add_column_test.go
@@ -30,7 +30,7 @@ func TestAddColumn(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:   "name",
@@ -163,7 +163,7 @@ func TestAddColumn(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:   "name",
@@ -273,7 +273,7 @@ func TestAddForeignKeyColumn(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:   "name",
@@ -288,7 +288,7 @@ func TestAddForeignKeyColumn(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "quantity",
@@ -375,7 +375,7 @@ func TestAddForeignKeyColumn(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:   "name",
@@ -390,7 +390,7 @@ func TestAddForeignKeyColumn(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "quantity",
@@ -478,7 +478,7 @@ func TestAddForeignKeyColumn(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "name",
@@ -492,7 +492,7 @@ func TestAddForeignKeyColumn(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "quantity",
@@ -589,7 +589,7 @@ func TestAddForeignKeyColumn(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "name",
@@ -603,7 +603,7 @@ func TestAddForeignKeyColumn(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "quantity",
@@ -716,7 +716,7 @@ func TestAddColumnWithUpSql(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:   "name",
@@ -798,7 +798,7 @@ func TestAddColumnWithUpSql(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:   "name",
@@ -880,7 +880,7 @@ func TestAddColumnWithUpSql(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:   "name",
@@ -962,7 +962,7 @@ func TestAddColumnWithUpSql(t *testing.T) {
 								{
 									Name: "id",
 									Type: "text",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:   "name",
@@ -1145,7 +1145,7 @@ func TestAddNotNullColumnWithNoDefault(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:   "name",
@@ -1212,7 +1212,7 @@ func TestAddColumnValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   ptr(true),
+						Pk:   true,
 					},
 					{
 						Name:   "name",
@@ -1442,7 +1442,7 @@ func TestAddColumnWithCheckConstraint(t *testing.T) {
 							{
 								Name: "id",
 								Type: "serial",
-								Pk:   ptr(true),
+								Pk:   true,
 							},
 							{
 								Name:   "name",
@@ -1517,7 +1517,7 @@ func TestAddColumnWithComment(t *testing.T) {
 							{
 								Name: "id",
 								Type: "serial",
-								Pk:   ptr(true),
+								Pk:   true,
 							},
 							{
 								Name:   "name",
@@ -1579,7 +1579,7 @@ func TestAddColumnDefaultTransformation(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 							},
 						},
@@ -1633,7 +1633,7 @@ func TestAddColumnDefaultTransformation(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 							},
 						},
@@ -1674,7 +1674,7 @@ func TestAddColumnToATableCreatedInTheSameMigration(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "name",
@@ -1744,7 +1744,7 @@ func TestAddColumnInvalidNameLength(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 							},
 						},

--- a/pkg/migrations/op_alter_column_test.go
+++ b/pkg/migrations/op_alter_column_test.go
@@ -30,7 +30,7 @@ func TestAlterColumnMultipleSubOperations(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -186,7 +186,7 @@ func TestAlterColumnMultipleSubOperations(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -303,7 +303,7 @@ func TestAlterColumnMultipleSubOperations(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -374,7 +374,7 @@ func TestAlterColumnMultipleSubOperations(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -389,7 +389,7 @@ func TestAlterColumnMultipleSubOperations(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -564,7 +564,7 @@ func TestAlterColumnValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   ptr(true),
+						Pk:   true,
 					},
 					{
 						Name: "name",
@@ -578,7 +578,7 @@ func TestAlterColumnValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   ptr(true),
+						Pk:   true,
 					},
 					{
 						Name: "title",

--- a/pkg/migrations/op_change_type_test.go
+++ b/pkg/migrations/op_change_type_test.go
@@ -30,7 +30,7 @@ func TestChangeColumnType(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "username",
@@ -151,7 +151,7 @@ func TestChangeColumnType(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -171,7 +171,7 @@ func TestChangeColumnType(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -228,7 +228,7 @@ func TestChangeColumnType(t *testing.T) {
 								{
 									Name: "id",
 									Type: "integer",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "age",
@@ -293,7 +293,7 @@ func TestChangeColumnType(t *testing.T) {
 								{
 									Name: "id",
 									Type: "integer",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "username",
@@ -358,7 +358,7 @@ func TestChangeColumnType(t *testing.T) {
 								{
 									Name: "id",
 									Type: "integer",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "age",
@@ -417,7 +417,7 @@ func TestChangeColumnType(t *testing.T) {
 								{
 									Name: "id",
 									Type: "integer",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "username",
@@ -474,7 +474,7 @@ func TestChangeColumnType(t *testing.T) {
 								{
 									Name: "id",
 									Type: "integer",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "username",
@@ -525,7 +525,7 @@ func TestChangeColumnType(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "username",
@@ -600,7 +600,7 @@ func TestChangeColumnType(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:    "username",
@@ -650,7 +650,7 @@ func TestChangeColumnTypeValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   ptr(true),
+						Pk:   true,
 					},
 					{
 						Name: "username",

--- a/pkg/migrations/op_create_constraint_test.go
+++ b/pkg/migrations/op_create_constraint_test.go
@@ -29,7 +29,7 @@ func TestCreateConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -110,7 +110,7 @@ func TestCreateConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -184,7 +184,7 @@ func TestCreateConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -268,7 +268,7 @@ func TestCreateConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -366,12 +366,12 @@ func TestCreateConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "zip",
 									Type: "integer",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -391,7 +391,7 @@ func TestCreateConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "users_id",
@@ -515,7 +515,7 @@ func TestCreateConstraintValidation(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -560,7 +560,7 @@ func TestCreateConstraintValidation(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -604,7 +604,7 @@ func TestCreateConstraintValidation(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -650,7 +650,7 @@ func TestCreateConstraintValidation(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",

--- a/pkg/migrations/op_create_index_test.go
+++ b/pkg/migrations/op_create_index_test.go
@@ -28,7 +28,7 @@ func TestCreateIndex(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -74,7 +74,7 @@ func TestCreateIndex(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -120,7 +120,7 @@ func TestCreateIndex(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -173,7 +173,7 @@ func TestCreateIndex(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -217,7 +217,7 @@ func TestCreateIndex(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -273,7 +273,7 @@ func TestCreateIndexOnMultipleColumns(t *testing.T) {
 							{
 								Name: "id",
 								Type: "serial",
-								Pk:   ptr(true),
+								Pk:   true,
 							},
 							{
 								Name:     "name",
@@ -330,7 +330,7 @@ func TestCreateIndexOnObjectsCreatedInSameMigration(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -372,7 +372,7 @@ func TestCreateIndexOnObjectsCreatedInSameMigration(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",

--- a/pkg/migrations/op_create_table_test.go
+++ b/pkg/migrations/op_create_table_test.go
@@ -30,7 +30,7 @@ func TestCreateTable(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:   "name",
@@ -89,12 +89,12 @@ func TestCreateTable(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "rand",
 									Type: "varchar(255)",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:   "name",
@@ -172,7 +172,7 @@ func TestCreateTable(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:   "name",
@@ -192,7 +192,7 @@ func TestCreateTable(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "user_id",
@@ -279,7 +279,7 @@ func TestCreateTable(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:   "name",
@@ -299,7 +299,7 @@ func TestCreateTable(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "user_id",
@@ -395,7 +395,7 @@ func TestCreateTable(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "name",
@@ -455,7 +455,7 @@ func TestCreateTable(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:    "name",
@@ -504,7 +504,7 @@ func TestCreateTableValidation(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:   "name",
@@ -524,7 +524,7 @@ func TestCreateTableValidation(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "user_id",
@@ -562,7 +562,7 @@ func TestCreateTableValidation(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:   "name",
@@ -588,7 +588,7 @@ func TestCreateTableValidation(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:   invalidName,
@@ -626,7 +626,7 @@ func TestCreateTableColumnDefaultTransformation(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:    "name",
@@ -677,7 +677,7 @@ func TestCreateTableColumnDefaultTransformation(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:    "name",

--- a/pkg/migrations/op_drop_column_test.go
+++ b/pkg/migrations/op_drop_column_test.go
@@ -27,7 +27,7 @@ func TestDropColumnWithDownSQL(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -117,7 +117,7 @@ func TestDropColumnWithDownSQL(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "array",
@@ -159,7 +159,7 @@ func TestDropColumnWithDownSQL(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "name",

--- a/pkg/migrations/op_drop_constraint_test.go
+++ b/pkg/migrations/op_drop_constraint_test.go
@@ -29,7 +29,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "title",
@@ -140,7 +140,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "title",
@@ -205,7 +205,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "name",
@@ -219,7 +219,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "title",
@@ -353,7 +353,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:   "name",
@@ -421,7 +421,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:    "name",
@@ -491,7 +491,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -511,7 +511,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -567,7 +567,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "title",
@@ -635,7 +635,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "title",
@@ -725,7 +725,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "title",
@@ -776,7 +776,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "title",
@@ -827,7 +827,7 @@ func TestDropConstraintValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   ptr(true),
+						Pk:   true,
 					},
 					{
 						Name: "title",

--- a/pkg/migrations/op_drop_index_test.go
+++ b/pkg/migrations/op_drop_index_test.go
@@ -25,7 +25,7 @@ func TestDropIndex(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -79,7 +79,7 @@ func TestDropIndex(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",

--- a/pkg/migrations/op_drop_multicolumn_constraint_test.go
+++ b/pkg/migrations/op_drop_multicolumn_constraint_test.go
@@ -27,7 +27,7 @@ func TestDropMultiColumnConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "integer",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "name",
@@ -157,7 +157,7 @@ func TestDropMultiColumnConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "integer",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "name",
@@ -270,7 +270,7 @@ func TestDropMultiColumnConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "integer",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -280,7 +280,7 @@ func TestDropMultiColumnConstraint(t *testing.T) {
 								{
 									Name: "zip",
 									Type: "integer",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 							},
 						},
@@ -290,7 +290,7 @@ func TestDropMultiColumnConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "integer",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "description",
@@ -422,7 +422,7 @@ func TestDropMultiColumnConstraintValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   ptr(true),
+						Pk:   true,
 					},
 					{
 						Name: "title",

--- a/pkg/migrations/op_drop_not_null_test.go
+++ b/pkg/migrations/op_drop_not_null_test.go
@@ -29,7 +29,7 @@ func TestDropNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "username",
@@ -145,7 +145,7 @@ func TestDropNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "username",
@@ -211,7 +211,7 @@ func TestDropNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -231,7 +231,7 @@ func TestDropNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -288,7 +288,7 @@ func TestDropNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "integer",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -353,7 +353,7 @@ func TestDropNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "integer",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -410,7 +410,7 @@ func TestDropNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -486,7 +486,7 @@ func TestDropNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -541,7 +541,7 @@ func TestDropNotNullValidation(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -578,7 +578,7 @@ func TestDropNotNullValidation(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",

--- a/pkg/migrations/op_drop_table_test.go
+++ b/pkg/migrations/op_drop_table_test.go
@@ -25,7 +25,7 @@ func TestDropTable(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:   "name",

--- a/pkg/migrations/op_rename_column_test.go
+++ b/pkg/migrations/op_rename_column_test.go
@@ -22,7 +22,7 @@ func TestRenameColumn(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   ptr(true),
+						Pk:   true,
 					},
 					{
 						Name:     "username",

--- a/pkg/migrations/op_rename_constraint_test.go
+++ b/pkg/migrations/op_rename_constraint_test.go
@@ -24,7 +24,7 @@ func TestRenameConstraint(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   ptr(true),
+						Pk:   true,
 					},
 					{
 						Name:     "username",
@@ -116,7 +116,7 @@ func TestRenameConstraintValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   ptr(true),
+						Pk:   true,
 					},
 					{
 						Name: "name",

--- a/pkg/migrations/op_set_check_test.go
+++ b/pkg/migrations/op_set_check_test.go
@@ -28,7 +28,7 @@ func TestSetCheckConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "title",
@@ -147,7 +147,7 @@ func TestSetCheckConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:    "title",
@@ -214,7 +214,7 @@ func TestSetCheckConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -234,7 +234,7 @@ func TestSetCheckConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -295,7 +295,7 @@ func TestSetCheckConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "title",
@@ -360,7 +360,7 @@ func TestSetCheckConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "title",
@@ -414,7 +414,7 @@ func TestSetCheckConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "title",
@@ -492,7 +492,7 @@ func TestSetCheckConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:    "title",
@@ -542,7 +542,7 @@ func TestSetCheckConstraint(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "title",
@@ -606,7 +606,7 @@ func TestSetCheckConstraintValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   ptr(true),
+						Pk:   true,
 					},
 					{
 						Name: "title",

--- a/pkg/migrations/op_set_comment_test.go
+++ b/pkg/migrations/op_set_comment_test.go
@@ -28,7 +28,7 @@ func TestSetComment(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:    "name",
@@ -109,7 +109,7 @@ func TestSetComment(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:    "name",
@@ -192,7 +192,7 @@ func TestSetComment(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:    "name",
@@ -242,7 +242,7 @@ func TestSetComment(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:    "name",

--- a/pkg/migrations/op_set_default_test.go
+++ b/pkg/migrations/op_set_default_test.go
@@ -28,7 +28,7 @@ func TestSetDefault(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -130,7 +130,7 @@ func TestSetDefault(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -232,7 +232,7 @@ func TestSetDefault(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -334,7 +334,7 @@ func TestSetDefault(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",

--- a/pkg/migrations/op_set_fk_test.go
+++ b/pkg/migrations/op_set_fk_test.go
@@ -28,7 +28,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "name",
@@ -42,7 +42,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "title",
@@ -176,7 +176,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "name",
@@ -190,7 +190,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "title",
@@ -265,7 +265,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "name",
@@ -279,7 +279,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "title",
@@ -371,7 +371,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "name",
@@ -385,7 +385,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "title",
@@ -480,7 +480,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "name",
@@ -494,7 +494,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "title",
@@ -593,7 +593,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "name",
@@ -607,7 +607,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "title",
@@ -686,7 +686,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "name",
@@ -700,7 +700,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "title",
@@ -772,7 +772,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "name",
@@ -786,7 +786,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "title",
@@ -857,7 +857,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "name",
@@ -871,7 +871,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "title",
@@ -933,7 +933,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "name",
@@ -947,7 +947,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "title",
@@ -1046,7 +1046,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "name",
@@ -1060,7 +1060,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "title",
@@ -1115,7 +1115,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "name",
@@ -1129,7 +1129,7 @@ func TestSetForeignKey(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "title",
@@ -1200,7 +1200,7 @@ func TestSetForeignKeyValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   ptr(true),
+						Pk:   true,
 					},
 					{
 						Name: "name",
@@ -1214,7 +1214,7 @@ func TestSetForeignKeyValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   ptr(true),
+						Pk:   true,
 					},
 					{
 						Name: "title",

--- a/pkg/migrations/op_set_notnull_test.go
+++ b/pkg/migrations/op_set_notnull_test.go
@@ -29,7 +29,7 @@ func TestSetNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "username",
@@ -154,7 +154,7 @@ func TestSetNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "username",
@@ -220,7 +220,7 @@ func TestSetNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -240,7 +240,7 @@ func TestSetNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -298,7 +298,7 @@ func TestSetNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "integer",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -362,7 +362,7 @@ func TestSetNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "integer",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -418,7 +418,7 @@ func TestSetNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -493,7 +493,7 @@ func TestSetNotNull(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -543,7 +543,7 @@ func TestSetNotNullValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   ptr(true),
+						Pk:   true,
 					},
 					{
 						Name:     "username",
@@ -596,7 +596,7 @@ func TestSetNotNullValidation(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "username",

--- a/pkg/migrations/op_set_replica_identity_test.go
+++ b/pkg/migrations/op_set_replica_identity_test.go
@@ -21,7 +21,7 @@ func TestSetReplicaIdentity(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   ptr(true),
+						Pk:   true,
 					},
 					{
 						Name:     "name",
@@ -152,7 +152,7 @@ func TestSetReplicaIdentityValidation(t *testing.T) {
 					{
 						Name: "id",
 						Type: "serial",
-						Pk:   ptr(true),
+						Pk:   true,
 					},
 					{
 						Name:   "name",

--- a/pkg/migrations/op_set_unique_test.go
+++ b/pkg/migrations/op_set_unique_test.go
@@ -28,7 +28,7 @@ func TestSetColumnUnique(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "username",
@@ -109,7 +109,7 @@ func TestSetColumnUnique(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "username",
@@ -173,7 +173,7 @@ func TestSetColumnUnique(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:    "username",
@@ -253,7 +253,7 @@ func TestSetColumnUnique(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -273,7 +273,7 @@ func TestSetColumnUnique(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "name",
@@ -333,7 +333,7 @@ func TestSetColumnUnique(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name: "username",
@@ -395,7 +395,7 @@ func TestSetColumnUnique(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "username",
@@ -456,7 +456,7 @@ func TestSetColumnUnique(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "username",
@@ -519,7 +519,7 @@ func TestSetColumnUnique(t *testing.T) {
 								{
 									Name: "id",
 									Type: "serial",
-									Pk:   ptr(true),
+									Pk:   true,
 								},
 								{
 									Name:     "username",

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -32,7 +32,7 @@ type Column struct {
 	Nullable *bool `json:"nullable,omitempty"`
 
 	// Indicates if the column is part of the primary key
-	Pk *bool `json:"pk,omitempty"`
+	Pk bool `json:"pk,omitempty"`
 
 	// Foreign key constraint for the column
 	References *ForeignKeyReference `json:"references,omitempty"`

--- a/pkg/roll/execute_test.go
+++ b/pkg/roll/execute_test.go
@@ -842,7 +842,7 @@ func createTableOp(tableName string) *migrations.OpCreateTable {
 			{
 				Name: "id",
 				Type: "integer",
-				Pk:   ptr(true),
+				Pk:   true,
 			},
 			{
 				Name:   "name",

--- a/pkg/state/history_test.go
+++ b/pkg/state/history_test.go
@@ -29,7 +29,7 @@ func TestSchemaHistoryReturnsFullSchemaHistory(t *testing.T) {
 							{
 								Name: "id",
 								Type: "serial",
-								Pk:   ptr(true),
+								Pk:   true,
 							},
 							{
 								Name:     "username",

--- a/schema.json
+++ b/schema.json
@@ -43,7 +43,8 @@
         },
         "pk": {
           "description": "Indicates if the column is part of the primary key",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "references": {
           "$ref": "#/$defs/ForeignKeyReference",


### PR DESCRIPTION
Change the type generated by the JSON schema for the `Column.Pk` field from `*bool` to `bool`.

This simplifies use of the field when using `pgroll` from code.

