### PR TITLE
Handle more unconvertible `CREATE TABLE` statements

### DIFF
--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -63,6 +63,9 @@ func canConvertCreateStatement(stmt *pgq.CreateStmt) bool {
 	// Setting a tablespace is not supported
 	case stmt.GetTablespacename() != "":
 		return false
+	// CREATE TABLE OF type_name is not supported
+	case stmt.GetOfTypename() != nil:
+		return false
 	default:
 		return true
 	}

--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -17,14 +17,22 @@ func convertCreateStmt(stmt *pgq.CreateStmt) (migrations.Operations, error) {
 		return nil, nil
 	}
 
-	// Convert the column definitions
-	columns := make([]migrations.Column, 0, len(stmt.TableElts))
+	// Convert the table elements - table elements can be:
+	// - Column definitions
+	// - Constraints
+	// - LIKE clauses (not supported)
+	var columns []migrations.Column
 	for _, elt := range stmt.TableElts {
-		column, err := convertColumnDef(elt.GetColumnDef())
-		if err != nil {
-			return nil, fmt.Errorf("error converting column definition: %w", err)
+		switch elt.Node.(type) {
+		case *pgq.Node_ColumnDef:
+			column, err := convertColumnDef(elt.GetColumnDef())
+			if err != nil {
+				return nil, fmt.Errorf("error converting column definition: %w", err)
+			}
+			columns = append(columns, *column)
+		default:
+			return nil, nil
 		}
-		columns = append(columns, *column)
 	}
 
 	return migrations.Operations{

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -90,6 +90,7 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 		// Any kind of partitioning is not supported
 		"CREATE TABLE foo(a int) PARTITION BY RANGE (a)",
 		"CREATE TABLE foo(a int) PARTITION BY LIST (a)",
+		"CREATE TABLE foo PARTITION OF bar FOR VALUES FROM (1) to (10)",
 
 		// Specifying a table access method is not supported
 		"CREATE TABLE foo(a int) USING bar",

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -108,6 +108,10 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 
 		// CREATE TABLE OF type_name is not supported
 		"CREATE TABLE foo OF type_bar",
+
+		// The LIKE clause is not supported
+		"CREATE TABLE foo(a int, LIKE bar)",
+		"CREATE TABLE foo(LIKE bar)",
 	}
 
 	for _, sql := range tests {

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -104,6 +104,9 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 
 		// Specifying a tablespace is not supported
 		"CREATE TABLE foo(a int) TABLESPACE bar",
+
+		// CREATE TABLE OF type_name is not supported
+		"CREATE TABLE foo OF type_bar",
 	}
 
 	for _, sql := range tests {


### PR DESCRIPTION
Build on #546 and ensure that more `CREATE TABLE` statements with options and clauses that are not representable as `pgroll` `OpCreateTable` operations fall back to raw SQL.

Part of #504 