### PR TITLE
Show completion estimate during backfill

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -55,8 +55,12 @@ func runMigrationFromFile(ctx context.Context, m *roll.Roll, fileName string, co
 
 func runMigration(ctx context.Context, m *roll.Roll, migration *migrations.Migration, complete bool) error {
 	sp, _ := pterm.DefaultSpinner.WithText("Starting migration...").Start()
-	cb := func(n int64) {
-		sp.UpdateText(fmt.Sprintf("%d records complete...", n))
+	cb := func(n int64, total int64) {
+		var percent float64
+		if total > 0 {
+			percent = float64(n) / float64(total) * 100
+		}
+		sp.UpdateText(fmt.Sprintf("%d records complete... (%.2f%%)", n, percent))
 	}
 
 	err := m.Start(ctx, migration, cb)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -60,7 +60,15 @@ func runMigration(ctx context.Context, m *roll.Roll, migration *migrations.Migra
 		if total > 0 {
 			percent = float64(n) / float64(total) * 100
 		}
-		sp.UpdateText(fmt.Sprintf("%d records complete... (%.2f%%)", n, percent))
+		if percent > 100 {
+			// This can happen if we're on the last batch
+			percent = 100
+		}
+		if total > 0 {
+			sp.UpdateText(fmt.Sprintf("%d records complete... (%.2f%%)", n, percent))
+		} else {
+			sp.UpdateText(fmt.Sprintf("%d records complete...", n))
+		}
 	}
 
 	err := m.Start(ctx, migration, cb)

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -20,6 +20,7 @@ const (
 
 type DB interface {
 	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
 	WithRetryableTransaction(ctx context.Context, f func(context.Context, *sql.Tx) error) error
 	Close() error
 }
@@ -50,6 +51,11 @@ func (db *RDB) ExecContext(ctx context.Context, query string, args ...interface{
 
 		return nil, err
 	}
+}
+
+// QueryRowContext wraps sql.DB.QueryRowContext.
+func (db *RDB) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	return db.DB.QueryRowContext(ctx, query, args...)
 }
 
 // WithRetryableTransaction runs `f` in a transaction, retrying on lock_timeout errors.

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -12,7 +12,7 @@ import (
 	"github.com/xataio/pgroll/pkg/schema"
 )
 
-type CallbackFn func(int64)
+type CallbackFn func(done int64, total int64)
 
 // Operation is an operation that can be applied to a schema
 type Operation interface {

--- a/pkg/roll/execute_test.go
+++ b/pkg/roll/execute_test.go
@@ -655,7 +655,7 @@ func TestCallbacksAreInvokedOnMigrationStart(t *testing.T) {
 
 		// Define a mock callback
 		invoked := false
-		cb := func(n int64) { invoked = true }
+		cb := func(n, total int64) { invoked = true }
 
 		// Start a migration that requires a backfill
 		err = mig.Start(ctx, &migrations.Migration{


### PR DESCRIPTION
Instead of only showing the number of rows backfills, show an estimate of the total number of tows completed as a percentage.

For example:

```
1500 records complete... (12.34%)
```

It attempts to estimate the total number of rows but will fall back to a full scan if the number of rows estimated is zero.

Closes #492 