### PR TITLE
Convert column `FOREIGN KEY`s in `CREATE TABLE`

### DIFF
--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -49,6 +49,34 @@ func TestConvertCreateTableStatements(t *testing.T) {
 			expectedOp: expect.CreateTableOp11,
 		},
 		{
+			sql:        "CREATE TABLE foo(a int REFERENCES bar(b))",
+			expectedOp: expect.CreateTableOp12,
+		},
+		{
+			sql:        "CREATE TABLE foo(a int REFERENCES bar(b) ON UPDATE NO ACTION)",
+			expectedOp: expect.CreateTableOp12,
+		},
+		{
+			sql:        "CREATE TABLE foo(a int REFERENCES bar(b) ON DELETE NO ACTION)",
+			expectedOp: expect.CreateTableOp12,
+		},
+		{
+			sql:        "CREATE TABLE foo(a int REFERENCES bar(b) ON DELETE RESTRICT)",
+			expectedOp: expect.CreateTableOp13,
+		},
+		{
+			sql:        "CREATE TABLE foo(a int REFERENCES bar(b) ON DELETE SET NULL)",
+			expectedOp: expect.CreateTableOp14,
+		},
+		{
+			sql:        "CREATE TABLE foo(a int REFERENCES bar(b) ON DELETE SET DEFAULT)",
+			expectedOp: expect.CreateTableOp15,
+		},
+		{
+			sql:        "CREATE TABLE foo(a int REFERENCES bar(b) ON DELETE CASCADE)",
+			expectedOp: expect.CreateTableOp16,
+		},
+		{
 			sql:        "CREATE TABLE foo(a varchar(255))",
 			expectedOp: expect.CreateTableOp3,
 		},

--- a/pkg/sql2pgroll/expect/create_table.go
+++ b/pkg/sql2pgroll/expect/create_table.go
@@ -129,3 +129,88 @@ var CreateTableOp11 = &migrations.OpCreateTable{
 		},
 	},
 }
+
+var CreateTableOp12 = &migrations.OpCreateTable{
+	Name: "foo",
+	Columns: []migrations.Column{
+		{
+			Name:     "a",
+			Type:     "int",
+			Nullable: true,
+			References: &migrations.ForeignKeyReference{
+				Name:     "foo_a_fkey",
+				Table:    "bar",
+				Column:   "b",
+				OnDelete: migrations.ForeignKeyReferenceOnDeleteNOACTION,
+			},
+		},
+	},
+}
+
+var CreateTableOp13 = &migrations.OpCreateTable{
+	Name: "foo",
+	Columns: []migrations.Column{
+		{
+			Name:     "a",
+			Type:     "int",
+			Nullable: true,
+			References: &migrations.ForeignKeyReference{
+				Name:     "foo_a_fkey",
+				Table:    "bar",
+				Column:   "b",
+				OnDelete: migrations.ForeignKeyReferenceOnDeleteRESTRICT,
+			},
+		},
+	},
+}
+
+var CreateTableOp14 = &migrations.OpCreateTable{
+	Name: "foo",
+	Columns: []migrations.Column{
+		{
+			Name:     "a",
+			Type:     "int",
+			Nullable: true,
+			References: &migrations.ForeignKeyReference{
+				Name:     "foo_a_fkey",
+				Table:    "bar",
+				Column:   "b",
+				OnDelete: migrations.ForeignKeyReferenceOnDeleteSETNULL,
+			},
+		},
+	},
+}
+
+var CreateTableOp15 = &migrations.OpCreateTable{
+	Name: "foo",
+	Columns: []migrations.Column{
+		{
+			Name:     "a",
+			Type:     "int",
+			Nullable: true,
+			References: &migrations.ForeignKeyReference{
+				Name:     "foo_a_fkey",
+				Table:    "bar",
+				Column:   "b",
+				OnDelete: migrations.ForeignKeyReferenceOnDeleteSETDEFAULT,
+			},
+		},
+	},
+}
+
+var CreateTableOp16 = &migrations.OpCreateTable{
+	Name: "foo",
+	Columns: []migrations.Column{
+		{
+			Name:     "a",
+			Type:     "int",
+			Nullable: true,
+			References: &migrations.ForeignKeyReference{
+				Name:     "foo_a_fkey",
+				Table:    "bar",
+				Column:   "b",
+				OnDelete: migrations.ForeignKeyReferenceOnDeleteCASCADE,
+			},
+		},
+	},
+}


### PR DESCRIPTION
Convert inline `FOREIGN KEY` constraints in `CREATE TABLE` statements like this:

```sql
CREATE TABLE foo(a int REFERENCES bar(b))
```

into `OpCreateTable` operations like this:

```json
[
  {
    "create_table": {
      "columns": [
        {
          "name": "a",
          "nullable": true,
          "references": {
            "column": "b",
            "name": "foo_a_fkey",
            "on_delete": "NO ACTION",
            "table": "bar"
          },
          "type": "int"
        }
      ],
      "name": "foo"
    }
  }
]
```