### PR TITLE
Fix `ALTER TABLE ADD COLUMN` default nullability

### DIFF
--- a/pkg/sql2pgroll/alter_table.go
+++ b/pkg/sql2pgroll/alter_table.go
@@ -418,8 +418,9 @@ func convertAlterTableAddColumn(stmt *pgq.AlterTableStmt, cmd *pgq.AlterTableCmd
 
 	operation := &migrations.OpAddColumn{
 		Column: migrations.Column{
-			Name: columnDef.GetColname(),
-			Type: columnType,
+			Name:     columnDef.GetColname(),
+			Type:     columnType,
+			Nullable: true,
 		},
 		Table: getQualifiedRelationName(stmt.GetRelation()),
 		Up:    PlaceHolderSQL,
@@ -430,8 +431,11 @@ func convertAlterTableAddColumn(stmt *pgq.AlterTableStmt, cmd *pgq.AlterTableCmd
 			switch constraint.GetConstraint().GetContype() {
 			case pgq.ConstrType_CONSTR_NULL:
 				operation.Column.Nullable = true
+			case pgq.ConstrType_CONSTR_NOTNULL:
+				operation.Column.Nullable = false
 			case pgq.ConstrType_CONSTR_PRIMARY:
 				operation.Column.Pk = true
+				operation.Column.Nullable = false
 			case pgq.ConstrType_CONSTR_UNIQUE:
 				operation.Column.Unique = true
 			case pgq.ConstrType_CONSTR_CHECK:

--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -148,7 +148,7 @@ func TestConvertAlterTableStatements(t *testing.T) {
 		},
 		{
 			sql:        "ALTER TABLE foo ADD COLUMN bar int NOT NULL",
-			expectedOp: expect.AddColumnOp1,
+			expectedOp: expect.AddColumnOp8,
 		},
 		{
 			sql:        "ALTER TABLE schema.foo ADD COLUMN bar int",

--- a/pkg/sql2pgroll/expect/add_column.go
+++ b/pkg/sql2pgroll/expect/add_column.go
@@ -11,8 +11,9 @@ var AddColumnOp1 = &migrations.OpAddColumn{
 	Table: "foo",
 	Up:    sql2pgroll.PlaceHolderSQL,
 	Column: migrations.Column{
-		Name: "bar",
-		Type: "int",
+		Name:     "bar",
+		Type:     "int",
+		Nullable: true,
 	},
 }
 
@@ -20,8 +21,9 @@ var AddColumnOp2 = &migrations.OpAddColumn{
 	Table: "schema.foo",
 	Up:    sql2pgroll.PlaceHolderSQL,
 	Column: migrations.Column{
-		Name: "bar",
-		Type: "int",
+		Name:     "bar",
+		Type:     "int",
+		Nullable: true,
 	},
 }
 
@@ -30,9 +32,10 @@ func AddColumnOp1WithDefault(def *string) *migrations.OpAddColumn {
 		Table: "foo",
 		Up:    sql2pgroll.PlaceHolderSQL,
 		Column: migrations.Column{
-			Name:    "bar",
-			Type:    "int",
-			Default: def,
+			Name:     "bar",
+			Type:     "int",
+			Default:  def,
+			Nullable: true,
 		},
 	}
 }
@@ -51,9 +54,10 @@ var AddColumnOp4 = &migrations.OpAddColumn{
 	Table: "foo",
 	Up:    sql2pgroll.PlaceHolderSQL,
 	Column: migrations.Column{
-		Name:   "bar",
-		Type:   "int",
-		Unique: true,
+		Name:     "bar",
+		Type:     "int",
+		Unique:   true,
+		Nullable: true,
 	},
 }
 
@@ -71,8 +75,9 @@ var AddColumnOp6 = &migrations.OpAddColumn{
 	Table: "foo",
 	Up:    sql2pgroll.PlaceHolderSQL,
 	Column: migrations.Column{
-		Name: "bar",
-		Type: "int",
+		Name:     "bar",
+		Type:     "int",
+		Nullable: true,
 		Check: &migrations.CheckConstraint{
 			Constraint: "bar > 0",
 			Name:       "",
@@ -84,12 +89,23 @@ var AddColumnOp7 = &migrations.OpAddColumn{
 	Table: "foo",
 	Up:    sql2pgroll.PlaceHolderSQL,
 	Column: migrations.Column{
-		Name: "bar",
-		Type: "int",
+		Name:     "bar",
+		Type:     "int",
+		Nullable: true,
 		Check: &migrations.CheckConstraint{
 			Constraint: "bar > 0",
 			Name:       "check_bar",
 		},
+	},
+}
+
+var AddColumnOp8 = &migrations.OpAddColumn{
+	Table: "foo",
+	Up:    sql2pgroll.PlaceHolderSQL,
+	Column: migrations.Column{
+		Name:     "bar",
+		Type:     "int",
+		Nullable: false,
 	},
 }
 
@@ -98,8 +114,9 @@ func AddColumnOp8WithOnDeleteAction(action migrations.ForeignKeyReferenceOnDelet
 		Table: "foo",
 		Up:    sql2pgroll.PlaceHolderSQL,
 		Column: migrations.Column{
-			Name: "bar",
-			Type: "int",
+			Name:     "bar",
+			Type:     "int",
+			Nullable: true,
 			References: &migrations.ForeignKeyReference{
 				Column:   "bar",
 				Name:     "fk_baz",


### PR DESCRIPTION
Columns added by `ALTER TABLE ADD COLUMN` are nullable by default.

For the `pgroll` `Column` type, these means we need to set `Nullable` to `true` by default when converting such SQL statements with `sql2pgroll`.