### PR TITLE
Change type of `Column.Unique` from `*bool` to `bool`

### DIFF
--- a/internal/benchmarks/benchmarks_test.go
+++ b/internal/benchmarks/benchmarks_test.go
@@ -241,7 +241,7 @@ var migCreateTable = migrations.Migration{
 					Name:     "name",
 					Type:     "varchar(255)",
 					Nullable: true,
-					Unique:   ptr(false),
+					Unique:   false,
 				},
 			},
 		},

--- a/pkg/migrations/column.go
+++ b/pkg/migrations/column.go
@@ -9,10 +9,7 @@ func (c *Column) IsNullable() bool {
 
 // IsUnique returns true if the column values must be unique
 func (c *Column) IsUnique() bool {
-	if c.Unique != nil {
-		return *c.Unique
-	}
-	return false
+	return c.Unique
 }
 
 // IsPrimaryKey returns true if the column is part of the primary key

--- a/pkg/migrations/op_add_column_test.go
+++ b/pkg/migrations/op_add_column_test.go
@@ -35,7 +35,7 @@ func TestAddColumn(t *testing.T) {
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: ptr(true),
+									Unique: true,
 								},
 							},
 						},
@@ -142,7 +142,7 @@ func TestAddColumn(t *testing.T) {
 								Name:     "description",
 								Type:     "integer",
 								Nullable: false,
-								Unique:   ptr(true),
+								Unique:   true,
 							},
 							Up: "'this is a description'",
 						},
@@ -168,7 +168,7 @@ func TestAddColumn(t *testing.T) {
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: ptr(true),
+									Unique: true,
 								},
 							},
 						},
@@ -278,7 +278,7 @@ func TestAddForeignKeyColumn(t *testing.T) {
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: ptr(true),
+									Unique: true,
 								},
 							},
 						},
@@ -380,7 +380,7 @@ func TestAddForeignKeyColumn(t *testing.T) {
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: ptr(true),
+									Unique: true,
 								},
 							},
 						},
@@ -721,7 +721,7 @@ func TestAddColumnWithUpSql(t *testing.T) {
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: ptr(true),
+									Unique: true,
 								},
 							},
 						},
@@ -803,7 +803,7 @@ func TestAddColumnWithUpSql(t *testing.T) {
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: ptr(true),
+									Unique: true,
 								},
 							},
 						},
@@ -885,7 +885,7 @@ func TestAddColumnWithUpSql(t *testing.T) {
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: ptr(true),
+									Unique: true,
 								},
 							},
 						},
@@ -967,7 +967,7 @@ func TestAddColumnWithUpSql(t *testing.T) {
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: ptr(true),
+									Unique: true,
 								},
 							},
 						},
@@ -1050,7 +1050,7 @@ func TestAddColumnWithUpSql(t *testing.T) {
 								{
 									Name:     "name",
 									Type:     "varchar(255)",
-									Unique:   ptr(true),
+									Unique:   true,
 									Nullable: false,
 								},
 							},
@@ -1150,7 +1150,7 @@ func TestAddNotNullColumnWithNoDefault(t *testing.T) {
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: ptr(true),
+									Unique: true,
 								},
 							},
 						},
@@ -1217,7 +1217,7 @@ func TestAddColumnValidation(t *testing.T) {
 					{
 						Name:   "name",
 						Type:   "varchar(255)",
-						Unique: ptr(true),
+						Unique: true,
 					},
 				},
 			},
@@ -1237,7 +1237,7 @@ func TestAddColumnValidation(t *testing.T) {
 					{
 						Name:     "name",
 						Type:     "varchar(255)",
-						Unique:   ptr(true),
+						Unique:   true,
 						Nullable: true,
 					},
 				},
@@ -1258,7 +1258,7 @@ func TestAddColumnValidation(t *testing.T) {
 					{
 						Name:     "name",
 						Type:     "varchar(255)",
-						Unique:   ptr(true),
+						Unique:   true,
 						Nullable: false,
 					},
 				},
@@ -1447,7 +1447,7 @@ func TestAddColumnWithCheckConstraint(t *testing.T) {
 							{
 								Name:   "name",
 								Type:   "varchar(255)",
-								Unique: ptr(true),
+								Unique: true,
 							},
 						},
 					},
@@ -1522,7 +1522,7 @@ func TestAddColumnWithComment(t *testing.T) {
 							{
 								Name:   "name",
 								Type:   "varchar(255)",
-								Unique: ptr(true),
+								Unique: true,
 							},
 						},
 					},

--- a/pkg/migrations/op_create_table_test.go
+++ b/pkg/migrations/op_create_table_test.go
@@ -35,7 +35,7 @@ func TestCreateTable(t *testing.T) {
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: ptr(true),
+									Unique: true,
 								},
 							},
 						},
