### PR TITLE
Convert ADD CONSTRAINT SQL into OpCreateConstraint operations for foreign keys

### DIFF
--- a/pkg/sql2pgroll/alter_table.go
+++ b/pkg/sql2pgroll/alter_table.go
@@ -228,8 +228,19 @@ func convertAlterTableAddForeignKeyConstraint(stmt *pgq.AlterTableStmt, constrai
 func canConvertAlterTableAddForeignKeyConstraint(constraint *pgq.Constraint) bool {
 	switch constraint.GetFkUpdAction() {
 	case "r", "c", "n", "d":
-		// We ignore "a" above since this is NO ACTION, the default
+		// RESTRICT, CASCADE, SET NULL, SET DEFAULT
 		return false
+	case "a":
+		// NO ACTION, the default
+		break
+	}
+	switch constraint.GetFkMatchtype() {
+	case "f":
+		// FULL
+		return false
+	case "s":
+		// SIMPLE, the default
+		break
 	}
 	return true
 }

--- a/pkg/sql2pgroll/alter_table.go
+++ b/pkg/sql2pgroll/alter_table.go
@@ -98,11 +98,13 @@ func convertAlterTableAlterColumnType(stmt *pgq.AlterTableStmt, cmd *pgq.AlterTa
 	}, nil
 }
 
-// convertAlterTableAddConstraint converts SQL statements like:
+// convertAlterTableAddConstraint converts SQL statements that add UNIQUE or FOREIGN KEY constraints,
+// for example:
 //
 // `ALTER TABLE foo ADD CONSTRAINT bar UNIQUE (a)`
+// `ALTER TABLE foo ADD CONSTRAINT fk_bar_c FOREIGN KEY (a) REFERENCES bar (c);`
 //
