### PR TITLE
Build `CGO_ENABLED` binaries for supported platforms in the `release` job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,6 +232,9 @@ jobs:
       with:
         fetch-depth: 0
 
+    # Mark the checkout as 'safe' despite being owned by `root`
+    - run: git config --global --add safe.directory $GITHUB_WORKSPACE 
+
     - run: git fetch --force --tags
 
     - name: Set up Docker Buildx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,6 +221,8 @@ jobs:
 
   release:
     runs-on: ubuntu-24.04
+    container:
+      image: surjection/goreleaser-cross:v1.23-v2.4.8
     needs: [test, lint, examples-schema-validation, examples, license-check, type-generation, dead-code-check, check-ledger, cross-build]
     if: startsWith(github.ref, 'refs/tags/')
     env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,10 +33,12 @@ builds:
         goarch: amd64
         env:
           - CC=x86_64-linux-gnu-gcc
+          - CGO_LDFLAGS=-static
       - goos: linux
         goarch: arm64
         env:
           - CC=aarch64-linux-gnu-gcc
+          - CGO_LDFLAGS=-static
       - goos: darwin
         goarch: amd64
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+#
+# This Dockerfile is used by GoReleaser in the `release` job.
+# See:
+# https://goreleaser.com/customization/docker
+#
 FROM scratch
 COPY pgroll /usr/bin/pgroll
 ENTRYPOINT [ "/usr/bin/pgroll" ]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,6 +79,7 @@ func Execute() error {
 	rootCmd.AddCommand(migrateCmd())
 	rootCmd.AddCommand(pullCmd())
 	rootCmd.AddCommand(latestCmd())
+	rootCmd.AddCommand(sqlCmd())
 
 	return rootCmd.Execute()
 }

--- a/cmd/sql.go
+++ b/cmd/sql.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/xataio/pgroll/pkg/sql2pgroll"
+)
+
+func sqlCmd() *cobra.Command {
+	sqlCmd := &cobra.Command{
+		Use:    "sql <sql statement>",
+		Short:  "Convert SQL statements to pgroll operations",
+		Args:   cobra.ExactArgs(1),
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sql := args[0]
+
+			ops, err := sql2pgroll.Convert(sql)
+			if err != nil {
+				return fmt.Errorf("failed to convert SQL statement: %w", err)
+			}
+
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(ops); err != nil {
+				return fmt.Errorf("failed to encode operations: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	return sqlCmd
+}


### PR DESCRIPTION
Make the `release` job run in a `goreleaser/goreleaser-cross` container so that we can build binaries for all supported architectures.

See the PR description for https://github.com/xataio/pgroll/pull/525 for details of why we need a cross-compilation toolchain as a result of taking a dependency on `pg_query_go` and how the the `goreleaser-cross` image is used.

The addition of the `-static` `LDFLAG` for the `linux/amd64` and `linux/arm64` builds is necessary to statically link in order for the resulting `pgroll` binaries to run in the `FROM scratch` image that `Goreleaser` uses to build docker images.

Also, revert #515 to re-add the `pgroll sql`  command now that `pgroll` can be built for all platforms when the dependency on `pg_query_go` is included in the build.