### PR TITLE
Use `xataio` fork of `pg_query_go` package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/cloudflare/backoff v0.0.0-20240920015135-e46b80a3a7d0
 	github.com/lib/pq v1.10.9
 	github.com/oapi-codegen/nullable v1.1.0
-	github.com/pganalyze/pg_query_go/v6 v6.0.0
 	github.com/pterm/pterm v0.12.80
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/cobra v1.8.1
@@ -14,6 +13,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.34.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.34.0
+	github.com/xataio/pg_query_go/v6 v6.0.0-20241216080535-894186571799
 	golang.org/x/tools v0.28.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,6 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
-github.com/pganalyze/pg_query_go/v6 v6.0.0 h1:in6RkR/apfqlAtvqgDxd4Y4o87a5Pr8fkKDB4DrDo2c=
-github.com/pganalyze/pg_query_go/v6 v6.0.0/go.mod h1:nvTHIuoud6e1SfrUaFwHqT0i4b5Nr+1rPWVds3B5+50=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -219,6 +217,8 @@ github.com/tklauser/go-sysconf v0.3.14 h1:g5vzr9iPFFz24v2KZXs/pvpvh8/V9Fw6vQK5ZZ
 github.com/tklauser/go-sysconf v0.3.14/go.mod h1:1ym4lWMLUOhuBOPGtRcJm7tEGX4SCYNEEEtghGG/8uY=
 github.com/tklauser/numcpus v0.8.0 h1:Mx4Wwe/FjZLeQsK/6kt2EOepwwSl7SmJrK5bV/dXYgY=
 github.com/tklauser/numcpus v0.8.0/go.mod h1:ZJZlAY+dmR4eut8epnzf0u/VwodKmryxR8txiloSqBE=
+github.com/xataio/pg_query_go/v6 v6.0.0-20241216080535-894186571799 h1:FUY7PHaOXMicK0kSh32BdLGwd6svrbNZrnup69jG0DM=
+github.com/xataio/pg_query_go/v6 v6.0.0-20241216080535-894186571799/go.mod h1:GK6bpfAhPtZb7wG/IccqvnH+cz3cmvvRTkC+MosESGo=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=

--- a/pkg/sql2pgroll/alter_table.go
+++ b/pkg/sql2pgroll/alter_table.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	"github.com/oapi-codegen/nullable"
-	pgq "github.com/pganalyze/pg_query_go/v6"
+	pgq "github.com/xataio/pg_query_go/v6"
 
 	"github.com/xataio/pgroll/pkg/migrations"
 )

--- a/pkg/sql2pgroll/convert.go
+++ b/pkg/sql2pgroll/convert.go
@@ -5,7 +5,7 @@ package sql2pgroll
 import (
 	"fmt"
 
-	pgq "github.com/pganalyze/pg_query_go/v6"
+	pgq "github.com/xataio/pg_query_go/v6"
 
 	"github.com/xataio/pgroll/pkg/migrations"
 )

--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -3,7 +3,7 @@
 package sql2pgroll
 
 import (
-	pgq "github.com/pganalyze/pg_query_go/v6"
+	pgq "github.com/xataio/pg_query_go/v6"
 
 	"github.com/xataio/pgroll/pkg/migrations"
 )

--- a/pkg/sql2pgroll/drop.go
+++ b/pkg/sql2pgroll/drop.go
@@ -5,7 +5,7 @@ package sql2pgroll
 import (
 	"strings"
 
-	pgq "github.com/pganalyze/pg_query_go/v6"
+	pgq "github.com/xataio/pg_query_go/v6"
 
 	"github.com/xataio/pgroll/pkg/migrations"
 )

--- a/pkg/sql2pgroll/rename.go
+++ b/pkg/sql2pgroll/rename.go
@@ -3,7 +3,7 @@
 package sql2pgroll
 
 import (
-	pgq "github.com/pganalyze/pg_query_go/v6"
+	pgq "github.com/xataio/pg_query_go/v6"
 
 	"github.com/xataio/pgroll/pkg/migrations"
 )

--- a/pkg/sql2pgroll/typename.go
+++ b/pkg/sql2pgroll/typename.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	pgq "github.com/pganalyze/pg_query_go/v6"
+	pgq "github.com/xataio/pg_query_go/v6"
 )
 
 // convertTypeName converts a TypeName node to a string.


### PR DESCRIPTION
Switch the `pg_query_go` dependency from https://github.com/pganalyze/pg_query_go to the fork at https://github.com/xataio/pg_query_go

The forked version adds a new `DeparseExpr` function for deparsing expression nodes (see https://github.com/xataio/pg_query_go/pull/1). This will expand the range of SQL DDL statements that `sql2pgroll` is able to convert to `pgroll` migrations.

Part of #504 