### PR TITLE
sql2pgroll: Support set and drop column defaults

### DIFF
--- a/pkg/sql2pgroll/alter_table.go
+++ b/pkg/sql2pgroll/alter_table.go
@@ -163,9 +163,9 @@ func convertAlterTableAddUniqueConstraint(stmt *pgq.AlterTableStmt, constraint *
 
 // convertAlterTableSetColumnDefault converts SQL statements like:
 //
-// `ALTER TABLE foo COLUMN bar SET DEFAULT 'foo'
-// `ALTER TABLE foo COLUMN bar SET DEFAULT null
-// `ALTER TABLE foo COLUMN bar DROP DEFAULT
+// `ALTER TABLE foo COLUMN bar SET DEFAULT 'foo'`
+// `ALTER TABLE foo COLUMN bar SET DEFAULT null`
+// `ALTER TABLE foo COLUMN bar DROP DEFAULT`
 //
 // to an OpDropColumn operation.
 func convertAlterTableSetColumnDefault(stmt *pgq.AlterTableStmt, cmd *pgq.AlterTableCmd) (migrations.Operation, error) {

--- a/pkg/sql2pgroll/alter_table.go
+++ b/pkg/sql2pgroll/alter_table.go
@@ -165,6 +165,10 @@ func convertAlterTableAddUniqueConstraint(stmt *pgq.AlterTableStmt, constraint *
 // convertAlterTableSetColumnDefault converts SQL statements like:
 //
 // `ALTER TABLE foo COLUMN bar SET DEFAULT 'foo'`
+// `ALTER TABLE foo COLUMN bar SET DEFAULT 123`
+// `ALTER TABLE foo COLUMN bar SET DEFAULT 123.456`
+// `ALTER TABLE foo COLUMN bar SET DEFAULT true`
+// `ALTER TABLE foo COLUMN bar SET DEFAULT B'0101'`
 // `ALTER TABLE foo COLUMN bar SET DEFAULT null`
 // `ALTER TABLE foo COLUMN bar DROP DEFAULT`
 //

--- a/pkg/sql2pgroll/alter_table.go
+++ b/pkg/sql2pgroll/alter_table.go
@@ -167,7 +167,7 @@ func convertAlterTableAddUniqueConstraint(stmt *pgq.AlterTableStmt, constraint *
 // `ALTER TABLE foo COLUMN bar SET DEFAULT null`
 // `ALTER TABLE foo COLUMN bar DROP DEFAULT`
 //
-// to an OpDropColumn operation.
+// to an OpAlterColumn operation.
 func convertAlterTableSetColumnDefault(stmt *pgq.AlterTableStmt, cmd *pgq.AlterTableCmd) (migrations.Operation, error) {
 	def := nullable.NewNullNullable[string]()
 	if val := cmd.GetDef().GetAConst().GetSval(); val != nil {

--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -113,6 +113,9 @@ func TestUnconvertableAlterTableStatements(t *testing.T) {
 		// CASCADE and IF EXISTS clauses are not represented by OpDropColumn
 		"ALTER TABLE foo DROP COLUMN bar CASCADE",
 		"ALTER TABLE foo DROP COLUMN IF EXISTS bar",
+
+		// Non literal default values
+		"ALTER TABLE foo ALTER COLUMN bar SET DEFAULT now()",
 	}
 
 	for _, sql := range tests {

--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -37,6 +37,18 @@ func TestConvertAlterTableStatements(t *testing.T) {
 			expectedOp: expect.AlterColumnOp3,
 		},
 		{
+			sql:        "ALTER TABLE foo ALTER COLUMN bar SET DEFAULT 'baz'",
+			expectedOp: expect.AlterColumnOp5,
+		},
+		{
+			sql:        "ALTER TABLE foo ALTER COLUMN bar DROP DEFAULT",
+			expectedOp: expect.AlterColumnOp6,
+		},
+		{
+			sql:        "ALTER TABLE foo ALTER COLUMN bar SET DEFAULT null",
+			expectedOp: expect.AlterColumnOp6,
+		},
+		{
 			sql:        "ALTER TABLE foo ADD CONSTRAINT bar UNIQUE (a)",
 			expectedOp: expect.CreateConstraintOp1,
 		},

--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -41,12 +41,28 @@ func TestConvertAlterTableStatements(t *testing.T) {
 			expectedOp: expect.AlterColumnOp5,
 		},
 		{
-			sql:        "ALTER TABLE foo ALTER COLUMN bar DROP DEFAULT",
+			sql:        "ALTER TABLE foo ALTER COLUMN bar SET DEFAULT 123",
 			expectedOp: expect.AlterColumnOp6,
 		},
 		{
+			sql:        "ALTER TABLE foo ALTER COLUMN bar SET DEFAULT true",
+			expectedOp: expect.AlterColumnOp9,
+		},
+		{
+			sql:        "ALTER TABLE foo ALTER COLUMN bar SET DEFAULT B'0101'",
+			expectedOp: expect.AlterColumnOp10,
+		},
+		{
+			sql:        "ALTER TABLE foo ALTER COLUMN bar SET DEFAULT 123.456",
+			expectedOp: expect.AlterColumnOp8,
+		},
+		{
+			sql:        "ALTER TABLE foo ALTER COLUMN bar DROP DEFAULT",
+			expectedOp: expect.AlterColumnOp7,
+		},
+		{
 			sql:        "ALTER TABLE foo ALTER COLUMN bar SET DEFAULT null",
-			expectedOp: expect.AlterColumnOp6,
+			expectedOp: expect.AlterColumnOp7,
 		},
 		{
 			sql:        "ALTER TABLE foo ADD CONSTRAINT bar UNIQUE (a)",

--- a/pkg/sql2pgroll/expect/alter_column.go
+++ b/pkg/sql2pgroll/expect/alter_column.go
@@ -50,7 +50,39 @@ var AlterColumnOp5 = &migrations.OpAlterColumn{
 var AlterColumnOp6 = &migrations.OpAlterColumn{
 	Table:   "foo",
 	Column:  "bar",
+	Default: nullable.NewNullableWithValue("123"),
+	Up:      sql2pgroll.PlaceHolderSQL,
+	Down:    sql2pgroll.PlaceHolderSQL,
+}
+
+var AlterColumnOp7 = &migrations.OpAlterColumn{
+	Table:   "foo",
+	Column:  "bar",
 	Default: nullable.NewNullNullable[string](),
+	Up:      sql2pgroll.PlaceHolderSQL,
+	Down:    sql2pgroll.PlaceHolderSQL,
+}
+
+var AlterColumnOp8 = &migrations.OpAlterColumn{
+	Table:   "foo",
+	Column:  "bar",
+	Default: nullable.NewNullableWithValue("123.456"),
+	Up:      sql2pgroll.PlaceHolderSQL,
+	Down:    sql2pgroll.PlaceHolderSQL,
+}
+
+var AlterColumnOp9 = &migrations.OpAlterColumn{
+	Table:   "foo",
+	Column:  "bar",
+	Default: nullable.NewNullableWithValue("true"),
+	Up:      sql2pgroll.PlaceHolderSQL,
+	Down:    sql2pgroll.PlaceHolderSQL,
+}
+
+var AlterColumnOp10 = &migrations.OpAlterColumn{
+	Table:   "foo",
+	Column:  "bar",
+	Default: nullable.NewNullableWithValue("b0101"),
 	Up:      sql2pgroll.PlaceHolderSQL,
 	Down:    sql2pgroll.PlaceHolderSQL,
 }

--- a/pkg/sql2pgroll/expect/alter_column.go
+++ b/pkg/sql2pgroll/expect/alter_column.go
@@ -3,6 +3,8 @@
 package expect
 
 import (
+	"github.com/oapi-codegen/nullable"
+
 	"github.com/xataio/pgroll/pkg/migrations"
 	"github.com/xataio/pgroll/pkg/sql2pgroll"
 )
@@ -35,6 +37,22 @@ var AlterColumnOp4 = &migrations.OpAlterColumn{
 	Table:  "foo",
 	Column: "a",
 	Name:   ptr("b"),
+}
+
+var AlterColumnOp5 = &migrations.OpAlterColumn{
+	Table:   "foo",
+	Column:  "bar",
+	Default: nullable.NewNullableWithValue("baz"),
+	Up:      sql2pgroll.PlaceHolderSQL,
+	Down:    sql2pgroll.PlaceHolderSQL,
+}
+
+var AlterColumnOp6 = &migrations.OpAlterColumn{
+	Table:   "foo",
+	Column:  "bar",
+	Default: nullable.NewNullNullable[string](),
+	Up:      sql2pgroll.PlaceHolderSQL,
+	Down:    sql2pgroll.PlaceHolderSQL,
 }
 
 func ptr[T any](v T) *T {


### PR DESCRIPTION
Support translating the following alter table statements into pgroll operations:

```sql
ALTER TABLE foo COLUMN bar SET DEFAULT 'foo'
ALTER TABLE foo COLUMN bar SET DEFAULT 123
ALTER TABLE foo COLUMN bar SET DEFAULT 123.456
ALTER TABLE foo COLUMN bar SET DEFAULT true
ALTER TABLE foo COLUMN bar SET DEFAULT B'0101'
ALTER TABLE foo COLUMN bar SET DEFAULT null
ALTER TABLE foo COLUMN bar DROP DEFAULT
```

For cases where the default is set to something other than a simple literal, we fall back to raw SQL.