### PR TITLE
Convert DROP INDEX SQL to pgroll operation

### DIFF
--- a/pkg/sql2pgroll/convert.go
+++ b/pkg/sql2pgroll/convert.go
@@ -45,6 +45,8 @@ func convert(sql string) (migrations.Operations, error) {
 		return convertAlterTableStmt(node.AlterTableStmt)
 	case *pgq.Node_RenameStmt:
 		return convertRenameStmt(node.RenameStmt)
+	case *pgq.Node_DropStmt:
+		return convertDropStatement(node.DropStmt)
 	default:
 		return makeRawSQLOperation(sql), nil
 	}

--- a/pkg/sql2pgroll/drop.go
+++ b/pkg/sql2pgroll/drop.go
@@ -3,6 +3,8 @@
 package sql2pgroll
 
 import (
+	"strings"
+
 	pgq "github.com/pganalyze/pg_query_go/v6"
 
 	"github.com/xataio/pgroll/pkg/migrations"
@@ -21,10 +23,15 @@ func convertDropIndexStatement(stmt *pgq.DropStmt) (migrations.Operations, error
 	if !canConvertDropIndex(stmt) {
 		return nil, nil
 	}
-	s := stmt.GetObjects()[0].GetList().GetItems()[0].GetString_().GetSval()
+	items := stmt.GetObjects()[0].GetList().GetItems()
+	parts := make([]string, len(items))
+	for i, item := range items {
+		parts[i] = item.GetString_().GetSval()
+	}
+
 	return migrations.Operations{
 		&migrations.OpDropIndex{
-			Name: s,
+			Name: strings.Join(parts, "."),
 		},
 	}, nil
 }

--- a/pkg/sql2pgroll/drop.go
+++ b/pkg/sql2pgroll/drop.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package sql2pgroll
+
+import (
+	pgq "github.com/pganalyze/pg_query_go/v6"
+
+	"github.com/xataio/pgroll/pkg/migrations"
+)
+
+// convertDropStatement converts supported drop statements to pgroll operations
+func convertDropStatement(stmt *pgq.DropStmt) (migrations.Operations, error) {
+	switch stmt.RemoveType {
+	case pgq.ObjectType_OBJECT_INDEX:
+		return convertDropIndexStatement(stmt)
+	}
+	return nil, nil
+}
+
+// convertDropIndexStatement converts simple DROP INDEX statements to pgroll operations
+func convertDropIndexStatement(stmt *pgq.DropStmt) (migrations.Operations, error) {
+	if !canConvertDropIndex(stmt) {
+		return nil, nil
+	}
+	s := stmt.Objects[0].GetList().Items[0].GetString_().GetSval()
+	return migrations.Operations{
+		&migrations.OpDropIndex{
+			Name: s,
+		},
+	}, nil
+}
+
+// canConvertDropIndex checks whether we can convert the statement without losing any information.
+func canConvertDropIndex(stmt *pgq.DropStmt) bool {
+	if len(stmt.Objects) > 1 {
+		return false
+	}
+	if stmt.MissingOk || stmt.Concurrent {
+		return false
+	}
+	if stmt.Behavior == pgq.DropBehavior_DROP_CASCADE {
+		return false
+	}
+	return true
+}

--- a/pkg/sql2pgroll/drop.go
+++ b/pkg/sql2pgroll/drop.go
@@ -10,8 +10,7 @@ import (
 
 // convertDropStatement converts supported drop statements to pgroll operations
 func convertDropStatement(stmt *pgq.DropStmt) (migrations.Operations, error) {
-	switch stmt.RemoveType {
-	case pgq.ObjectType_OBJECT_INDEX:
+	if stmt.RemoveType == pgq.ObjectType_OBJECT_INDEX {
 		return convertDropIndexStatement(stmt)
 	}
 	return nil, nil

--- a/pkg/sql2pgroll/drop.go
+++ b/pkg/sql2pgroll/drop.go
@@ -21,7 +21,7 @@ func convertDropIndexStatement(stmt *pgq.DropStmt) (migrations.Operations, error
 	if !canConvertDropIndex(stmt) {
 		return nil, nil
 	}
-	s := stmt.Objects[0].GetList().Items[0].GetString_().GetSval()
+	s := stmt.GetObjects()[0].GetList().GetItems()[0].GetString_().GetSval()
 	return migrations.Operations{
 		&migrations.OpDropIndex{
 			Name: s,

--- a/pkg/sql2pgroll/drop.go
+++ b/pkg/sql2pgroll/drop.go
@@ -34,9 +34,6 @@ func canConvertDropIndex(stmt *pgq.DropStmt) bool {
 	if len(stmt.Objects) > 1 {
 		return false
 	}
-	if stmt.MissingOk || stmt.Concurrent {
-		return false
-	}
 	if stmt.Behavior == pgq.DropBehavior_DROP_CASCADE {
 		return false
 	}

--- a/pkg/sql2pgroll/drop_test.go
+++ b/pkg/sql2pgroll/drop_test.go
@@ -25,13 +25,18 @@ func TestDropIndexStatements(t *testing.T) {
 			expectedOp: expect.DropIndexOp1,
 		},
 		{
+			sql:        "DROP INDEX myschema.foo",
+			expectedOp: expect.DropIndexOp1,
+		},
+		{
 			sql:        "DROP INDEX foo RESTRICT",
 			expectedOp: expect.DropIndexOp1,
 		},
 		{
 			sql:        "DROP INDEX IF EXISTS foo",
 			expectedOp: expect.DropIndexOp1,
-		}, {
+		},
+		{
 			sql:        "DROP INDEX CONCURRENTLY foo",
 			expectedOp: expect.DropIndexOp1,
 		},

--- a/pkg/sql2pgroll/drop_test.go
+++ b/pkg/sql2pgroll/drop_test.go
@@ -26,7 +26,7 @@ func TestDropIndexStatements(t *testing.T) {
 		},
 		{
 			sql:        "DROP INDEX myschema.foo",
-			expectedOp: expect.DropIndexOp1,
+			expectedOp: expect.DropIndexOp2,
 		},
 		{
 			sql:        "DROP INDEX foo RESTRICT",

--- a/pkg/sql2pgroll/drop_test.go
+++ b/pkg/sql2pgroll/drop_test.go
@@ -28,6 +28,13 @@ func TestDropIndexStatements(t *testing.T) {
 			sql:        "DROP INDEX foo RESTRICT",
 			expectedOp: expect.DropIndexOp1,
 		},
+		{
+			sql:        "DROP INDEX IF EXISTS foo",
+			expectedOp: expect.DropIndexOp1,
+		}, {
+			sql:        "DROP INDEX CONCURRENTLY foo",
+			expectedOp: expect.DropIndexOp1,
+		},
 	}
 
 	for _, tc := range tests {
@@ -46,8 +53,6 @@ func TestUnconvertableDropIndexStatements(t *testing.T) {
 	t.Parallel()
 
 	tests := []string{
-		"DROP INDEX CONCURRENTLY foo",
-		"DROP INDEX IF EXISTS foo",
 		"DROP INDEX foo CASCADE",
 	}
 

--- a/pkg/sql2pgroll/drop_test.go
+++ b/pkg/sql2pgroll/drop_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package sql2pgroll_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/xataio/pgroll/pkg/migrations"
+	"github.com/xataio/pgroll/pkg/sql2pgroll"
+	"github.com/xataio/pgroll/pkg/sql2pgroll/expect"
+)
+
+func TestDropIndexStatements(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		sql        string
+		expectedOp migrations.Operation
+	}{
+		{
+			sql:        "DROP INDEX foo",
+			expectedOp: expect.DropIndexOp1,
+		},
+		{
+			sql:        "DROP INDEX foo RESTRICT",
+			expectedOp: expect.DropIndexOp1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.sql, func(t *testing.T) {
+			ops, err := sql2pgroll.Convert(tc.sql)
+			require.NoError(t, err)
+
+			require.Len(t, ops, 1)
+
+			assert.Equal(t, tc.expectedOp, ops[0])
+		})
+	}
+}
+
+func TestUnconvertableDropIndexStatements(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{
+		"DROP INDEX CONCURRENTLY foo",
+		"DROP INDEX IF EXISTS foo",
+		"DROP INDEX foo CASCADE",
+	}
+
+	for _, sql := range tests {
+		t.Run(sql, func(t *testing.T) {
+			ops, err := sql2pgroll.Convert(sql)
+			require.NoError(t, err)
+
+			require.Len(t, ops, 1)
+
+			assert.Equal(t, expect.RawSQLOp(sql), ops[0])
+		})
+	}
+}

--- a/pkg/sql2pgroll/expect/drop_index.go
+++ b/pkg/sql2pgroll/expect/drop_index.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package expect
+
+import (
+	"github.com/xataio/pgroll/pkg/migrations"
+)
+
+var DropIndexOp1 = &migrations.OpDropIndex{
+	Name: "foo",
+}

--- a/pkg/sql2pgroll/expect/drop_index.go
+++ b/pkg/sql2pgroll/expect/drop_index.go
@@ -9,3 +9,7 @@ import (
 var DropIndexOp1 = &migrations.OpDropIndex{
 	Name: "foo",
 }
+
+var DropIndexOp2 = &migrations.OpDropIndex{
+	Name: "myschema.foo",
+}


### PR DESCRIPTION
Converts SQL in the following forms to the equivalent pgroll operation:

```sql
DROP INDEX foo
DROP INDEX schema.foo
DROP INDEX foo RESTRICT
DROP INDEX CONCURRENTLY foo
DROP INDEX IF EXISTS foo
```

The following forms are left as raw SQL operations since we do not support them in pgroll yet:

```sql
DROP INDEX foo CASCADE
```

Part of https://github.com/xataio/pgroll/issues/504