### PR TITLE
Handle unconvertible `CREATE TABLE` statements

### DIFF
--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -42,6 +42,10 @@ func canConvertCreateStatement(stmt *pgq.CreateStmt) bool {
 	if stmt.GetRelation().GetRelpersistence() != "p" {
 		return false
 	}
+	// CREATE TABLE IF NOT EXISTS is not supported
+	if stmt.GetIfNotExists() {
+		return false
+	}
 	return true
 }
 

--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -48,6 +48,9 @@ func canConvertCreateStatement(stmt *pgq.CreateStmt) bool {
 	// Table inheritance is not supported
 	case len(stmt.GetInhRelations()) != 0:
 		return false
+	// Paritioned tables are not supported
+	case stmt.GetPartspec() != nil:
+		return false
 	default:
 		return true
 	}

--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -51,6 +51,9 @@ func canConvertCreateStatement(stmt *pgq.CreateStmt) bool {
 	// Paritioned tables are not supported
 	case stmt.GetPartspec() != nil:
 		return false
+	// Specifying an access method is not supported
+	case stmt.GetAccessMethod() != "":
+		return false
 	default:
 		return true
 	}

--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -57,6 +57,9 @@ func canConvertCreateStatement(stmt *pgq.CreateStmt) bool {
 	// Specifying storage options is not supported
 	case len(stmt.GetOptions()) != 0:
 		return false
+	// ON COMMIT options are not supported
+	case stmt.GetOncommit() != pgq.OnCommitAction_ONCOMMIT_NOOP:
+		return false
 	default:
 		return true
 	}

