### PR TITLE
Allow some named inline column constraints in `CREATE TABLE` statements

### DIFF
--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -57,8 +57,20 @@ func TestConvertCreateTableStatements(t *testing.T) {
 			expectedOp: expect.CreateTableOp10,
 		},
 		{
+			sql:        "CREATE TABLE foo(a int CONSTRAINT my_check CHECK (a > 0))",
+			expectedOp: expect.CreateTableOp18,
+		},
+		{
 			sql:        "CREATE TABLE foo(a timestamptz DEFAULT now())",
 			expectedOp: expect.CreateTableOp11,
+		},
+		{
+			sql:        "CREATE TABLE foo(a int CONSTRAINT my_fk REFERENCES bar(b))",
+			expectedOp: expect.CreateTableOp19,
+		},
+		{
+			sql:        "CREATE TABLE foo(a int REFERENCES bar(b))",
+			expectedOp: expect.CreateTableOp12,
 		},
 		{
 			sql:        "CREATE TABLE foo(a int REFERENCES bar(b) NOT DEFERRABLE)",
@@ -227,14 +239,13 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 		"CREATE TABLE foo(a int REFERENCES bar (b) ON UPDATE SET DEFAULT)",
 		"CREATE TABLE foo(a int REFERENCES bar (b) MATCH FULL)",
 
-		// Named inline constraints are not supported
-		"CREATE TABLE foo(a int CONSTRAINT foo_check CHECK (a > 0))",
-		"CREATE TABLE foo(a int CONSTRAINT foo_unique UNIQUE)",
-		"CREATE TABLE foo(a int CONSTRAINT foo_pk PRIMARY KEY)",
-		"CREATE TABLE foo(a int CONSTRAINT foo_fk REFERENCES bar(b))",
+		// Named inline constraints are not supported for DEFAULT, NULL, NOT NULL,
+		// UNIQUE or PRIMARY KEY constraints
 		"CREATE TABLE foo(a int CONSTRAINT foo_default DEFAULT 0)",
 		"CREATE TABLE foo(a int CONSTRAINT foo_null NULL)",
 		"CREATE TABLE foo(a int CONSTRAINT foo_notnull NOT NULL)",
+		"CREATE TABLE foo(a int CONSTRAINT foo_unique UNIQUE)",
+		"CREATE TABLE foo(a int CONSTRAINT foo_pk PRIMARY KEY)",
 
 		// Generated columns are not supported
 		"CREATE TABLE foo(a int GENERATED ALWAYS AS (1) STORED)",

--- a/pkg/sql2pgroll/expect/create_table.go
+++ b/pkg/sql2pgroll/expect/create_table.go
@@ -225,3 +225,35 @@ var CreateTableOp17 = &migrations.OpCreateTable{
 		},
 	},
 }
+
+var CreateTableOp18 = &migrations.OpCreateTable{
+	Name: "foo",
+	Columns: []migrations.Column{
+		{
+			Name:     "a",
+			Type:     "int",
+			Nullable: true,
+			Check: &migrations.CheckConstraint{
+				Name:       "my_check",
+				Constraint: "a > 0",
+			},
+		},
+	},
+}
+
+var CreateTableOp19 = &migrations.OpCreateTable{
+	Name: "foo",
+	Columns: []migrations.Column{
+		{
+			Name:     "a",
+			Type:     "int",
+			Nullable: true,
+			References: &migrations.ForeignKeyReference{
+				Name:     "my_fk",
+				Table:    "bar",
+				Column:   "b",
+				OnDelete: migrations.ForeignKeyReferenceOnDeleteNOACTION,
+			},
+		},
+	},
+}


### PR DESCRIPTION
Allow some named inline column constraints in `CREATE TABLE` statements.

SQL like this can be converted to a pgroll `OpCreateTable`:

```sql
CREATE TABLE foo(a int CONSTRAINT my_check CHECK (a > 0))
CREATE TABLE foo(a int CONSTRAINT my_fk REFERENCES bar(b))
```

The previous behaviour was to allow only the unnamed forms of these constraints:

```sql
CREATE TABLE foo(a int CHECK (a > 0))
CREATE TABLE foo(a int REFERENCES bar(b))
```

Named inline column constraints remain unsupported for `DEFAULT`, `NULL`, `NOT NULL`, `UNIQUE` and `PRIMARY KEY` constraints and will fall back to a raw SQL operation.