### PR TITLE
Reduce duplication between `CREATE TABLE` and `ADD COLUMN` SQL conversion

### DIFF
--- a/pkg/sql2pgroll/expect/add_column.go
+++ b/pkg/sql2pgroll/expect/add_column.go
@@ -80,7 +80,7 @@ var AddColumnOp6 = &migrations.OpAddColumn{
 		Nullable: true,
 		Check: &migrations.CheckConstraint{
 			Constraint: "bar > 0",
-			Name:       "",
+			Name:       "foo_bar_check",
 		},
 	},
 }


### PR DESCRIPTION
There is a lot of duplication between the `CREATE TABLE` and `ALTER TABLE ADD COLUMN` conversion code.

Reduce the duplication by having the `ALTER TABLE ADD COLUMN` conversion code and the `CREATE TABLE` conversion code use the same `convertColumnDef` function, which handles the conversion of a column definition to a `migrations.Column` struct along with the conversion of the column constraints.