@@ -99,7 +99,7 @@ func TestCreateTable(t *testing.T) {
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: ptr(true),
+									Unique: true,
 								},
 							},
 						},
@@ -177,7 +177,7 @@ func TestCreateTable(t *testing.T) {
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: ptr(true),
+									Unique: true,
 								},
 							},
 						},
@@ -284,7 +284,7 @@ func TestCreateTable(t *testing.T) {
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: ptr(true),
+									Unique: true,
 								},
 							},
 						},
@@ -460,7 +460,7 @@ func TestCreateTable(t *testing.T) {
 								{
 									Name:    "name",
 									Type:    "varchar(255)",
-									Unique:  ptr(true),
+									Unique:  true,
 									Comment: ptr("the username"),
 								},
 							},
@@ -509,7 +509,7 @@ func TestCreateTableValidation(t *testing.T) {
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: ptr(true),
+									Unique: true,
 								},
 							},
 						},
@@ -567,7 +567,7 @@ func TestCreateTableValidation(t *testing.T) {
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: ptr(true),
+									Unique: true,
 								},
 							},
 						},
@@ -593,7 +593,7 @@ func TestCreateTableValidation(t *testing.T) {
 								{
 									Name:   invalidName,
 									Type:   "varchar(255)",
-									Unique: ptr(true),
+									Unique: true,
 								},
 							},
 						},

--- a/pkg/migrations/op_drop_constraint_test.go
+++ b/pkg/migrations/op_drop_constraint_test.go
@@ -358,7 +358,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name:   "name",
 									Type:   "text",
-									Unique: ptr(true),
+									Unique: true,
 								},
 							},
 						},
@@ -426,7 +426,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name:    "name",
 									Type:    "text",
-									Unique:  ptr(true),
+									Unique:  true,
 									Default: ptr("'anonymous'"),
 								},
 							},
@@ -521,7 +521,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name:   "department_id",
 									Type:   "integer",
-									Unique: ptr(true),
+									Unique: true,
 									References: &migrations.ForeignKeyReference{
 										Name:   "fk_employee_department",
 										Table:  "departments",
@@ -573,7 +573,7 @@ func TestDropConstraint(t *testing.T) {
 									Name:     "title",
 									Type:     "text",
 									Nullable: true,
-									Unique:   ptr(true),
+									Unique:   true,
 								},
 							},
 						},
@@ -730,7 +730,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name:     "title",
 									Type:     "text",
-									Unique:   ptr(true),
+									Unique:   true,
 									Nullable: false,
 								},
 							},
@@ -781,7 +781,7 @@ func TestDropConstraint(t *testing.T) {
 								{
 									Name:     "title",
 									Type:     "text",
-									Unique:   ptr(true),
+									Unique:   true,
 									Nullable: false,
 									Comment:  ptr("the title of the post"),
 								},

--- a/pkg/migrations/op_drop_table_test.go
+++ b/pkg/migrations/op_drop_table_test.go
@@ -30,7 +30,7 @@ func TestDropTable(t *testing.T) {
 								{
 									Name:   "name",
 									Type:   "varchar(255)",
-									Unique: ptr(true),
+									Unique: true,
 								},
 							},
 						},

--- a/pkg/migrations/op_set_replica_identity_test.go
+++ b/pkg/migrations/op_set_replica_identity_test.go
@@ -157,7 +157,7 @@ func TestSetReplicaIdentityValidation(t *testing.T) {
 					{
 						Name:   "name",
 						Type:   "varchar(255)",
-						Unique: ptr(true),
+						Unique: true,
 					},
 				},
 			},

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -41,7 +41,7 @@ type Column struct {
 	Type string `json:"type"`
 
 	// Indicates if the column values must be unique
-	Unique *bool `json:"unique,omitempty"`
+	Unique bool `json:"unique,omitempty"`
 }
 
 // Foreign key reference definition

--- a/pkg/roll/execute_test.go
+++ b/pkg/roll/execute_test.go
@@ -847,7 +847,7 @@ func createTableOp(tableName string) *migrations.OpCreateTable {
 			{
 				Name:   "name",
 				Type:   "varchar(255)",
-				Unique: ptr(true),
+				Unique: true,
 			},
 		},
 	}

--- a/schema.json
+++ b/schema.json
@@ -57,7 +57,8 @@
         },
         "unique": {
           "description": "Indicates if the column values must be unique",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "comment": {
           "description": "Postgres comment for the column",


### PR DESCRIPTION
Change the type generated by the JSON schema for the `Column.Unique` field from `*bool` to `bool`.

This simplifies use of the field when using `pgroll` from code.

