### PR TITLE
Change `CREATE TABLE` `DEFAULT` constraint handling

### DIFF
--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -137,11 +137,14 @@ func convertColumnDef(tableName string, col *pgq.ColumnDef) (*migrations.Column,
 			if isConstraintNamed(c.GetConstraint()) {
 				return nil, nil
 			}
-			d, err := pgq.DeparseExpr(c.GetConstraint().GetRawExpr())
+			d, err := extractDefault(c.GetConstraint().GetRawExpr())
 			if err != nil {
 				return nil, fmt.Errorf("error deparsing default value: %w", err)
 			}
-			defaultValue = &d
+			if !d.IsNull() {
+				v := d.MustGet()
+				defaultValue = &v
+			}
 		case pgq.ConstrType_CONSTR_FOREIGN:
 			foreignKey, err = convertInlineForeignKeyConstraint(tableName, col.GetColname(), c.GetConstraint())
 			if err != nil {

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -73,6 +73,10 @@ func TestConvertCreateTableStatements(t *testing.T) {
 			expectedOp: expect.CreateTableOp11,
 		},
 		{
+			sql:        "CREATE TABLE foo(a int DEFAULT NULL)",
+			expectedOp: expect.CreateTableOp20,
+		},
+		{
 			sql:        "CREATE TABLE foo(a int CONSTRAINT my_fk REFERENCES bar(b))",
 			expectedOp: expect.CreateTableOp19,
 		},

--- a/pkg/sql2pgroll/expect/create_table.go
+++ b/pkg/sql2pgroll/expect/create_table.go
@@ -257,3 +257,14 @@ var CreateTableOp19 = &migrations.OpCreateTable{
 		},
 	},
 }
+
+var CreateTableOp20 = &migrations.OpCreateTable{
+	Name: "foo",
+	Columns: []migrations.Column{
+		{
+			Name:     "a",
+			Type:     "int",
+			Nullable: true,
+		},
+	},
+}


### PR DESCRIPTION
Change how `CREATE TABLE` statements like:

```sql
CREATE TABLE foo(a int DEFAULT NULL)
```

are converted to `OpCreateTable` operations.

When a column has a default value of `NULL`, the `default` field in the resulting `Column` object should be omitted, rather than set to `"NULL"`.

This makes conversion of `CREATE TABLE` statements consistent with conversion of `ALTER TABLE ADD COLUMN` statements.