### PR TITLE
Fall back to SQL for unconvertible column constraint options in `CREATE TABLE` statements

### DIFF
--- a/pkg/sql2pgroll/alter_table.go
+++ b/pkg/sql2pgroll/alter_table.go
@@ -181,7 +181,7 @@ func convertAlterTableAddUniqueConstraint(stmt *pgq.AlterTableStmt, constraint *
 }
 
 func convertAlterTableAddForeignKeyConstraint(stmt *pgq.AlterTableStmt, constraint *pgq.Constraint) (migrations.Operation, error) {
-	if !canConvertAlterTableAddForeignKeyConstraint(constraint) {
+	if !canConvertForeignKeyConstraint(constraint) {
 		return nil, nil
 	}
 
@@ -240,7 +240,7 @@ func parseOnDeleteAction(action string) (migrations.ForeignKeyReferenceOnDelete,
 	}
 }
 
-func canConvertAlterTableAddForeignKeyConstraint(constraint *pgq.Constraint) bool {
+func canConvertForeignKeyConstraint(constraint *pgq.Constraint) bool {
 	if constraint.SkipValidation {
 		return false
 	}

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -25,6 +25,10 @@ func TestConvertCreateTableStatements(t *testing.T) {
 			expectedOp: expect.CreateTableOp1,
 		},
 		{
+			sql:        "CREATE TABLE foo(a int NULL)",
+			expectedOp: expect.CreateTableOp1,
+		},
+		{
 			sql:        "CREATE TABLE foo(a int NOT NULL)",
 			expectedOp: expect.CreateTableOp2,
 		},
@@ -131,6 +135,34 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 		"CREATE TABLE foo(a int, UNIQUE (a))",
 		"CREATE TABLE foo(a int, PRIMARY KEY (a))",
 		"CREATE TABLE foo(a int, FOREIGN KEY (a) REFERENCES bar(b))",
+
+		// Primary key constraint options are not supported
+		"CREATE TABLE foo(a int PRIMARY KEY USING INDEX TABLESPACE bar)",
+		"CREATE TABLE foo(a int PRIMARY KEY WITH (fillfactor=70))",
+
+		// CHECK constraint NO INHERIT option is not supported
+		"CREATE TABLE foo(a int CHECK (a > 0) NO INHERIT)",
+
+		// Options on UNIQUE constraints are not supported
+		"CREATE TABLE foo(a int UNIQUE NULLS NOT DISTINCT)",
+		"CREATE TABLE foo(a int UNIQUE WITH (fillfactor=70))",
+		"CREATE TABLE foo(a int UNIQUE USING INDEX TABLESPACE baz)",
+
+		// Some options on FOREIGN KEY constraints are not supported
+		"CREATE TABLE foo(a int REFERENCES bar (b) ON UPDATE RESTRICT)",
+		"CREATE TABLE foo(a int REFERENCES bar (b) ON UPDATE CASCADE)",
+		"CREATE TABLE foo(a int REFERENCES bar (b) ON UPDATE SET NULL)",
+		"CREATE TABLE foo(a int REFERENCES bar (b) ON UPDATE SET DEFAULT)",
+		"CREATE TABLE foo(a int REFERENCES bar (b) MATCH FULL)",
+
+		// Named inline constraints are not supported
+		"CREATE TABLE foo(a int CONSTRAINT foo_check CHECK (a > 0))",
+		"CREATE TABLE foo(a int CONSTRAINT foo_unique UNIQUE)",
+		"CREATE TABLE foo(a int CONSTRAINT foo_pk PRIMARY KEY)",
+		"CREATE TABLE foo(a int CONSTRAINT foo_fk REFERENCES bar(b))",
+		"CREATE TABLE foo(a int CONSTRAINT foo_default DEFAULT 0)",
+		"CREATE TABLE foo(a int CONSTRAINT foo_null NULL)",
+		"CREATE TABLE foo(a int CONSTRAINT foo_notnull NOT NULL)",
 	}
 
 	for _, sql := range tests {


### PR DESCRIPTION
Fall back to raw SQL for unsupported constraint options for:
  * `PRIMARY KEY` constraints
  * `CHECK` constraints
  * `UNIQUE` constraints
  * `FOREIGN KEY` constraints

in `CREATE TABLE` statements.

Also add tests to ensure that named inline constraints fall back to raw SQL.