### PR TITLE
Use expression deparsing to convert column `DEFAULT` expressions

### DIFF
--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -65,6 +65,10 @@ func TestConvertAlterTableStatements(t *testing.T) {
 			expectedOp: expect.AlterColumnOp7,
 		},
 		{
+			sql:        "ALTER TABLE foo ALTER COLUMN bar SET DEFAULT now()",
+			expectedOp: expect.AlterColumnOp11,
+		},
+		{
 			sql:        "ALTER TABLE foo ADD CONSTRAINT bar UNIQUE (a)",
 			expectedOp: expect.CreateConstraintOp1,
 		},
@@ -145,9 +149,6 @@ func TestUnconvertableAlterTableStatements(t *testing.T) {
 		// CASCADE and IF EXISTS clauses are not represented by OpDropColumn
 		"ALTER TABLE foo DROP COLUMN bar CASCADE",
 		"ALTER TABLE foo DROP COLUMN IF EXISTS bar",
-
-		// Non literal default values
-		"ALTER TABLE foo ALTER COLUMN bar SET DEFAULT now()",
 
 		// Unsupported foreign key statements
 		"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON UPDATE RESTRICT;",

--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -69,6 +69,10 @@ func TestConvertAlterTableStatements(t *testing.T) {
 			expectedOp: expect.AlterColumnOp11,
 		},
 		{
+			sql:        "ALTER TABLE foo ALTER COLUMN bar SET DEFAULT (first_name || ' ' || last_name)",
+			expectedOp: expect.AlterColumnOp12,
+		},
+		{
 			sql:        "ALTER TABLE foo ADD CONSTRAINT bar UNIQUE (a)",
 			expectedOp: expect.CreateConstraintOp1,
 		},

--- a/pkg/sql2pgroll/expect/alter_column.go
+++ b/pkg/sql2pgroll/expect/alter_column.go
@@ -82,7 +82,19 @@ var AlterColumnOp9 = &migrations.OpAlterColumn{
 var AlterColumnOp10 = &migrations.OpAlterColumn{
 	Table:   "foo",
 	Column:  "bar",
-	Default: nullable.NewNullableWithValue("'b0101'"),
+	Default: nullable.NewNullableWithValue("b'0101'"),
+	Up:      sql2pgroll.PlaceHolderSQL,
+	Down:    sql2pgroll.PlaceHolderSQL,
+}
+
+var AlterColumnOp11 = &migrations.OpAlterColumn{
+	Table:   "foo",
+	Column:  "bar",
+	Default: nullable.NewNullableWithValue("now()"),
+	Up:      sql2pgroll.PlaceHolderSQL,
+	Down:    sql2pgroll.PlaceHolderSQL,
+}
+
 	Up:      sql2pgroll.PlaceHolderSQL,
 	Down:    sql2pgroll.PlaceHolderSQL,
 }

--- a/pkg/sql2pgroll/expect/alter_column.go
+++ b/pkg/sql2pgroll/expect/alter_column.go
@@ -95,6 +95,10 @@ var AlterColumnOp11 = &migrations.OpAlterColumn{
 	Down:    sql2pgroll.PlaceHolderSQL,
 }
 
+var AlterColumnOp12 = &migrations.OpAlterColumn{
+	Table:   "foo",
+	Column:  "bar",
+	Default: nullable.NewNullableWithValue("(first_name || ' ') || last_name"),
 	Up:      sql2pgroll.PlaceHolderSQL,
 	Down:    sql2pgroll.PlaceHolderSQL,
 }


### PR DESCRIPTION
Deparse column `DEFAULT` expressions using `pg_query_go.DeparseExpr` to allow conversion of arbitrary expressions in column `DEFAULT`s to `pgroll` migrations.

Replace manual deparsing of literal nodes with use of `DeparseExpr` to allow deparsing of any column `DEFAULT` expression.

Update test cases:
* `ALTER TABLE foo ALTER COLUMN bar SET DEFAULT now()` is now representable as an `OpAlterColumn`; no need to fall back to raw SQL anymore.
* Add a new testcase: `ALTER TABLE foo ALTER COLUMN bar SET DEFAULT (first_name || ' ' || last_name)` to demonstrate conversion of a column `DEFAULT` using a more complex expression.

Part of #504 