### PR TITLE
Convert `RENAME COLUMN` to `pgroll` operation

### DIFF
--- a/pkg/sql2pgroll/convert.go
+++ b/pkg/sql2pgroll/convert.go
@@ -42,6 +42,8 @@ func convert(sql string) (migrations.Operations, error) {
 		return convertCreateStmt(node.CreateStmt)
 	case *pgq.Node_AlterTableStmt:
 		return convertAlterTableStmt(node.AlterTableStmt)
+	case *pgq.Node_RenameStmt:
+		return convertRenameStmt(node.RenameStmt)
 	default:
 		return makeRawSQLOperation(sql), nil
 	}

--- a/pkg/sql2pgroll/expect/alter_table.go
+++ b/pkg/sql2pgroll/expect/alter_table.go
@@ -55,6 +55,12 @@ var AlterTableOp5 = &migrations.OpCreateConstraint{
 	},
 }
 
+var AlterTableOp6 = &migrations.OpAlterColumn{
+	Table:  "foo",
+	Column: "a",
+	Name:   ptr("b"),
+}
+
 func ptr[T any](v T) *T {
 	return &v
 }

--- a/pkg/sql2pgroll/rename.go
+++ b/pkg/sql2pgroll/rename.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package sql2pgroll
+
+import (
+	pgq "github.com/pganalyze/pg_query_go/v6"
+	"github.com/xataio/pgroll/pkg/migrations"
+)
+
+func convertRenameStmt(stmt *pgq.RenameStmt) (migrations.Operations, error) {
+	if stmt.GetRelationType() != pgq.ObjectType_OBJECT_TABLE {
+		return nil, nil
+	}
+	if stmt.GetRenameType() != pgq.ObjectType_OBJECT_COLUMN {
+		return nil, nil
+	}
+
+	return migrations.Operations{
+		&migrations.OpAlterColumn{
+			Table:  stmt.GetRelation().GetRelname(),
+			Column: stmt.GetSubname(),
+			Name:   ptr(stmt.GetNewname()),
+		},
+	}, nil
+}

--- a/pkg/sql2pgroll/rename_test.go
+++ b/pkg/sql2pgroll/rename_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package sql2pgroll_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xataio/pgroll/pkg/migrations"
+	"github.com/xataio/pgroll/pkg/sql2pgroll"
+	"github.com/xataio/pgroll/pkg/sql2pgroll/expect"
+)
+
+func TestConvertRenameColumnStatements(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		sql        string
+		expectedOp migrations.Operation
+	}{
+		{
+			sql:        "ALTER TABLE foo RENAME COLUMN a TO b",
+			expectedOp: expect.AlterTableOp6,
+		},
+		{
+			sql:        "ALTER TABLE foo RENAME a TO b",
+			expectedOp: expect.AlterTableOp6,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.sql, func(t *testing.T) {
+			ops, err := sql2pgroll.Convert(tc.sql)
+			require.NoError(t, err)
+
+			require.Len(t, ops, 1)
+
+			assert.Equal(t, tc.expectedOp, ops[0])
+		})
+	}
+}


### PR DESCRIPTION
Convert SQL statements of the form:

```sql
ALTER TABLE foo RENAME COLUMN a TO b
ALTER TABLE foo RENAME a TO b
```

to the equivalent `OpAlterColumn` operation:

```json
[
  {
    "alter_column": {
      "table": "foo",
      "column": "a",
      "name": "b"
    }
  }
]
```

Part of #504