### PR TITLE
Update docs for the `create_index` operation

### DIFF
--- a/docs/operations/create_index.mdx
+++ b/docs/operations/create_index.mdx
@@ -12,6 +12,7 @@ description: A create index operation creates a new index on a set of columns.
     "name": "index name",
     "columns": [ "names of columns on which to define the index" ]
     "predicate": "conditional expression for defining a partial index",
+    "storage_parameters": "comma-separated list of storage parameters",
     "unique": true | false,
     "method": "btree"
   }


### PR DESCRIPTION
Add the missing `storage_parameters` field to the `create_index` operation documentation.