### PR TITLE
Convert `DROP NOT NULL` SQL to pgroll operation

### DIFF
--- a/pkg/sql2pgroll/alter_table.go
+++ b/pkg/sql2pgroll/alter_table.go
@@ -22,21 +22,22 @@ func convertAlterTableStmt(stmt *pgq.AlterTableStmt) (migrations.Operations, err
 			continue
 		}
 
-		//nolint:gocritic
 		switch alterTableCmd.Subtype {
 		case pgq.AlterTableType_AT_SetNotNull:
-			ops = append(ops, convertAlterTableSetNotNull(stmt, alterTableCmd))
+			ops = append(ops, convertAlterTableSetNotNull(stmt, alterTableCmd, true))
+		case pgq.AlterTableType_AT_DropNotNull:
+			ops = append(ops, convertAlterTableSetNotNull(stmt, alterTableCmd, false))
 		}
 	}
 
 	return ops, nil
 }
 
-func convertAlterTableSetNotNull(stmt *pgq.AlterTableStmt, cmd *pgq.AlterTableCmd) migrations.Operation {
+func convertAlterTableSetNotNull(stmt *pgq.AlterTableStmt, cmd *pgq.AlterTableCmd, notNull bool) migrations.Operation {
 	return &migrations.OpAlterColumn{
 		Table:    stmt.GetRelation().GetRelname(),
 		Column:   cmd.GetName(),
-		Nullable: ptr(false),
+		Nullable: ptr(!notNull),
 		Up:       PlaceHolderSQL,
 		Down:     PlaceHolderSQL,
 	}

--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -23,6 +23,10 @@ func TestConvertAlterTableStatements(t *testing.T) {
 			sql:        "ALTER TABLE foo ALTER COLUMN a SET NOT NULL",
 			expectedOp: expect.AlterTableOp1,
 		},
+		{
+			sql:        "ALTER TABLE foo ALTER COLUMN a DROP NOT NULL",
+			expectedOp: expect.AlterTableOp2,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/sql2pgroll/expect/alter_table.go
+++ b/pkg/sql2pgroll/expect/alter_table.go
@@ -15,6 +15,14 @@ var AlterTableOp1 = &migrations.OpAlterColumn{
 	Down:     sql2pgroll.PlaceHolderSQL,
 }
 
+var AlterTableOp2 = &migrations.OpAlterColumn{
+	Table:    "foo",
+	Column:   "a",
+	Nullable: ptr(true),
+	Up:       sql2pgroll.PlaceHolderSQL,
+	Down:     sql2pgroll.PlaceHolderSQL,
+}
+
 func ptr[T any](v T) *T {
 	return &v
 }


### PR DESCRIPTION
Update the `sql2pgroll` package to convert SQL like:

```sql
ALTER TABLE foo ALTER COLUMN a DROP NOT NULL
```

to the equivalent `pgroll` operation:

```json
[
  {
    "alter_column": {
      "column": "a",
      "down": "TODO: Implement SQL data migration",
      "nullable": true,
      "table": "foo",
      "up": "TODO: Implement SQL data migration"
    }
  }
]
```