### PR TITLE
Convert `ALTER TABLE foo RENAME TO bar` SQL to `pgroll` operation

### DIFF
--- a/pkg/sql2pgroll/expect/rename_table.go
+++ b/pkg/sql2pgroll/expect/rename_table.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package expect
+
+import "github.com/xataio/pgroll/pkg/migrations"
+
+var RenameTableOp1 = &migrations.OpRenameTable{
+	From: "foo",
+	To:   "bar",
+}

--- a/pkg/sql2pgroll/rename.go
+++ b/pkg/sql2pgroll/rename.go
@@ -7,17 +7,24 @@ import (
 	"github.com/xataio/pgroll/pkg/migrations"
 )
 
+// convertRenameStmt converts RenameStmt nodes to pgroll operations.
 func convertRenameStmt(stmt *pgq.RenameStmt) (migrations.Operations, error) {
 	switch stmt.GetRenameType() {
 	case pgq.ObjectType_OBJECT_TABLE:
 		return convertRenameTable(stmt)
 	case pgq.ObjectType_OBJECT_COLUMN:
 		return convertRenameColumn(stmt)
+	default:
+		return nil, nil
 	}
-
-	return nil, nil
 }
 
+// convertRenameColumn converts SQL statements like:
+//
+// `ALTER TABLE foo RENAME COLUMN a TO b`
+// `ALTER TABLE foo RENAME a TO b`
+//
+// to an OpAlterColumn operation.
 func convertRenameColumn(stmt *pgq.RenameStmt) (migrations.Operations, error) {
 	return migrations.Operations{
 		&migrations.OpAlterColumn{
@@ -28,6 +35,11 @@ func convertRenameColumn(stmt *pgq.RenameStmt) (migrations.Operations, error) {
 	}, nil
 }
 
+// convertRenameTable converts SQL statements like:
+//
+// `ALTER TABLE foo RENAME TO bar`
+//
+// to an OpRenameTable operation.
 func convertRenameTable(stmt *pgq.RenameStmt) (migrations.Operations, error) {
 	return migrations.Operations{
 		&migrations.OpRenameTable{

--- a/pkg/sql2pgroll/rename_test.go
+++ b/pkg/sql2pgroll/rename_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/xataio/pgroll/pkg/sql2pgroll/expect"
 )
 
-func TestConvertRenameColumnStatements(t *testing.T) {
+func TestConvertRenameStatements(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -26,6 +26,10 @@ func TestConvertRenameColumnStatements(t *testing.T) {
 		{
 			sql:        "ALTER TABLE foo RENAME a TO b",
 			expectedOp: expect.AlterColumnOp4,
+		},
+		{
+			sql:        "ALTER TABLE foo RENAME TO bar",
+			expectedOp: expect.RenameTableOp1,
 		},
 	}
 


### PR DESCRIPTION
Convert SQL statements of the form:

```sql
ALTER TABLE foo RENAME TO bar
```

to the corresponding `OpRenameTable` operation:

```json
[
  {
    "rename_table": {
      "from": "foo",
      "to": "bar"
    }
  }
]
```

Part of #504 