### PR TITLE
Use original table name without prefix when processing create table

### DIFF
--- a/examples/29_set_replica_identity.json
+++ b/examples/29_set_replica_identity.json
@@ -6,7 +6,7 @@
         "table": "fruits",
         "identity": {
           "type": "index",
-          "index": "_pgroll_new_fruits_pkey"
+          "index": "fruits_pkey"
         }
       }
     }

--- a/pkg/migrations/op_create_index_test.go
+++ b/pkg/migrations/op_create_index_test.go
@@ -349,7 +349,7 @@ func TestCreateIndexOnObjectsCreatedInSameMigration(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The index has been created on the underlying table.
-				IndexMustExist(t, db, schema, migrations.TemporaryName("users"), "idx_users_name")
+				IndexMustExist(t, db, schema, "users", "idx_users_name")
 			},
 			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// The index has been dropped from the the underlying table.

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -53,18 +53,13 @@ func (o *OpCreateTable) Start(ctx context.Context, conn db.DB, latestSchema stri
 }
 
 func (o *OpCreateTable) Complete(ctx context.Context, conn db.DB, tr SQLTransformer, s *schema.Schema) error {
-	tempName := TemporaryName(o.Name)
-	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s RENAME TO %s",
-		pq.QuoteIdentifier(tempName),
-		pq.QuoteIdentifier(o.Name)))
-	return err
+	// No-op
+	return nil
 }
 
 func (o *OpCreateTable) Rollback(ctx context.Context, conn db.DB, tr SQLTransformer, s *schema.Schema) error {
-	tempName := TemporaryName(o.Name)
-
 	_, err := conn.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s",
-		pq.QuoteIdentifier(tempName)))
+		pq.QuoteIdentifier(o.Name)))
 	return err
 }
 

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -22,7 +22,7 @@ func (o *OpCreateTable) Start(ctx context.Context, conn db.DB, latestSchema stri
 		return nil, fmt.Errorf("failed to create columns SQL: %w", err)
 	}
 
-	// Create the table using the original name
+	// Create the table
 	_, err = conn.ExecContext(ctx, fmt.Sprintf("CREATE TABLE %s (%s)",
 		pq.QuoteIdentifier(o.Name),
 		columnsSQL))

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -22,10 +22,9 @@ func (o *OpCreateTable) Start(ctx context.Context, conn db.DB, latestSchema stri
 		return nil, fmt.Errorf("failed to create columns SQL: %w", err)
 	}
 
