### PR TITLE
Convert `SET DATA TYPE` SQL to `pgroll` operation

### DIFF
--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -27,6 +27,14 @@ func TestConvertAlterTableStatements(t *testing.T) {
 			sql:        "ALTER TABLE foo ALTER COLUMN a DROP NOT NULL",
 			expectedOp: expect.AlterTableOp2,
 		},
+		{
+			sql:        "ALTER TABLE foo ALTER COLUMN a SET DATA TYPE text",
+			expectedOp: expect.AlterTableOp3,
+		},
+		{
+			sql:        "ALTER TABLE foo ALTER COLUMN a TYPE text",
+			expectedOp: expect.AlterTableOp3,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -3,9 +3,6 @@
 package sql2pgroll
 
 import (
-	"fmt"
-	"strings"
-
 	pgq "github.com/pganalyze/pg_query_go/v6"
 	"github.com/xataio/pgroll/pkg/migrations"
 )
@@ -26,42 +23,8 @@ func convertCreateStmt(stmt *pgq.CreateStmt) ([]migrations.Operation, error) {
 }
 
 func convertColumnDef(col *pgq.ColumnDef) migrations.Column {
-	ignoredTypeParts := map[string]bool{
-		"pg_catalog": true,
-	}
-
-	// Build the type name, including any schema qualifiers
-	typeParts := make([]string, 0, len(col.GetTypeName().Names))
-	for _, node := range col.GetTypeName().Names {
-		typePart := node.GetString_().GetSval()
-		if _, ok := ignoredTypeParts[typePart]; ok {
-			continue
-		}
-		typeParts = append(typeParts, typePart)
-	}
-
-	// Build the type modifiers, such as precision and scale for numeric types
-	var typeMods []string
-	for _, node := range col.GetTypeName().Typmods {
-		if x, ok := node.GetAConst().Val.(*pgq.A_Const_Ival); ok {
-			typeMods = append(typeMods, fmt.Sprintf("%d", x.Ival.GetIval()))
-		}
-	}
-	var typeModifier string
-	if len(typeMods) > 0 {
-		typeModifier = fmt.Sprintf("(%s)", strings.Join(typeMods, ","))
-	}
-
-	// Build the array bounds for array types
-	var arrayBounds string
-	for _, node := range col.GetTypeName().ArrayBounds {
-		bound := node.GetInteger().GetIval()
-		if bound == -1 {
-			arrayBounds = "[]"
-		} else {
-			arrayBounds = fmt.Sprintf("%s[%d]", arrayBounds, bound)
-		}
-	}
+	// Convert the column type
+	typeString := convertTypeName(col.TypeName)
 
 	// Determine column nullability, uniqueness, and primary key status
 	var notNull, unique, pk bool
@@ -81,7 +44,7 @@ func convertColumnDef(col *pgq.ColumnDef) migrations.Column {
 
 	return migrations.Column{
 		Name:     col.Colname,
-		Type:     strings.Join(typeParts, ".") + typeModifier + arrayBounds,
+		Type:     typeString,
 		Nullable: !notNull,
 		Unique:   unique,
 		Default:  defaultValue,

--- a/pkg/sql2pgroll/expect/alter_table.go
+++ b/pkg/sql2pgroll/expect/alter_table.go
@@ -23,6 +23,14 @@ var AlterTableOp2 = &migrations.OpAlterColumn{
 	Down:     sql2pgroll.PlaceHolderSQL,
 }
 
+var AlterTableOp3 = &migrations.OpAlterColumn{
+	Table:  "foo",
+	Column: "a",
+	Type:   ptr("text"),
+	Up:     sql2pgroll.PlaceHolderSQL,
+	Down:   sql2pgroll.PlaceHolderSQL,
+}
+
 func ptr[T any](v T) *T {
 	return &v
 }

--- a/pkg/sql2pgroll/typename.go
+++ b/pkg/sql2pgroll/typename.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package sql2pgroll
+
+import (
+	"fmt"
+	"strings"
+
+	pgq "github.com/pganalyze/pg_query_go/v6"
+)
+
+// convertTypeName converts a TypeName node to a string.
+func convertTypeName(typeName *pgq.TypeName) string {
+	ignoredTypeParts := map[string]bool{
+		"pg_catalog": true,
+	}
+
+	// Build the type name, including any schema qualifiers
+	typeParts := make([]string, 0, len(typeName.Names))
+	for _, node := range typeName.Names {
+		typePart := node.GetString_().GetSval()
+		if _, ok := ignoredTypeParts[typePart]; ok {
+			continue
+		}
+		typeParts = append(typeParts, typePart)
+	}
+
+	// Build the type modifiers, such as precision and scale for numeric types
+	var typeMods []string
+	for _, node := range typeName.Typmods {
+		if x, ok := node.GetAConst().Val.(*pgq.A_Const_Ival); ok {
+			typeMods = append(typeMods, fmt.Sprintf("%d", x.Ival.GetIval()))
+		}
+	}
+	var typeModifier string
+	if len(typeMods) > 0 {
+		typeModifier = fmt.Sprintf("(%s)", strings.Join(typeMods, ","))
+	}
+
+	// Build the array bounds for array types
+	var arrayBounds string
+	for _, node := range typeName.ArrayBounds {
+		bound := node.GetInteger().GetIval()
+		if bound == -1 {
+			arrayBounds = "[]"
+		} else {
+			arrayBounds = fmt.Sprintf("%s[%d]", arrayBounds, bound)
+		}
+	}
+
+	return strings.Join(typeParts, ".") + typeModifier + arrayBounds
+}


### PR DESCRIPTION
Convert SQL statements of the form:

```sql
ALTER TABLE foo ALTER COLUMN a [SET DATA] TYPE text
```

to the equivalent `pgroll` migration:

```json
[
  {
    "alter_column": {
      "column": "a",
      "down": "TODO: Implement SQL data migration",
      "table": "foo",
      "type": "text",
      "up": "TODO: Implement SQL data migration"
    }
  }
]
```

Part of https://github.com/xataio/pgroll/pull/504