### PR TITLE
Make `check-ledger` job required for release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,7 +190,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [test, lint, examples-schema-validation, examples, license-check, type-generation, dead-code-check]
+    needs: [test, lint, examples-schema-validation, examples, license-check, type-generation, dead-code-check, check-ledger]
     if: startsWith(github.ref, 'refs/tags/')
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"


### PR DESCRIPTION
Include `check-ledger` in the list of required jobs for the `release` job.