### PR TITLE
Convert `RENAME CONSTRAINT` SQL to `pgroll` operation

### DIFF
--- a/pkg/sql2pgroll/expect/rename_constraint.go
+++ b/pkg/sql2pgroll/expect/rename_constraint.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package expect
+
+import "github.com/xataio/pgroll/pkg/migrations"
+
+var RenameConstraintOp1 = &migrations.OpRenameConstraint{
+	Table: "foo",
+	From:  "bar",
+	To:    "baz",
+}

--- a/pkg/sql2pgroll/rename.go
+++ b/pkg/sql2pgroll/rename.go
@@ -14,6 +14,8 @@ func convertRenameStmt(stmt *pgq.RenameStmt) (migrations.Operations, error) {
 		return convertRenameTable(stmt)
 	case pgq.ObjectType_OBJECT_COLUMN:
 		return convertRenameColumn(stmt)
+	case pgq.ObjectType_OBJECT_TABCONSTRAINT:
+		return convertRenameConstraint(stmt)
 	default:
 		return nil, nil
 	}
@@ -45,6 +47,21 @@ func convertRenameTable(stmt *pgq.RenameStmt) (migrations.Operations, error) {
 		&migrations.OpRenameTable{
 			From: stmt.GetRelation().GetRelname(),
 			To:   stmt.GetNewname(),
+		},
+	}, nil
+}
+
+// convertRenameConstraint converts SQL statements like:
+//
+// `ALTER TABLE foo RENAME CONSTRAINT a TO b`
+//
+// to an OpRenameConstraint operation.
+func convertRenameConstraint(stmt *pgq.RenameStmt) (migrations.Operations, error) {
+	return migrations.Operations{
+		&migrations.OpRenameConstraint{
+			Table: stmt.GetRelation().GetRelname(),
+			From:  stmt.GetSubname(),
+			To:    stmt.GetNewname(),
 		},
 	}, nil
 }

--- a/pkg/sql2pgroll/rename_test.go
+++ b/pkg/sql2pgroll/rename_test.go
@@ -31,6 +31,10 @@ func TestConvertRenameStatements(t *testing.T) {
 			sql:        "ALTER TABLE foo RENAME TO bar",
 			expectedOp: expect.RenameTableOp1,
 		},
+		{
+			sql:        "ALTER TABLE foo RENAME CONSTRAINT bar TO baz",
+			expectedOp: expect.RenameConstraintOp1,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Convert SQL statements like:

```sql
ALTER TABLE foo RENAME CONSTRAINT bar TO baz
```

to an `OpRenameConstraint` operation:

```json
[
  {
    "rename_constraint": {
      "table": "foo",
      "from": "bar",
      "to": "baz"
    }
  }
]
```

Part of #504 