### PR TITLE
Convert column `DEFAULT`s in `CREATE TABLE` statements

### DIFF
--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -45,6 +45,10 @@ func TestConvertCreateTableStatements(t *testing.T) {
 			expectedOp: expect.CreateTableOp10,
 		},
 		{
+			sql:        "CREATE TABLE foo(a timestamptz DEFAULT now())",
+			expectedOp: expect.CreateTableOp11,
+		},
+		{
 			sql:        "CREATE TABLE foo(a varchar(255))",
 			expectedOp: expect.CreateTableOp3,
 		},

--- a/pkg/sql2pgroll/expect/create_table.go
+++ b/pkg/sql2pgroll/expect/create_table.go
@@ -117,3 +117,15 @@ var CreateTableOp10 = &migrations.OpCreateTable{
 		},
 	},
 }
+
+var CreateTableOp11 = &migrations.OpCreateTable{
+	Name: "foo",
+	Columns: []migrations.Column{
+		{
+			Name:     "a",
+			Type:     "timestamptz",
+			Nullable: true,
+			Default:  ptr("now()"),
+		},
+	},
+}


### PR DESCRIPTION
Convert inline `DEFAULT` values in `CREATE TABLE` statements like this:

```sql
CREATE TABLE foo(a text DEFAULT 'foo')
```

into `OpCreateTable` operations like this:

```json
[
  {
    "create_table": {
      "columns": [
        {
          "default": "'foo'",
          "name": "a",
          "nullable": true,
          "type": "text"
        }
      ],
      "name": "foo"
    }
  }
]
```