### PR TITLE
Convert DROP TABLE SQL to pgroll operation

### DIFF
--- a/pkg/sql2pgroll/drop.go
+++ b/pkg/sql2pgroll/drop.go
@@ -12,8 +12,12 @@ import (
 
 // convertDropStatement converts supported drop statements to pgroll operations
 func convertDropStatement(stmt *pgq.DropStmt) (migrations.Operations, error) {
-	if stmt.RemoveType == pgq.ObjectType_OBJECT_INDEX {
+	switch stmt.RemoveType {
+	case pgq.ObjectType_OBJECT_INDEX:
 		return convertDropIndexStatement(stmt)
+	case pgq.ObjectType_OBJECT_TABLE:
+		return convertDropTableStatement(stmt)
+
 	}
 	return nil, nil
 }
@@ -41,6 +45,33 @@ func canConvertDropIndex(stmt *pgq.DropStmt) bool {
 	if len(stmt.Objects) > 1 {
 		return false
 	}
+	if stmt.Behavior == pgq.DropBehavior_DROP_CASCADE {
+		return false
+	}
+	return true
+}
+
+// convertDropTableStatement converts simple DROP TABLE statements to pgroll operations
+func convertDropTableStatement(stmt *pgq.DropStmt) (migrations.Operations, error) {
+	if !canConvertDropTable(stmt) {
+		return nil, nil
+	}
+
+	items := stmt.GetObjects()[0].GetList().GetItems()
+	parts := make([]string, len(items))
+	for i, item := range items {
+		parts[i] = item.GetString_().GetSval()
+	}
+
+	return migrations.Operations{
+		&migrations.OpDropTable{
+			Name: strings.Join(parts, "."),
+		},
+	}, nil
+}
+
+// canConvertDropTable checks whether we can convert the statement without losing any information.
+func canConvertDropTable(stmt *pgq.DropStmt) bool {
 	if stmt.Behavior == pgq.DropBehavior_DROP_CASCADE {
 		return false
 	}

--- a/pkg/sql2pgroll/drop.go
+++ b/pkg/sql2pgroll/drop.go
@@ -72,8 +72,5 @@ func convertDropTableStatement(stmt *pgq.DropStmt) (migrations.Operations, error
 
 // canConvertDropTable checks whether we can convert the statement without losing any information.
 func canConvertDropTable(stmt *pgq.DropStmt) bool {
-	if stmt.Behavior == pgq.DropBehavior_DROP_CASCADE {
-		return false
-	}
-	return true
+	return stmt.Behavior != pgq.DropBehavior_DROP_CASCADE
 }

--- a/pkg/sql2pgroll/expect/drop_table.go
+++ b/pkg/sql2pgroll/expect/drop_table.go
@@ -1,0 +1,13 @@
+package expect
+
+import (
+	"github.com/xataio/pgroll/pkg/migrations"
+)
+
+var DropTableOp1 = &migrations.OpDropTable{
+	Name: "foo",
+}
+
+var DropTableOp2 = &migrations.OpDropTable{
+	Name: "foo.bar",
+}

--- a/pkg/sql2pgroll/expect/drop_table.go
+++ b/pkg/sql2pgroll/expect/drop_table.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package expect
 
 import (


### PR DESCRIPTION
Converts `DROP TABLE` statements in these forms:

```sql
DROP TABLE foo
DROP TABLE foo RESTRICT
DROP TABLE foo.bar
DROP TABLE IF EXISTS foo
```

These forms fall back to raw SQL:

```sql
DROP TABLE foo CASCADE
```

Part of https://github.com/xataio/pgroll/issues/504