### PR TITLE
Handle unconvertible `CREATE TABLE` column defintions

### DIFF
--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -122,10 +122,14 @@ func convertColumnDef(col *pgq.ColumnDef) (*migrations.Column, error) {
 // canConvertColumnDef returns true iff `col` can be converted to a pgroll
 // `Column` definition.
 func canConvertColumnDef(col *pgq.ColumnDef) bool {
+	switch {
 	// Column storage options are not supported
-	if col.GetStorageName() != "" {
+	case col.GetStorageName() != "":
 		return false
+		// Column compression options are not supported
+	case col.GetCompression() != "":
+		return false
+	default:
+		return true
 	}
-
-	return true
 }

--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -126,8 +126,11 @@ func canConvertColumnDef(col *pgq.ColumnDef) bool {
 	// Column storage options are not supported
 	case col.GetStorageName() != "":
 		return false
-		// Column compression options are not supported
+	// Column compression options are not supported
 	case col.GetCompression() != "":
+		return false
+	// Column collation options are not supported
+	case col.GetCollClause() != nil:
 		return false
 	default:
 		return true

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -113,8 +113,11 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 		"CREATE TABLE foo(a int, LIKE bar)",
 		"CREATE TABLE foo(LIKE bar)",
 
-		// column `STORAGE` options are not supported
+		// Column `STORAGE` options are not supported
 		"CREATE TABLE foo(a int STORAGE PLAIN)",
+
+		// Column compression options are not supported
+		"CREATE TABLE foo(a text COMPRESSION pglz)",
 	}
 
 	for _, sql := range tests {

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -112,6 +112,9 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 		// The LIKE clause is not supported
 		"CREATE TABLE foo(a int, LIKE bar)",
 		"CREATE TABLE foo(LIKE bar)",
+
+		// column `STORAGE` options are not supported
+		"CREATE TABLE foo(a int STORAGE PLAIN)",
 	}
 
 	for _, sql := range tests {

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -118,6 +118,9 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 
 		// Column compression options are not supported
 		"CREATE TABLE foo(a text COMPRESSION pglz)",
+
+		// Column collation is not supported
+		"CREATE TABLE foo(a text COLLATE en_US)",
 	}
 
 	for _, sql := range tests {


### PR DESCRIPTION
Column definitions in `CREATE TABLE` statements offer [several options](https://www.postgresql.org/docs/current/sql-createtable.html), most of which aren't currently representable by `pgroll` `Column` definitions.

Add tests and code to ensure that `CREATE TABLE` statements containing columns that use any of these unrepresentable options fall back to raw SQL operations.

Part of #504 