### PR TITLE
Update docs with deprecation notice

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1210,6 +1210,8 @@ Example **drop column** migrations:
 
 ### Drop constraint
 
+:warning: The **drop constraint** operation is deprecated. Please use the [drop multi-column constraint](#drop-multi-column-constraint) operation instead. The **drop_constraint** operation will be removed in a future release of `pgroll`. :warning:
+
 A drop constraint operation drops a single-column constraint from an existing table.
 
 Only `CHECK`, `FOREIGN KEY`, and `UNIQUE` constraints can be dropped.


### PR DESCRIPTION
Add a deprecation notice to the docs for the `drop_constraint` operation.

Direct link to the updated docs section: [docs/README.md](https://github.com/xataio/pgroll/blob/add-deprecation-note-to-docs/docs/README.md#drop-constraint)