### PR TITLE
Add missing index renaming when completing a migration

### DIFF
--- a/pkg/migrations/rename.go
+++ b/pkg/migrations/rename.go
@@ -138,6 +138,9 @@ func RenameDuplicatedColumn(ctx context.Context, conn db.DB, table *schema.Table
 			if err != nil {
 				return fmt.Errorf("failed to rename index %q: %w", idx.Name, err)
 			}
+
+			// Index no longer exists, remove it from the table
+			delete(table.Indexes, idx.Name)
 		}
 
 		if _, ok := table.UniqueConstraints[StripDuplicationPrefix(idx.Name)]; idx.Unique && ok {
@@ -154,8 +157,6 @@ func RenameDuplicatedColumn(ctx context.Context, conn db.DB, table *schema.Table
 			}
 		}
 
-		// Index no longer exists, remove it from the table
-		delete(table.Indexes, idx.Name)
 	}
 
 	return nil


### PR DESCRIPTION
During testing the faithful duplication of indexed columns I discovered that
if a column is included in multiple indices the only one of the indices are renamed. It happened because the index was deleted from the bookkeeper in the table even if the index was not renamed.

```
postgres=# \d items
                                          Table "public.items"
 Column |          Type          | Collation | Nullable |                    Default
--------+------------------------+-----------+----------+-----------------------------------------------
 id     | integer                |           | not null | nextval('_pgroll_new_items_id_seq'::regclass)
 city   | character varying(255) |           |          |
 name   | character varying(255) |           |          |
Indexes:
    "_pgroll_new_items_pkey" PRIMARY KEY, btree (id)
    "_pgroll_dup_idx_items_unique_name" UNIQUE, btree (name)
    "items_unique_name_id" UNIQUE CONSTRAINT, btree (city, name)

```

Correct output after my fix:

```
postgres=# \d items
                                          Table "public.items"
 Column |          Type          | Collation | Nullable |                    Default
--------+------------------------+-----------+----------+-----------------------------------------------
 id     | integer                |           | not null | nextval('_pgroll_new_items_id_seq'::regclass)
 city   | character varying(255) |           |          |
 name   | character varying(255) |           |          |
Indexes:
    "_pgroll_new_items_pkey" PRIMARY KEY, btree (id)
    "idx_items_unique_name" UNIQUE, btree (name)
    "items_unique_name_id" UNIQUE CONSTRAINT, btree (city, name)

```
