### PR TITLE
Fall back to raw SQL for `GENERATED` columns in `CREATE TABLE` statements

### DIFF
--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -139,6 +139,12 @@ func convertColumnDef(tableName string, col *pgq.ColumnDef) (*migrations.Column,
 			if foreignKey == nil {
 				return nil, nil
 			}
+		case pgq.ConstrType_CONSTR_GENERATED:
+			// Generated columns are not supported
+			return nil, nil
+		case pgq.ConstrType_CONSTR_IDENTITY:
+			// Identity columns are not supported
+			return nil, nil
 		}
 	}
 

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -199,6 +199,10 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 		"CREATE TABLE foo(a int CONSTRAINT foo_default DEFAULT 0)",
 		"CREATE TABLE foo(a int CONSTRAINT foo_null NULL)",
 		"CREATE TABLE foo(a int CONSTRAINT foo_notnull NOT NULL)",
+
+		// Generated columns are not supported
+		"CREATE TABLE foo(a int GENERATED ALWAYS AS (1) STORED)",
+		"CREATE TABLE foo(a int GENERATED ALWAYS AS IDENTITY)",
 	}
 
 	for _, sql := range tests {


### PR DESCRIPTION
Ensure that `CREATE TABLE` statements with generated columns are converted to raw SQL operations; they can't currently be represented as `Column`s in an `OpCreateTable` 