### PR TITLE
Fall back to raw SQL for `NOT VALID` foreign key constraints

### DIFF
--- a/pkg/sql2pgroll/alter_table.go
+++ b/pkg/sql2pgroll/alter_table.go
@@ -235,6 +235,10 @@ func convertAlterTableAddForeignKeyConstraint(stmt *pgq.AlterTableStmt, constrai
 }
 
 func canConvertAlterTableAddForeignKeyConstraint(constraint *pgq.Constraint) bool {
+	if constraint.SkipValidation {
+		return false
+	}
+
 	switch constraint.GetFkUpdAction() {
 	case "r", "c", "n", "d":
 		// RESTRICT, CASCADE, SET NULL, SET DEFAULT

--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -113,10 +113,6 @@ func TestConvertAlterTableStatements(t *testing.T) {
 			expectedOp: expect.AddForeignKeyOp2,
 		},
 		{
-			sql:        "ALTER TABLE foo ADD CONSTRAINT fk_bar_c FOREIGN KEY (a) REFERENCES bar (c) NOT VALID;",
-			expectedOp: expect.AddForeignKeyOp2,
-		},
-		{
 			sql:        "ALTER TABLE schema_a.foo ADD CONSTRAINT fk_bar_c FOREIGN KEY (a) REFERENCES schema_a.bar (c);",
 			expectedOp: expect.AddForeignKeyOp3,
 		},
@@ -184,6 +180,7 @@ func TestUnconvertableAlterTableStatements(t *testing.T) {
 		"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON UPDATE SET NULL;",
 		"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) ON UPDATE SET DEFAULT;",
 		"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) MATCH FULL;",
+		"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) NOT VALID",
 		// MATCH PARTIAL is not implemented in the actual parser yet
 		//"ALTER TABLE foo ADD CONSTRAINT fk_bar_cd FOREIGN KEY (a, b) REFERENCES bar (c, d) MATCH PARTIAL;",
 


### PR DESCRIPTION
Update how `sql2pgroll` handles conversion of `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY` statements.

Fall back to raw SQL if `NOT VALID` is specified as part of an `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY` statement because `OpCreateMultiColumnConstraint`  currently always validates foreign key constraints. 
