### PR TITLE
Make `ALTER TABLE foo ALTER COLUMN a SET DATA TYPE text` options unrepresentable

### DIFF
--- a/pkg/sql2pgroll/alter_table.go
+++ b/pkg/sql2pgroll/alter_table.go
@@ -181,6 +181,9 @@ func canConvertColumnForSetDataType(column *pgq.ColumnDef) bool {
 	if column.GetCollClause() != nil {
 		return false
 	}
+	if column.GetRawDefault() != nil {
+		return false
+	}
 	return true
 }
 

--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -68,9 +68,10 @@ func TestUnconvertableAlterTableAddConstraintStatements(t *testing.T) {
 		"ALTER TABLE foo ADD CONSTRAINT bar UNIQUE (a) WITH (fillfactor=70)",
 		"ALTER TABLE foo ADD CONSTRAINT bar UNIQUE (a) USING INDEX TABLESPACE baz",
 
-		// Altering a column to change its collation is not representable by an
-		// `OpAlterColumn` operation
+		// COLLATE and USING clauses are not representable by `OpAlterColumn`
+		// operations when changing data type.
 		`ALTER TABLE foo ALTER COLUMN a SET DATA TYPE text COLLATE "en_US"`,
+		"ALTER TABLE foo ALTER COLUMN a SET DATA TYPE text USING 'foo'",
 	}
 
 	for _, sql := range tests {

--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -67,6 +67,10 @@ func TestUnconvertableAlterTableAddConstraintStatements(t *testing.T) {
 		"ALTER TABLE foo ADD CONSTRAINT bar UNIQUE (a) INCLUDE (b)",
 		"ALTER TABLE foo ADD CONSTRAINT bar UNIQUE (a) WITH (fillfactor=70)",
 		"ALTER TABLE foo ADD CONSTRAINT bar UNIQUE (a) USING INDEX TABLESPACE baz",
+
+		// Altering a column to change its collation is not representable by an
+		// `OpAlterColumn` operation
+		`ALTER TABLE foo ALTER COLUMN a SET DATA TYPE text COLLATE "en_US"`,
 	}
 
 	for _, sql := range tests {


### PR DESCRIPTION
Ensure that SQL statements of the form:

```sql
ALTER TABLE foo ALTER COLUMN a SET DATA TYPE text COLLATE "en_US"
ALTER TABLE foo ALTER COLUMN a SET DATA TYPE text USING 'foo'
```

are converted to raw SQL operations instead of an `OpAlterColumn` operation. The change of collation is not currently representable by an `OpAlterColumn` operation and neither is the `USING` clause.

Part of #504 