### PR TITLE
Convert SQL `CREATE TABLE` inline `CHECK` constraints

### DIFF
--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -60,6 +60,10 @@ func TestConvertCreateTableStatements(t *testing.T) {
 			sql:        "CREATE TABLE foo(a text[5][3])",
 			expectedOp: expect.CreateTableOp9,
 		},
+		{
+			sql:        "CREATE TABLE foo(a int CHECK (a > 0))",
+			expectedOp: expect.CreateTableOp10,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -33,20 +33,24 @@ func TestConvertCreateTableStatements(t *testing.T) {
 			expectedOp: expect.CreateTableOp2,
 		},
 		{
-			sql:        "CREATE TABLE foo(a varchar(255))",
-			expectedOp: expect.CreateTableOp3,
-		},
-		{
-			sql:        "CREATE TABLE foo(a numeric(10, 2))",
-			expectedOp: expect.CreateTableOp4,
-		},
-		{
 			sql:        "CREATE TABLE foo(a int UNIQUE)",
 			expectedOp: expect.CreateTableOp5,
 		},
 		{
 			sql:        "CREATE TABLE foo(a int PRIMARY KEY)",
 			expectedOp: expect.CreateTableOp6,
+		},
+		{
+			sql:        "CREATE TABLE foo(a int CHECK (a > 0))",
+			expectedOp: expect.CreateTableOp10,
+		},
+		{
+			sql:        "CREATE TABLE foo(a varchar(255))",
+			expectedOp: expect.CreateTableOp3,
+		},
+		{
+			sql:        "CREATE TABLE foo(a numeric(10, 2))",
+			expectedOp: expect.CreateTableOp4,
 		},
 		{
 			sql:        "CREATE TABLE foo(a text[])",
@@ -59,10 +63,6 @@ func TestConvertCreateTableStatements(t *testing.T) {
 		{
 			sql:        "CREATE TABLE foo(a text[5][3])",
 			expectedOp: expect.CreateTableOp9,
-		},
-		{
-			sql:        "CREATE TABLE foo(a int CHECK (a > 0))",
-			expectedOp: expect.CreateTableOp10,
 		},
 	}
 

--- a/pkg/sql2pgroll/expect/create_table.go
+++ b/pkg/sql2pgroll/expect/create_table.go
@@ -102,3 +102,17 @@ var CreateTableOp9 = &migrations.OpCreateTable{
 		},
 	},
 }
+
+var CreateTableOp10 = &migrations.OpCreateTable{
+	Name: "foo",
+	Columns: []migrations.Column{
+		{
+			Name:     "a",
+			Type:     "int",
+			Nullable: true,
+			Check: &migrations.CheckConstraint{
+				Constraint: "a > 0",
+			},
+		},
+	},
+}

--- a/pkg/sql2pgroll/expect/create_table.go
+++ b/pkg/sql2pgroll/expect/create_table.go
@@ -111,6 +111,7 @@ var CreateTableOp10 = &migrations.OpCreateTable{
 			Type:     "int",
 			Nullable: true,
 			Check: &migrations.CheckConstraint{
+				Name:       "foo_a_check",
 				Constraint: "a > 0",
 			},
 		},


### PR DESCRIPTION
Convert SQL `CREATE TABLE` statements with inline `CHECK` constraints like this:

```
CREATE TABLE foo(a int CHECK (a > 0))
```

to `OpCreateTable` operations like this:

```json
[
  {
    "create_table": {
      "columns": [
        {
          "check": {
            "constraint": "a > 0",
            "name": "foo_a_check"
          },
          "name": "a",
          "nullable": true,
          "type": "int"
        }
      ],
      "name": "foo"
    }
  }
]
```