### PR TITLE
Fix `sql2pgrol`l conversion of string `DEFAULT` expressions

### DIFF
--- a/pkg/sql2pgroll/alter_table.go
+++ b/pkg/sql2pgroll/alter_table.go
@@ -276,7 +276,7 @@ func convertAlterTableSetColumnDefault(stmt *pgq.AlterTableStmt, cmd *pgq.AlterT
 		// We have a constant
 		switch v := c.GetVal().(type) {
 		case *pgq.A_Const_Sval:
-			operation.Default = nullable.NewNullableWithValue(v.Sval.GetSval())
+			operation.Default = nullable.NewNullableWithValue(fmt.Sprintf("'%s'", v.Sval.GetSval()))
 		case *pgq.A_Const_Ival:
 			operation.Default = nullable.NewNullableWithValue(strconv.FormatInt(int64(v.Ival.Ival), 10))
 		case *pgq.A_Const_Fval:
@@ -284,7 +284,7 @@ func convertAlterTableSetColumnDefault(stmt *pgq.AlterTableStmt, cmd *pgq.AlterT
 		case *pgq.A_Const_Boolval:
 			operation.Default = nullable.NewNullableWithValue(strconv.FormatBool(v.Boolval.Boolval))
 		case *pgq.A_Const_Bsval:
-			operation.Default = nullable.NewNullableWithValue(v.Bsval.Bsval)
+			operation.Default = nullable.NewNullableWithValue(fmt.Sprintf("'%s'", v.Bsval.GetBsval()))
 		default:
 			return nil, fmt.Errorf("unknown constant type: %T", c.GetVal())
 		}

--- a/pkg/sql2pgroll/expect/alter_column.go
+++ b/pkg/sql2pgroll/expect/alter_column.go
@@ -42,7 +42,7 @@ var AlterColumnOp4 = &migrations.OpAlterColumn{
 var AlterColumnOp5 = &migrations.OpAlterColumn{
 	Table:   "foo",
 	Column:  "bar",
-	Default: nullable.NewNullableWithValue("baz"),
+	Default: nullable.NewNullableWithValue("'baz'"),
 	Up:      sql2pgroll.PlaceHolderSQL,
 	Down:    sql2pgroll.PlaceHolderSQL,
 }
@@ -82,7 +82,7 @@ var AlterColumnOp9 = &migrations.OpAlterColumn{
 var AlterColumnOp10 = &migrations.OpAlterColumn{
 	Table:   "foo",
 	Column:  "bar",
-	Default: nullable.NewNullableWithValue("b0101"),
+	Default: nullable.NewNullableWithValue("'b0101'"),
 	Up:      sql2pgroll.PlaceHolderSQL,
 	Down:    sql2pgroll.PlaceHolderSQL,
 }


### PR DESCRIPTION
Column `DEFAULT` expressions for strings and bitstrings need to quoted, otherwise they are interpreted as identifiers.

Update the test expectations and the conversion code to quote the values.