--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -38,8 +38,8 @@ func convertCreateStmt(stmt *pgq.CreateStmt) (migrations.Operations, error) {
 // canConvertCreateTableStatement returns true iff `stmt` can be converted to a
 // pgroll operation.
 func canConvertCreateStatement(stmt *pgq.CreateStmt) bool {
-	// Temporary tables are not supported
-	if stmt.GetRelation().GetRelpersistence() == "t" {
+	// Temporary and unlogged tables are not supported
+	if stmt.GetRelation().GetRelpersistence() != "p" {
 		return false
 	}
 	return true

--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -60,6 +60,9 @@ func canConvertCreateStatement(stmt *pgq.CreateStmt) bool {
 	// ON COMMIT options are not supported
 	case stmt.GetOncommit() != pgq.OnCommitAction_ONCOMMIT_NOOP:
 		return false
+	// Setting a tablespace is not supported
+	case stmt.GetTablespacename() != "":
+		return false
 	default:
 		return true
 	}

--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -38,15 +38,19 @@ func convertCreateStmt(stmt *pgq.CreateStmt) (migrations.Operations, error) {
 // canConvertCreateTableStatement returns true iff `stmt` can be converted to a
 // pgroll operation.
 func canConvertCreateStatement(stmt *pgq.CreateStmt) bool {
+	switch {
 	// Temporary and unlogged tables are not supported
-	if stmt.GetRelation().GetRelpersistence() != "p" {
+	case stmt.GetRelation().GetRelpersistence() != "p":
 		return false
-	}
 	// CREATE TABLE IF NOT EXISTS is not supported
-	if stmt.GetIfNotExists() {
+	case stmt.GetIfNotExists():
 		return false
+	// Table inheritance is not supported
+	case len(stmt.GetInhRelations()) != 0:
+		return false
+	default:
+		return true
 	}
-	return true
 }
 
 func convertColumnDef(col *pgq.ColumnDef) (*migrations.Column, error) {

--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -54,6 +54,9 @@ func canConvertCreateStatement(stmt *pgq.CreateStmt) bool {
 	// Specifying an access method is not supported
 	case stmt.GetAccessMethod() != "":
 		return false
+	// Specifying storage options is not supported
+	case len(stmt.GetOptions()) != 0:
+		return false
 	default:
 		return true
 	}

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -82,6 +82,7 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 		"CREATE TEMPORARY TABLE foo(a int)",
 		"CREATE UNLOGGED TABLE foo(a int)",
 		"CREATE TABLE IF NOT EXISTS foo(a int)",
+		"CREATE TABLE foo(a int) INHERITS (bar)",
 	}
 
 	for _, sql := range tests {

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -86,6 +86,9 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 		// Any kind of partitioning is not supported
 		"CREATE TABLE foo(a int) PARTITION BY RANGE (a)",
 		"CREATE TABLE foo(a int) PARTITION BY LIST (a)",
+
+		// Specifying a table access method is not supported
+		"CREATE TABLE foo(a int) USING bar",
 	}
 
 	for _, sql := range tests {

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -81,6 +81,7 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 		// operation
 		"CREATE TEMPORARY TABLE foo(a int)",
 		"CREATE UNLOGGED TABLE foo(a int)",
+		"CREATE TABLE IF NOT EXISTS foo(a int)",
 	}
 
 	for _, sql := range tests {

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -77,12 +77,15 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 	t.Parallel()
 
 	tests := []string{
-		// Temporary and unlogged tables are not representable as a pgroll
-		// operation
+		// CREATE TABLE options that are not representable as `pgroll` operations.
 		"CREATE TEMPORARY TABLE foo(a int)",
 		"CREATE UNLOGGED TABLE foo(a int)",
 		"CREATE TABLE IF NOT EXISTS foo(a int)",
 		"CREATE TABLE foo(a int) INHERITS (bar)",
+
+		// Any kind of partitioning is not supported
+		"CREATE TABLE foo(a int) PARTITION BY RANGE (a)",
+		"CREATE TABLE foo(a int) PARTITION BY LIST (a)",
 	}
 
 	for _, sql := range tests {

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -77,10 +77,14 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 	t.Parallel()
 
 	tests := []string{
-		// CREATE TABLE options that are not representable as `pgroll` operations.
+		// Temporary and unlogged tables are not supported
 		"CREATE TEMPORARY TABLE foo(a int)",
 		"CREATE UNLOGGED TABLE foo(a int)",
+
+		// The IF NOT EXISTS clause is not supported
 		"CREATE TABLE IF NOT EXISTS foo(a int)",
+
+		// Table inheritance is not supported
 		"CREATE TABLE foo(a int) INHERITS (bar)",
 
 		// Any kind of partitioning is not supported
@@ -97,6 +101,9 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 		// valid for all tables, but Postgres will reject them for non-temporary
 		// tables. We err on the side of caution and reject them for all tables.
 		"CREATE TABLE foo(a int) ON COMMIT DROP",
+
+		// Specifying a tablespace is not supported
+		"CREATE TABLE foo(a int) TABLESPACE bar",
 	}
 
 	for _, sql := range tests {

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -89,6 +89,9 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 
 		// Specifying a table access method is not supported
 		"CREATE TABLE foo(a int) USING bar",
+
+		// Specifying storage options is not supported
+		"CREATE TABLE foo(a int) WITH (fillfactor=70)",
 	}
 
 	for _, sql := range tests {

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -72,3 +72,23 @@ func TestConvertCreateTableStatements(t *testing.T) {
 		})
 	}
 }
+
+func TestUnconvertableCreateTableStatements(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{
+		// Temporary tables are not representable as a pgroll operation
+		"CREATE TEMPORARY TABLE foo(a int)",
+	}
+
+	for _, sql := range tests {
+		t.Run(sql, func(t *testing.T) {
+			ops, err := sql2pgroll.Convert(sql)
+			require.NoError(t, err)
+
+			require.Len(t, ops, 1)
+
+			assert.Equal(t, expect.RawSQLOp(sql), ops[0])
+		})
+	}
+}

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -92,6 +92,11 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 
 		// Specifying storage options is not supported
 		"CREATE TABLE foo(a int) WITH (fillfactor=70)",
+
+		// ON COMMMIT options are not supported. These options are syntactically
+		// valid for all tables, but Postgres will reject them for non-temporary
+		// tables. We err on the side of caution and reject them for all tables.
+		"CREATE TABLE foo(a int) ON COMMIT DROP",
 	}
 
 	for _, sql := range tests {

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -77,8 +77,10 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 	t.Parallel()
 
 	tests := []string{
-		// Temporary tables are not representable as a pgroll operation
+		// Temporary and unlogged tables are not representable as a pgroll
+		// operation
 		"CREATE TEMPORARY TABLE foo(a int)",
+		"CREATE UNLOGGED TABLE foo(a int)",
 	}
 
 	for _, sql := range tests {


### PR DESCRIPTION
There are [many options](https://www.postgresql.org/docs/current/sql-createtable.html) for the `CREATE TABLE` statement in Postgres, most of which are not currently representable by the `pgroll` `OpCreateTable` operation.

Add tests to ensure that `sql2proll.Convert`falls back to raw SQL operations when these unconvertible options are present in a SQL statement.

Part of #504 