-// To an OpCreateConstraint operation.
+// An OpCreateConstraint operation is returned.
 func convertAlterTableAddConstraint(stmt *pgq.AlterTableStmt, cmd *pgq.AlterTableCmd) (migrations.Operation, error) {
 	node, ok := cmd.GetDef().Node.(*pgq.Node_Constraint)
 	if !ok {

--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -154,6 +154,9 @@ func TestUnconvertableAlterTableStatements(t *testing.T) {
 		"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON UPDATE CASCADE;",
 		"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON UPDATE SET NULL;",
 		"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON UPDATE SET DEFAULT;",
+		"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) MATCH FULL;",
+		// MATCH PARTIAL is not implemented in the actual parser yet
+		//"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) MATCH PARTIAL;",
 	}
 
 	for _, sql := range tests {

--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -105,6 +105,10 @@ func TestConvertAlterTableStatements(t *testing.T) {
 			expectedOp: expect.AddForeignKeyOp2,
 		},
 		{
+			sql:        "ALTER TABLE foo ADD CONSTRAINT fk_bar_c FOREIGN KEY (a) REFERENCES bar (c) NOT VALID;",
+			expectedOp: expect.AddForeignKeyOp2,
+		},
+		{
 			sql:        "ALTER TABLE schema_a.foo ADD CONSTRAINT fk_bar_c FOREIGN KEY (a) REFERENCES schema_a.bar (c);",
 			expectedOp: expect.AddForeignKeyOp3,
 		},
@@ -144,6 +148,12 @@ func TestUnconvertableAlterTableStatements(t *testing.T) {
 
 		// Non literal default values
 		"ALTER TABLE foo ALTER COLUMN bar SET DEFAULT now()",
+
+		// Unsupported foreign key statements
+		"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON UPDATE RESTRICT;",
+		"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON UPDATE CASCADE;",
+		"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON UPDATE SET NULL;",
+		"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON UPDATE SET DEFAULT;",
 	}
 
 	for _, sql := range tests {

--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -104,6 +104,10 @@ func TestConvertAlterTableStatements(t *testing.T) {
 			sql:        "ALTER TABLE foo ADD CONSTRAINT fk_bar_c FOREIGN KEY (a) REFERENCES bar (c);",
 			expectedOp: expect.AddForeignKeyOp2,
 		},
+		{
+			sql:        "ALTER TABLE schema_a.foo ADD CONSTRAINT fk_bar_c FOREIGN KEY (a) REFERENCES schema_a.bar (c);",
+			expectedOp: expect.AddForeignKeyOp3,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -100,6 +100,10 @@ func TestConvertAlterTableStatements(t *testing.T) {
 			sql:        "ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON DELETE SET NULL;",
 			expectedOp: expect.AddForeignKeyOp1WithOnDelete(migrations.ForeignKeyReferenceOnDeleteSETNULL),
 		},
+		{
+			sql:        "ALTER TABLE foo ADD CONSTRAINT fk_bar_c FOREIGN KEY (a) REFERENCES bar (c);",
+			expectedOp: expect.AddForeignKeyOp2,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -82,23 +82,23 @@ func TestConvertAlterTableStatements(t *testing.T) {
 		},
 		{
 			sql:        "ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d);",
-			expectedOp: expect.AddForeignKeyOp1,
+			expectedOp: expect.AddForeignKeyOp1WithOnDelete(migrations.ForeignKeyReferenceOnDeleteNOACTION),
 		},
 		{
 			sql:        "ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON DELETE NO ACTION;",
-			expectedOp: expect.AddForeignKeyOp1,
+			expectedOp: expect.AddForeignKeyOp1WithOnDelete(migrations.ForeignKeyReferenceOnDeleteNOACTION),
 		},
 		{
 			sql:        "ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON DELETE RESTRICT;",
-			expectedOp: expect.AddForeignKeyOp2,
+			expectedOp: expect.AddForeignKeyOp1WithOnDelete(migrations.ForeignKeyReferenceOnDeleteRESTRICT),
 		},
 		{
 			sql:        "ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON DELETE SET DEFAULT ;",
-			expectedOp: expect.AddForeignKeyOp3,
+			expectedOp: expect.AddForeignKeyOp1WithOnDelete(migrations.ForeignKeyReferenceOnDeleteSETDEFAULT),
 		},
 		{
 			sql:        "ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON DELETE SET NULL;",
-			expectedOp: expect.AddForeignKeyOp4,
+			expectedOp: expect.AddForeignKeyOp1WithOnDelete(migrations.ForeignKeyReferenceOnDeleteSETNULL),
 		},
 	}
 

--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -80,6 +80,26 @@ func TestConvertAlterTableStatements(t *testing.T) {
 			sql:        "ALTER TABLE foo DROP COLUMN bar RESTRICT ",
 			expectedOp: expect.DropColumnOp1,
 		},
+		{
+			sql:        "ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d);",
+			expectedOp: expect.AddForeignKeyOp1,
+		},
+		{
+			sql:        "ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON DELETE NO ACTION;",
+			expectedOp: expect.AddForeignKeyOp1,
+		},
+		{
+			sql:        "ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON DELETE RESTRICT;",
+			expectedOp: expect.AddForeignKeyOp2,
+		},
+		{
+			sql:        "ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON DELETE SET DEFAULT ;",
+			expectedOp: expect.AddForeignKeyOp3,
+		},
+		{
+			sql:        "ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON DELETE SET NULL;",
+			expectedOp: expect.AddForeignKeyOp4,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/sql2pgroll/expect/add_foreign_key.go
+++ b/pkg/sql2pgroll/expect/add_foreign_key.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package expect
+
+import (
+	"github.com/xataio/pgroll/pkg/migrations"
+	"github.com/xataio/pgroll/pkg/sql2pgroll"
+)
+
+var AddForeignKeyOp1 = &migrations.OpCreateConstraint{
+	Check:   nil,
+	Columns: []string{"a", "b"},
+	Name:    "fk_bar_cd",
+	References: &migrations.OpCreateConstraintReferences{
+		Columns:  []string{"c", "d"},
+		OnDelete: migrations.ForeignKeyReferenceOnDeleteNOACTION,
+		Table:    "bar",
+	},
+	Table: "foo",
+	Type:  migrations.OpCreateConstraintTypeForeignKey,
+	Up: map[string]string{
+		"a": sql2pgroll.PlaceHolderSQL,
+		"b": sql2pgroll.PlaceHolderSQL,
+	},
+	Down: map[string]string{
+		"a": sql2pgroll.PlaceHolderSQL,
+		"b": sql2pgroll.PlaceHolderSQL,
+	},
+}
+
+var AddForeignKeyOp2 = &migrations.OpCreateConstraint{
+	Check:   nil,
+	Columns: []string{"a", "b"},
+	Name:    "fk_bar_cd",
+	References: &migrations.OpCreateConstraintReferences{
+		Columns:  []string{"c", "d"},
+		OnDelete: migrations.ForeignKeyReferenceOnDeleteRESTRICT,
+		Table:    "bar",
+	},
+	Table: "foo",
+	Type:  migrations.OpCreateConstraintTypeForeignKey,
+	Up: map[string]string{
+		"a": sql2pgroll.PlaceHolderSQL,
+		"b": sql2pgroll.PlaceHolderSQL,
+	},
+	Down: map[string]string{
+		"a": sql2pgroll.PlaceHolderSQL,
+		"b": sql2pgroll.PlaceHolderSQL,
+	},
+}
+
+var AddForeignKeyOp3 = &migrations.OpCreateConstraint{
+	Check:   nil,
+	Columns: []string{"a", "b"},
+	Name:    "fk_bar_cd",
+	References: &migrations.OpCreateConstraintReferences{
+		Columns:  []string{"c", "d"},
+		OnDelete: migrations.ForeignKeyReferenceOnDeleteSETDEFAULT,
+		Table:    "bar",
+	},
+	Table: "foo",
+	Type:  migrations.OpCreateConstraintTypeForeignKey,
+	Up: map[string]string{
+		"a": sql2pgroll.PlaceHolderSQL,
+		"b": sql2pgroll.PlaceHolderSQL,
+	},
+	Down: map[string]string{
+		"a": sql2pgroll.PlaceHolderSQL,
+		"b": sql2pgroll.PlaceHolderSQL,
+	},
+}
+
+var AddForeignKeyOp4 = &migrations.OpCreateConstraint{
+	Check:   nil,
+	Columns: []string{"a", "b"},
+	Name:    "fk_bar_cd",
+	References: &migrations.OpCreateConstraintReferences{
+		Columns:  []string{"c", "d"},
+		OnDelete: migrations.ForeignKeyReferenceOnDeleteSETNULL,
+		Table:    "bar",
+	},
+	Table: "foo",
+	Type:  migrations.OpCreateConstraintTypeForeignKey,
+	Up: map[string]string{
+		"a": sql2pgroll.PlaceHolderSQL,
+		"b": sql2pgroll.PlaceHolderSQL,
+	},
+	Down: map[string]string{
+		"a": sql2pgroll.PlaceHolderSQL,
+		"b": sql2pgroll.PlaceHolderSQL,
+	},
+}

--- a/pkg/sql2pgroll/expect/add_foreign_key.go
+++ b/pkg/sql2pgroll/expect/add_foreign_key.go
@@ -7,86 +7,25 @@ import (
 	"github.com/xataio/pgroll/pkg/sql2pgroll"
 )
 
-var AddForeignKeyOp1 = &migrations.OpCreateConstraint{
-	Check:   nil,
-	Columns: []string{"a", "b"},
-	Name:    "fk_bar_cd",
-	References: &migrations.OpCreateConstraintReferences{
-		Columns:  []string{"c", "d"},
-		OnDelete: migrations.ForeignKeyReferenceOnDeleteNOACTION,
-		Table:    "bar",
-	},
-	Table: "foo",
-	Type:  migrations.OpCreateConstraintTypeForeignKey,
-	Up: map[string]string{
-		"a": sql2pgroll.PlaceHolderSQL,
-		"b": sql2pgroll.PlaceHolderSQL,
-	},
-	Down: map[string]string{
-		"a": sql2pgroll.PlaceHolderSQL,
-		"b": sql2pgroll.PlaceHolderSQL,
-	},
-}
-
-var AddForeignKeyOp2 = &migrations.OpCreateConstraint{
-	Check:   nil,
-	Columns: []string{"a", "b"},
-	Name:    "fk_bar_cd",
-	References: &migrations.OpCreateConstraintReferences{
-		Columns:  []string{"c", "d"},
-		OnDelete: migrations.ForeignKeyReferenceOnDeleteRESTRICT,
-		Table:    "bar",
-	},
-	Table: "foo",
-	Type:  migrations.OpCreateConstraintTypeForeignKey,
-	Up: map[string]string{
-		"a": sql2pgroll.PlaceHolderSQL,
-		"b": sql2pgroll.PlaceHolderSQL,
-	},
-	Down: map[string]string{
-		"a": sql2pgroll.PlaceHolderSQL,
-		"b": sql2pgroll.PlaceHolderSQL,
-	},
-}
-
-var AddForeignKeyOp3 = &migrations.OpCreateConstraint{
-	Check:   nil,
-	Columns: []string{"a", "b"},
-	Name:    "fk_bar_cd",
-	References: &migrations.OpCreateConstraintReferences{
-		Columns:  []string{"c", "d"},
-		OnDelete: migrations.ForeignKeyReferenceOnDeleteSETDEFAULT,
-		Table:    "bar",
-	},
-	Table: "foo",
-	Type:  migrations.OpCreateConstraintTypeForeignKey,
-	Up: map[string]string{
-		"a": sql2pgroll.PlaceHolderSQL,
-		"b": sql2pgroll.PlaceHolderSQL,
-	},
-	Down: map[string]string{
-		"a": sql2pgroll.PlaceHolderSQL,
-		"b": sql2pgroll.PlaceHolderSQL,
-	},
-}
-
-var AddForeignKeyOp4 = &migrations.OpCreateConstraint{
-	Check:   nil,
-	Columns: []string{"a", "b"},
-	Name:    "fk_bar_cd",
-	References: &migrations.OpCreateConstraintReferences{
-		Columns:  []string{"c", "d"},
-		OnDelete: migrations.ForeignKeyReferenceOnDeleteSETNULL,
-		Table:    "bar",
-	},
-	Table: "foo",
-	Type:  migrations.OpCreateConstraintTypeForeignKey,
-	Up: map[string]string{
-		"a": sql2pgroll.PlaceHolderSQL,
-		"b": sql2pgroll.PlaceHolderSQL,
-	},
-	Down: map[string]string{
-		"a": sql2pgroll.PlaceHolderSQL,
-		"b": sql2pgroll.PlaceHolderSQL,
-	},
+func AddForeignKeyOp1WithOnDelete(onDelete migrations.ForeignKeyReferenceOnDelete) *migrations.OpCreateConstraint {
+	return &migrations.OpCreateConstraint{
+		Check:   nil,
+		Columns: []string{"a", "b"},
+		Name:    "fk_bar_cd",
+		References: &migrations.OpCreateConstraintReferences{
+			Columns:  []string{"c", "d"},
+			OnDelete: onDelete,
+			Table:    "bar",
+		},
+		Table: "foo",
+		Type:  migrations.OpCreateConstraintTypeForeignKey,
+		Up: map[string]string{
+			"a": sql2pgroll.PlaceHolderSQL,
+			"b": sql2pgroll.PlaceHolderSQL,
+		},
+		Down: map[string]string{
+			"a": sql2pgroll.PlaceHolderSQL,
+			"b": sql2pgroll.PlaceHolderSQL,
+		},
+	}
 }

--- a/pkg/sql2pgroll/expect/add_foreign_key.go
+++ b/pkg/sql2pgroll/expect/add_foreign_key.go
@@ -9,7 +9,6 @@ import (
 
 func AddForeignKeyOp1WithOnDelete(onDelete migrations.ForeignKeyReferenceOnDelete) *migrations.OpCreateConstraint {
 	return &migrations.OpCreateConstraint{
-		Check:   nil,
 		Columns: []string{"a", "b"},
 		Name:    "fk_bar_cd",
 		References: &migrations.OpCreateConstraintReferences{
@@ -28,4 +27,22 @@ func AddForeignKeyOp1WithOnDelete(onDelete migrations.ForeignKeyReferenceOnDelet
 			"b": sql2pgroll.PlaceHolderSQL,
 		},
 	}
+}
+
+var AddForeignKeyOp2 = &migrations.OpCreateConstraint{
+	Columns: []string{"a"},
+	Name:    "fk_bar_c",
+	References: &migrations.OpCreateConstraintReferences{
+		Columns:  []string{"c"},
+		OnDelete: migrations.ForeignKeyReferenceOnDeleteNOACTION,
+		Table:    "bar",
+	},
+	Table: "foo",
+	Type:  migrations.OpCreateConstraintTypeForeignKey,
+	Up: map[string]string{
+		"a": sql2pgroll.PlaceHolderSQL,
+	},
+	Down: map[string]string{
+		"a": sql2pgroll.PlaceHolderSQL,
+	},
 }

--- a/pkg/sql2pgroll/expect/add_foreign_key.go
+++ b/pkg/sql2pgroll/expect/add_foreign_key.go
@@ -46,3 +46,21 @@ var AddForeignKeyOp2 = &migrations.OpCreateConstraint{
 		"a": sql2pgroll.PlaceHolderSQL,
 	},
 }
+
+var AddForeignKeyOp3 = &migrations.OpCreateConstraint{
+	Columns: []string{"a"},
+	Name:    "fk_bar_c",
+	References: &migrations.OpCreateConstraintReferences{
+		Columns:  []string{"c"},
+		OnDelete: migrations.ForeignKeyReferenceOnDeleteNOACTION,
+		Table:    "schema_a.bar",
+	},
+	Table: "schema_a.foo",
+	Type:  migrations.OpCreateConstraintTypeForeignKey,
+	Up: map[string]string{
+		"a": sql2pgroll.PlaceHolderSQL,
+	},
+	Down: map[string]string{
+		"a": sql2pgroll.PlaceHolderSQL,
+	},
+}


### PR DESCRIPTION
Supports translating statements in the following forms:

```sql
ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d)
ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON DELETE NO ACTION
ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON DELETE RESTRICT
ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON DELETE SET DEFAULT
ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON DELETE SET NULL
ALTER TABLE foo ADD CONSTRAINT fk_bar_c FOREIGN KEY (a) REFERENCES bar (c)
ALTER TABLE schema.foo ADD CONSTRAINT fk_bar_c FOREIGN KEY (a) REFERENCES schema.bar (c)
```

The following fall back to raw SQL:

```sql
ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON UPDATE RESTRICT;
ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON UPDATE CASCADE;
ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON UPDATE SET NULL;
ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON UPDATE SET DEFAULT;
ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) MATCH FULL;
```

Part of https://github.com/xataio/pgroll/issues/504