### PR TITLE
Convert `ALTER TABLE ... ADD CONSTRAINT ... CHECK` SQL to `pgroll` operation

### DIFF
--- a/pkg/sql2pgroll/alter_table.go
+++ b/pkg/sql2pgroll/alter_table.go
@@ -370,10 +370,10 @@ func convertAlterTableDropConstraint(stmt *pgq.AlterTableStmt, cmd *pgq.AlterTab
 
 	return &migrations.OpDropMultiColumnConstraint{
 		Up: migrations.MultiColumnUpSQL{
-			"placeholder": PlaceHolderSQL,
+			PlaceHolderColumnName: PlaceHolderSQL,
 		},
 		Down: migrations.MultiColumnDownSQL{
-			"placeholder": PlaceHolderSQL,
+			PlaceHolderColumnName: PlaceHolderSQL,
 		},
 		Table: tableName,
 		Name:  cmd.GetName(),

--- a/pkg/sql2pgroll/alter_table.go
+++ b/pkg/sql2pgroll/alter_table.go
@@ -235,6 +235,10 @@ func convertAlterTableAddForeignKeyConstraint(stmt *pgq.AlterTableStmt, constrai
 }
 
 func canConvertAlterTableAddForeignKeyConstraint(constraint *pgq.Constraint) bool {
+	if constraint.SkipValidation {
+		return false
+	}
+
 	switch constraint.GetFkUpdAction() {
 	case "r", "c", "n", "d":
 		// RESTRICT, CASCADE, SET NULL, SET DEFAULT

--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -136,6 +136,14 @@ func TestConvertAlterTableStatements(t *testing.T) {
 			sql:        "ALTER TABLE foo DROP CONSTRAINT IF EXISTS constraint_foo RESTRICT",
 			expectedOp: expect.OpDropConstraintWithTable("foo"),
 		},
+		{
+			sql:        "ALTER TABLE foo ADD CONSTRAINT bar CHECK (age > 0)",
+			expectedOp: expect.CreateConstraintOp3,
+		},
+		{
+			sql:        "ALTER TABLE schema.foo ADD CONSTRAINT bar CHECK (age > 0)",
+			expectedOp: expect.CreateConstraintOp4,
+		},
 	}
 
 	for _, tc := range tests {
@@ -181,6 +189,11 @@ func TestUnconvertableAlterTableStatements(t *testing.T) {
 
 		// Drop constraint with CASCADE
 		"ALTER TABLE foo DROP CONSTRAINT bar CASCADE",
+
+		// NO INHERIT and NOT VALID options on CHECK constraints are not
+		// representable by `OpCreateConstraint`
+		"ALTER TABLE foo ADD CONSTRAINT bar CHECK (age > 0) NO INHERIT",
+		"ALTER TABLE foo ADD CONSTRAINT bar CHECK (age > 0) NOT VALID",
 	}
 
 	for _, sql := range tests {

--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -113,10 +113,6 @@ func TestConvertAlterTableStatements(t *testing.T) {
 			expectedOp: expect.AddForeignKeyOp2,
 		},
 		{
-			sql:        "ALTER TABLE foo ADD CONSTRAINT fk_bar_c FOREIGN KEY (a) REFERENCES bar (c) NOT VALID;",
-			expectedOp: expect.AddForeignKeyOp2,
-		},
-		{
 			sql:        "ALTER TABLE schema_a.foo ADD CONSTRAINT fk_bar_c FOREIGN KEY (a) REFERENCES schema_a.bar (c);",
 			expectedOp: expect.AddForeignKeyOp3,
 		},
@@ -184,6 +180,7 @@ func TestUnconvertableAlterTableStatements(t *testing.T) {
 		"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON UPDATE SET NULL;",
 		"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON UPDATE SET DEFAULT;",
 		"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) MATCH FULL;",
+		"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) NOT VALID",
 		// MATCH PARTIAL is not implemented in the actual parser yet
 		//"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) MATCH PARTIAL;",
 

--- a/pkg/sql2pgroll/expect/create_constraint.go
+++ b/pkg/sql2pgroll/expect/create_constraint.go
@@ -30,3 +30,31 @@ var CreateConstraintOp2 = &migrations.OpCreateConstraint{
 		"b": sql2pgroll.PlaceHolderSQL,
 	},
 }
+
+var CreateConstraintOp3 = &migrations.OpCreateConstraint{
+	Type:    migrations.OpCreateConstraintTypeCheck,
+	Name:    "bar",
+	Table:   "foo",
+	Check:   ptr("age > 0"),
+	Columns: []string{sql2pgroll.PlaceHolderColumnName},
+	Up: map[string]string{
+		sql2pgroll.PlaceHolderColumnName: sql2pgroll.PlaceHolderSQL,
+	},
+	Down: map[string]string{
+		sql2pgroll.PlaceHolderColumnName: sql2pgroll.PlaceHolderSQL,
+	},
+}
+
+var CreateConstraintOp4 = &migrations.OpCreateConstraint{
+	Type:    migrations.OpCreateConstraintTypeCheck,
+	Name:    "bar",
+	Table:   "schema.foo",
+	Check:   ptr("age > 0"),
+	Columns: []string{sql2pgroll.PlaceHolderColumnName},
+	Up: map[string]string{
+		sql2pgroll.PlaceHolderColumnName: sql2pgroll.PlaceHolderSQL,
+	},
+	Down: map[string]string{
+		sql2pgroll.PlaceHolderColumnName: sql2pgroll.PlaceHolderSQL,
+	},
+}

--- a/pkg/sql2pgroll/expect/drop_constraint.go
+++ b/pkg/sql2pgroll/expect/drop_constraint.go
@@ -10,10 +10,10 @@ import (
 func OpDropConstraintWithTable(table string) *migrations.OpDropMultiColumnConstraint {
 	return &migrations.OpDropMultiColumnConstraint{
 		Up: migrations.MultiColumnUpSQL{
-			"placeholder": sql2pgroll.PlaceHolderSQL,
+			sql2pgroll.PlaceHolderColumnName: sql2pgroll.PlaceHolderSQL,
 		},
 		Down: migrations.MultiColumnDownSQL{
-			"placeholder": sql2pgroll.PlaceHolderSQL,
+			sql2pgroll.PlaceHolderColumnName: sql2pgroll.PlaceHolderSQL,
 		},
 		Table: table,
 		Name:  "constraint_foo",


### PR DESCRIPTION
Convert SQL statements like:

```sql
ALTER TABLE foo ADD CONSTRAINT bar CHECK (age > 0)
```

to the equivalent `pgroll` operation:

```json
[
  {
    "create_constraint": {
      "check": "age > 0",
      "columns": [
        "placeholder"
      ],
      "down": {
        "placeholder": "TODO: Implement SQL data migration"
      },
      "name": "bar",
      "table": "foo",
      "type": "check",
      "up": {
        "placeholder": "TODO: Implement SQL data migration"
      }
    }
  }
]
```

As we don't currently have a reliable way of extracting the columns covered by the constraint from the the `CHECK` SQL expression, the converted `pgroll` operation uses placeholders for the `columns`, `up` and `down` fields.

Some forms of the statement are not currently representable by the `create_constraint` operation. For these a raw SQL migration is generated:

```sql
"ALTER TABLE foo ADD CONSTRAINT bar CHECK (age > 0) NO INHERIT",
"ALTER TABLE foo ADD CONSTRAINT bar CHECK (age > 0) NOT VALID",
```