### PR TITLE
Use `ubuntu 24.04` as the runner in all workflows

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   benchmark:
     name: 'benchmark (pg: ${{ matrix.pgVersion }})'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -37,7 +37,7 @@ jobs:
 
   gather:
     name: 'Gather results'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [benchmark]
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   test:
     name: 'test (pg: ${{ matrix.pgVersion }}, schema: ${{ matrix.testSchema }})'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -32,7 +32,7 @@ jobs:
 
   lint:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
 
@@ -67,7 +67,7 @@ jobs:
 
   type-generation:
     name: type generation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -86,7 +86,7 @@ jobs:
 
   check-ledger:
     name: check ledger
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
      - uses: actions/checkout@v4
 
@@ -104,7 +104,7 @@ jobs:
          
   dead-code-check:
     name: dead code check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -128,7 +128,7 @@ jobs:
 
   license-check:
     name: license check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -139,7 +139,7 @@ jobs:
 
   examples-schema-validation:
     name: validate examples JSON
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -149,7 +149,7 @@ jobs:
 
   examples:
     name: 'examples (pg: ${{ matrix.pgVersion }}, schema: ${{ matrix.testSchema }})'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -189,7 +189,7 @@ jobs:
         PGROLL_SCHEMA: ${{ matrix.testSchema }}
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [test, lint, examples-schema-validation, examples, license-check, type-generation, dead-code-check, check-ledger]
     if: startsWith(github.ref, 'refs/tags/')
     env:

--- a/.github/workflows/publish_benchmarks.yaml
+++ b/.github/workflows/publish_benchmarks.yaml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   publish:
     name: Publish benchmarks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2


### PR DESCRIPTION
Update the runner used by all jobs in all workflows to use `ubuntu-24.04` instead of `ubuntu-latest`.

`ubuntu-24.04` will become `ubuntu-latest` over the next month, see:

https://github.com/actions/runner-images/issues/10636