### PR TITLE
Convert schema-qualified `CREATE TABLE` statements

### DIFF
--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -41,7 +41,7 @@ func convertCreateStmt(stmt *pgq.CreateStmt) (migrations.Operations, error) {
 
 	return migrations.Operations{
 		&migrations.OpCreateTable{
-			Name:    stmt.Relation.GetRelname(),
+			Name:    getQualifiedRelationName(stmt.GetRelation()),
 			Columns: columns,
 		},
 	}, nil

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -25,6 +25,10 @@ func TestConvertCreateTableStatements(t *testing.T) {
 			expectedOp: expect.CreateTableOp1,
 		},
 		{
+			sql:        "CREATE TABLE schema.foo(a int)",
+			expectedOp: expect.CreateTableOp17,
+		},
+		{
 			sql:        "CREATE TABLE foo(a int NULL)",
 			expectedOp: expect.CreateTableOp1,
 		},

--- a/pkg/sql2pgroll/expect/create_table.go
+++ b/pkg/sql2pgroll/expect/create_table.go
@@ -214,3 +214,14 @@ var CreateTableOp16 = &migrations.OpCreateTable{
 		},
 	},
 }
+
+var CreateTableOp17 = &migrations.OpCreateTable{
+	Name: "schema.foo",
+	Columns: []migrations.Column{
+		{
+			Name:     "a",
+			Type:     "int",
+			Nullable: true,
+		},
+	},
+}


### PR DESCRIPTION
Ensure that schema qualified `CREATE TABLE` statements are correctly converted to a `migrations.OpCreateTable` operation.