### PR TITLE
Add a multi-column test case for `CREATE TABLE`

### DIFF
--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -160,6 +160,10 @@ func TestConvertCreateTableStatements(t *testing.T) {
 			sql:        "CREATE TABLE foo(a text[5][3])",
 			expectedOp: expect.CreateTableOp9,
 		},
+		{
+			sql:        "CREATE TABLE foo(a serial PRIMARY KEY, b int DEFAULT 100 CHECK (b > 0), c text NOT NULL UNIQUE)",
+			expectedOp: expect.CreateTableOp21,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/sql2pgroll/expect/create_table.go
+++ b/pkg/sql2pgroll/expect/create_table.go
@@ -268,3 +268,29 @@ var CreateTableOp20 = &migrations.OpCreateTable{
 		},
 	},
 }
+
+var CreateTableOp21 = &migrations.OpCreateTable{
+	Name: "foo",
+	Columns: []migrations.Column{
+		{
+			Name: "a",
+			Type: "serial",
+			Pk:   true,
+		},
+		{
+			Name:    "b",
+			Type:    "int",
+			Default: ptr("100"),
+			Check: &migrations.CheckConstraint{
+				Name:       "foo_b_check",
+				Constraint: "b > 0",
+			},
+			Nullable: true,
+		},
+		{
+			Name:   "c",
+			Type:   "text",
+			Unique: true,
+		},
+	},
+}


### PR DESCRIPTION
Add a multi-column test case for conversion of `CREATE TABLE` statements to `pgroll` operations.

All other test cases are single-column. This commit adds a multi-column test case with multiple constraints.