### PR TITLE
Update `pg query go` dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.34.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.34.0
-	github.com/xataio/pg_query_go/v6 v6.0.0-20241217092625-e7ba1fbaf89e
+	github.com/xataio/pg_query_go/v6 v6.0.0-20241223083246-5033a992750b
 	golang.org/x/tools v0.28.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -219,6 +219,10 @@ github.com/tklauser/numcpus v0.8.0 h1:Mx4Wwe/FjZLeQsK/6kt2EOepwwSl7SmJrK5bV/dXYg
 github.com/tklauser/numcpus v0.8.0/go.mod h1:ZJZlAY+dmR4eut8epnzf0u/VwodKmryxR8txiloSqBE=
 github.com/xataio/pg_query_go/v6 v6.0.0-20241217092625-e7ba1fbaf89e h1:9DShoOhR7/IsNPwTAMkTMbsEZRVcuJCb20RIVGQTIdU=
 github.com/xataio/pg_query_go/v6 v6.0.0-20241217092625-e7ba1fbaf89e/go.mod h1:GK6bpfAhPtZb7wG/IccqvnH+cz3cmvvRTkC+MosESGo=
+github.com/xataio/pg_query_go/v6 v6.0.0-20241222163555-c4167b6980b7 h1:eYizaaHiZG9Szjkt0N0xnn0lEc0F4/IY+pVYZmACW7I=
+github.com/xataio/pg_query_go/v6 v6.0.0-20241222163555-c4167b6980b7/go.mod h1:GK6bpfAhPtZb7wG/IccqvnH+cz3cmvvRTkC+MosESGo=
+github.com/xataio/pg_query_go/v6 v6.0.0-20241223083246-5033a992750b h1:rZyagmQlpbFFKUMW7k/hQVklPGKAZ9Nzv0xqPPd7SQU=
+github.com/xataio/pg_query_go/v6 v6.0.0-20241223083246-5033a992750b/go.mod h1:GK6bpfAhPtZb7wG/IccqvnH+cz3cmvvRTkC+MosESGo=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=


### PR DESCRIPTION
Update the https://github.com/xataio/pg_query_go dependency to the latest `main` pseudo-version.

This brings in better support for deparsing `reloptions` clauses via https://github.com/xataio/pg_query_go/pull/6.