### PR TITLE
Use `omissis/go-jsonschema` image for type generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,7 @@ format:
 
 generate: format
 	# Generate the types from the JSON schema
-	# Temporarily use the `surjection/go-jsonschema` image because we need https://github.com/omissis/go-jsonschema/pull/220
-	# Use the official `omissis/gojsonschema` image once 0.17.0 is released.
-	docker run --rm -v $$PWD/schema.json:/mnt/schema.json surjection/go-jsonschema:0.16.1 --only-models -p migrations --tags json /mnt/schema.json > pkg/migrations/types.go
+	docker run --rm -v $$PWD/schema.json:/mnt/schema.json omissis/go-jsonschema:0.17.0 --only-models -p migrations --tags json /mnt/schema.json > pkg/migrations/types.go
 	
 	# Add the license header
 	echo "// SPDX-License-Identifier: Apache-2.0" | cat - pkg/migrations/types.go > pkg/migrations/types.go.tmp


### PR DESCRIPTION
Generate types from the JSON schema using the official`omissis/go-jsonschema` image instead of the custom `surjection/go-jsonschema` image.

We built and used the `surjection/go-jsonschema` image because we needed a feature that was not yet released in `omissis/go-jsonschema`:

https://github.com/omissis/go-jsonschema/pull/220

Now that the feature is available in the `omissis/go-jsonschema` `0.17` [release](https://github.com/omissis/go-jsonschema/releases/tag/v0.17.0) we can switch back to using it.