-	// Create the table under a temporary name
-	tempName := TemporaryName(o.Name)
+	// Create the table using the original name
 	_, err = conn.ExecContext(ctx, fmt.Sprintf("CREATE TABLE %s (%s)",
-		pq.QuoteIdentifier(tempName),
+		pq.QuoteIdentifier(o.Name),
 		columnsSQL))
 	if err != nil {
 		return nil, err
@@ -34,7 +33,7 @@ func (o *OpCreateTable) Start(ctx context.Context, conn db.DB, latestSchema stri
 	// Add comments to any columns that have them
 	for _, col := range o.Columns {
 		if col.Comment != nil {
-			if err := addCommentToColumn(ctx, conn, tempName, col.Name, col.Comment); err != nil {
+			if err := addCommentToColumn(ctx, conn, o.Name, col.Name, col.Comment); err != nil {
 				return nil, fmt.Errorf("failed to add comment to column: %w", err)
 			}
 		}
@@ -42,7 +41,7 @@ func (o *OpCreateTable) Start(ctx context.Context, conn db.DB, latestSchema stri
 
 	// Add comment to the table itself
 	if o.Comment != nil {
-		if err := addCommentToTable(ctx, conn, tempName, o.Comment); err != nil {
+		if err := addCommentToTable(ctx, conn, o.Name, o.Comment); err != nil {
 			return nil, fmt.Errorf("failed to add comment to table: %w", err)
 		}
 	}
@@ -125,7 +124,7 @@ func (o *OpCreateTable) updateSchema(s *schema.Schema) *schema.Schema {
 		}
 	}
 	s.AddTable(o.Name, schema.Table{
-		Name:    TemporaryName(o.Name),
+		Name:    o.Name,
 		Columns: columns,
 	})
 

--- a/pkg/migrations/op_create_table_test.go
+++ b/pkg/migrations/op_create_table_test.go
@@ -214,7 +214,7 @@ func TestCreateTable(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The foreign key constraint exists on the new table.
-				ValidatedForeignKeyMustExist(t, db, schema, migrations.TemporaryName("orders"), "fk_users_id")
+				ValidatedForeignKeyMustExist(t, db, schema, "orders", "fk_users_id")
 
 				// Inserting a row into the referenced table succeeds.
 				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
@@ -322,7 +322,7 @@ func TestCreateTable(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The foreign key constraint exists on the new table.
-				ValidatedForeignKeyMustExist(t, db, schema, migrations.TemporaryName("orders"), "fk_users_id", withOnDeleteCascade())
+				ValidatedForeignKeyMustExist(t, db, schema, "orders", "fk_users_id", withOnDeleteCascade())
 
 				// Inserting a row into the referenced table succeeds.
 				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
@@ -412,7 +412,7 @@ func TestCreateTable(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The check constraint exists on the new table.
-				CheckConstraintMustExist(t, db, schema, migrations.TemporaryName("users"), "check_name_length")
+				CheckConstraintMustExist(t, db, schema, "users", "check_name_length")
 
 				// Inserting a row into the table succeeds when the check constraint is satisfied.
 				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
@@ -469,11 +469,10 @@ func TestCreateTable(t *testing.T) {
 				},
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
-				tableName := migrations.TemporaryName("users")
 				// The comment has been added to the underlying table.
-				TableMustHaveComment(t, db, schema, tableName, "the users table")
+				TableMustHaveComment(t, db, schema, "users", "the users table")
 				// The comment has been added to the underlying column.
-				ColumnMustHaveComment(t, db, schema, tableName, "name", "the username")
+				ColumnMustHaveComment(t, db, schema, "users", "name", "the username")
 			},
 			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},

--- a/pkg/migrations/op_drop_constraint_test.go
+++ b/pkg/migrations/op_drop_constraint_test.go
@@ -369,7 +369,7 @@ func TestDropConstraint(t *testing.T) {
 					Operations: migrations.Operations{
 						&migrations.OpDropConstraint{
 							Table: "users",
-							Name:  "_pgroll_new_users_name_key",
+							Name:  "users_name_key",
 							Up:    "name",
 							Down:  "name || '-' || (random()*1000000)::integer",
 						},
@@ -438,7 +438,7 @@ func TestDropConstraint(t *testing.T) {
 					Operations: migrations.Operations{
 						&migrations.OpDropConstraint{
 							Table: "users",
-							Name:  "_pgroll_new_users_name_key",
+							Name:  "users_name_key",
 							Up:    "name",
 							Down:  "name || '-' || (random()*1000000)::integer",
 						},
@@ -537,7 +537,7 @@ func TestDropConstraint(t *testing.T) {
 					Operations: migrations.Operations{
 						&migrations.OpDropConstraint{
 							Table: "employees",
-							Name:  "_pgroll_new_employees_department_id_key",
+							Name:  "employees_department_id_key",
 							Up:    "department_id",
 							Down:  "department_id",
 						},
@@ -599,7 +599,7 @@ func TestDropConstraint(t *testing.T) {
 					Operations: migrations.Operations{
 						&migrations.OpDropConstraint{
 							Table: "posts",
-							Name:  "_pgroll_new_posts_title_key",
+							Name:  "posts_title_key",
 							Up:    "title",
 							Down:  "title",
 						},
@@ -742,7 +742,7 @@ func TestDropConstraint(t *testing.T) {
 					Operations: migrations.Operations{
 						&migrations.OpDropConstraint{
 							Table: "posts",
-							Name:  "_pgroll_new_posts_title_key",
+							Name:  "posts_title_key",
 							Up:    "title",
 							Down:  "title",
 						},
@@ -794,7 +794,7 @@ func TestDropConstraint(t *testing.T) {
 					Operations: migrations.Operations{
 						&migrations.OpDropConstraint{
 							Table: "posts",
-							Name:  "_pgroll_new_posts_title_key",
+							Name:  "posts_title_key",
 							Up:    "title",
 							Down:  "title",
 						},

--- a/pkg/migrations/op_set_replica_identity_test.go
+++ b/pkg/migrations/op_set_replica_identity_test.go
@@ -120,7 +120,7 @@ func TestSetReplicaIdentity(t *testing.T) {
 							Table: "users",
 							Identity: migrations.ReplicaIdentity{
 								Type:  "index",
-								Index: "_pgroll_new_users_pkey",
+								Index: "users_pkey",
 							},
 						},
 					},


### PR DESCRIPTION
Using the original name, instead of calling `TemporaryName` which adds the prefix `_pgroll_new_` in create table operations and also when rolling back.
Includes necessary changes in tests.
Fixes: #571 