### PR TITLE
Convert DROP CONSTRAINT SQL into OpDropMultiColumnConstraint operations

### DIFF
--- a/pkg/migrations/rename.go
+++ b/pkg/migrations/rename.go
@@ -14,8 +14,8 @@ import (
 )
 
 // RenameDuplicatedColumn
-// * renames a duplicated column to its original name
-// * renames any foreign keys on the duplicated column to their original name.
+// * Renames a duplicated column to its original name
+// * Renames any foreign keys on the duplicated column to their original name.
 // * Validates and renames any temporary `CHECK` constraints on the duplicated column.
 func RenameDuplicatedColumn(ctx context.Context, conn db.DB, table *schema.Table, column *schema.Column) error {
 	const (

--- a/pkg/sql2pgroll/alter_table.go
+++ b/pkg/sql2pgroll/alter_table.go
@@ -42,6 +42,8 @@ func convertAlterTableStmt(stmt *pgq.AlterTableStmt) (migrations.Operations, err
 			op, err = convertAlterTableDropColumn(stmt, alterTableCmd)
 		case pgq.AlterTableType_AT_ColumnDefault:
 			op, err = convertAlterTableSetColumnDefault(stmt, alterTableCmd)
+		case pgq.AlterTableType_AT_DropConstraint:
+			op, err = convertAlterTableDropConstraint(stmt, alterTableCmd)
 		}
 
 		if err != nil {
@@ -305,6 +307,37 @@ func convertAlterTableSetColumnDefault(stmt *pgq.AlterTableStmt, cmd *pgq.AlterT
 
 	// Unknown case, fall back to raw SQL
 	return nil, nil
+}
+
+// convertAlterTableDropConstraint convert DROP CONSTRAINT SQL into an OpDropMultiColumnConstraint.
+// Because we are unable to infer the columns involved, placeholder migrations are used.
+//
+// SQL statements like the following are supported:
+//
+// `ALTER TABLE foo DROP CONSTRAINT constraint_foo`
+// `ALTER TABLE foo DROP CONSTRAINT IF EXISTS constraint_foo`
+// `ALTER TABLE foo DROP CONSTRAINT IF EXISTS constraint_foo RESTRICT`
+//
+// CASCADE is currently not supported and will fall back to raw SQL
+func convertAlterTableDropConstraint(stmt *pgq.AlterTableStmt, cmd *pgq.AlterTableCmd) (migrations.Operation, error) {
+	if !canConvertDropConstraint(cmd) {
+		return nil, nil
+	}
+
+	return &migrations.OpDropMultiColumnConstraint{
+		Up: migrations.MultiColumnUpSQL{
+			"placeholder": PlaceHolderSQL,
+		},
+		Down: migrations.MultiColumnDownSQL{
+			"placeholder": PlaceHolderSQL,
+		},
+		Table: stmt.GetRelation().GetRelname(),
+		Name:  cmd.GetName(),
+	}, nil
+}
+
+func canConvertDropConstraint(cmd *pgq.AlterTableCmd) bool {
+	return cmd.Behavior != pgq.DropBehavior_DROP_CASCADE
 }
 
 func convertAlterTableDropColumn(stmt *pgq.AlterTableStmt, cmd *pgq.AlterTableCmd) (migrations.Operation, error) {

--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -112,6 +112,18 @@ func TestConvertAlterTableStatements(t *testing.T) {
 			sql:        "ALTER TABLE schema_a.foo ADD CONSTRAINT fk_bar_c FOREIGN KEY (a) REFERENCES schema_a.bar (c);",
 			expectedOp: expect.AddForeignKeyOp3,
 		},
+		{
+			sql:        "ALTER TABLE foo DROP CONSTRAINT constraint_foo",
+			expectedOp: expect.OpDropConstraint1,
+		},
+		{
+			sql:        "ALTER TABLE foo DROP CONSTRAINT IF EXISTS constraint_foo",
+			expectedOp: expect.OpDropConstraint1,
+		},
+		{
+			sql:        "ALTER TABLE foo DROP CONSTRAINT IF EXISTS constraint_foo RESTRICT",
+			expectedOp: expect.OpDropConstraint1,
+		},
 	}
 
 	for _, tc := range tests {
@@ -157,6 +169,9 @@ func TestUnconvertableAlterTableStatements(t *testing.T) {
 		"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) MATCH FULL;",
 		// MATCH PARTIAL is not implemented in the actual parser yet
 		//"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) MATCH PARTIAL;",
+
+		// Drop constraint with CASCADE
+		"ALTER TABLE foo DROP CONSTRAINT bar CASCADE",
 	}
 
 	for _, sql := range tests {

--- a/pkg/sql2pgroll/expect/drop_constraint.go
+++ b/pkg/sql2pgroll/expect/drop_constraint.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package expect
+
+import (
+	"github.com/xataio/pgroll/pkg/migrations"
+	"github.com/xataio/pgroll/pkg/sql2pgroll"
+)
+
+var OpDropConstraint1 = &migrations.OpDropMultiColumnConstraint{
+	Up: migrations.MultiColumnUpSQL{
+		"placeholder": sql2pgroll.PlaceHolderSQL,
+	},
+	Down: migrations.MultiColumnDownSQL{
+		"placeholder": sql2pgroll.PlaceHolderSQL,
+	},
+	Table: "foo",
+	Name:  "constraint_foo",
+}


### PR DESCRIPTION
Convert `DROP CONSTRAINT SQL` into an `OpDropMultiColumnConstraint`.
Because we are unable to infer the columns involved, placeholder migrations are used.

SQL statements like the following are supported:

```sql
ALTER TABLE foo DROP CONSTRAINT constraint_foo
ALTER TABLE foo DROP CONSTRAINT IF EXISTS constraint_foo
ALTER TABLE foo DROP CONSTRAINT IF EXISTS constraint_foo RESTRICT
```

`CASCADE` is currently not supported and will fall back to raw SQL

Part of https://github.com/xataio/pgroll/issues/504