### PR TITLE
Add `constraints` option to `create_table` and `unique` constraint support

### DIFF
--- a/docs/operations/create_table.mdx
+++ b/docs/operations/create_table.mdx
@@ -9,7 +9,8 @@ description: A create table operation creates a new table in the database.
 {
   "create_table": {
     "name": "name of new table",
-    "columns": [...]
+    "columns": [...],
+    "constraints": [...]
   }
 }
 ```
@@ -39,6 +40,26 @@ Each `column` is defined as:
 ```
 
 Default values are subject to the usual rules for quoting SQL expressions. In particular, string literals should be surrounded with single quotes.
+
+Each `constraint` is defined as:
+
+```json
+{
+  "name": "constraint name",
+  "type": "constraint type",
+  "columns": ["list", "of", "columns"],
+  "nulls_not_distinct": true|false,
+  "deferrable": true|false,
+  "initially_deferred": true|false,
+  "index_parameters": {
+    "tablespace": "index_tablespace",
+    "storage_parameters": "parameter=value",
+    "include_columns": ["list", "of", "columns", "included in index"]
+  },
+},
+```
+
+Supported constraint types: `unique`.
 
 ## Examples
 
@@ -98,3 +119,9 @@ Create a table with a `CHECK` constraint on one column:
 Create a table with different `DEFAULT` values:
 
 <ExampleSnippet example="28_different_defaults.json" language="json" />
+
+### Create a table with table level unique constraint
+
+Create a table with table level constraints:
+
+<ExampleSnippet example="50_create_table_with_table_constraint.json" language="json" />

--- a/examples/.ledger
+++ b/examples/.ledger
@@ -47,3 +47,4 @@
 47_add_table_foreign_key_constraint.json
 48_drop_tickets_check.json
 49_unset_not_null_on_indexed_column.json
+50_create_table_with_table_constraint.json

--- a/examples/50_create_table_with_table_constraint.json
+++ b/examples/50_create_table_with_table_constraint.json
@@ -1,0 +1,39 @@
+{
+  "name": "50_create_table_with_table_constraint",
+  "operations": [
+    {
+      "create_table": {
+        "name": "phonebook",
+        "columns": [
+          {
+            "name": "id",
+            "type": "serial",
+            "pk": true
+          },
+          {
+            "name": "name",
+            "type": "varchar(255)"
+          },
+          {
+            "name": "city",
+            "type": "varchar(255)"
+          },
+          {
+            "name": "phone",
+            "type": "varchar(255)"
+          }
+        ],
+        "constraints": [
+          {
+            "name": "unique_numbers",
+            "type": "unique",
+            "columns": ["phone"],
+            "index_parameters": {
+              "include_columns": ["name"]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/50_create_table_with_table_constraint.json
+++ b/examples/50_create_table_with_table_constraint.json
@@ -27,9 +27,13 @@
           {
             "name": "unique_numbers",
             "type": "unique",
-            "columns": ["phone"],
+            "columns": [
+              "phone"
+            ],
             "index_parameters": {
-              "include_columns": ["name"]
+              "include_columns": [
+                "name"
+              ]
             }
           }
         ]

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -230,11 +230,15 @@ type ConstraintSQLWriter struct {
 }
 
 func (w *ConstraintSQLWriter) WriteUnique(nullsNotDistinct *bool) string {
+	var constraint string
+	if w.Name != "" {
+		constraint = fmt.Sprintf("CONSTRAINT %s ", pq.QuoteIdentifier(w.Name))
+	}
 	nullsDistinct := ""
 	if nullsNotDistinct != nil && *nullsNotDistinct {
 		nullsDistinct = "NULLS NOT DISTINCT"
 	}
-	constraint := fmt.Sprintf("CONSTRAINT %s UNIQUE %s (%s)", pq.QuoteIdentifier(w.Name), nullsDistinct, strings.Join(quoteColumnNames(w.Columns), ", "))
+	constraint += fmt.Sprintf("UNIQUE %s (%s)", nullsDistinct, strings.Join(quoteColumnNames(w.Columns), ", "))
 	constraint += w.addIndexParameters()
 	constraint += w.addDeferrable()
 	return constraint

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -195,9 +195,11 @@ func constraintsToSQL(constraints []Constraint) (string, error) {
 			Columns:           c.Columns,
 			InitiallyDeferred: c.InitiallyDeferred,
 			Deferrable:        c.Deferrable,
-			IncludeColumns:    c.IndexParameters.IncludeColumns,
-			StorageParameters: c.IndexParameters.StorageParameters,
-			Tablespace:        c.IndexParameters.Tablespace,
+		}
+		if c.IndexParameters != nil {
+			writer.IncludeColumns = c.IndexParameters.IncludeColumns
+			writer.StorageParameters = c.IndexParameters.StorageParameters
+			writer.Tablespace = c.IndexParameters.Tablespace
 		}
 
 		switch c.Type { //nolint:gocritic // more cases are coming soon

--- a/pkg/migrations/op_create_table_test.go
+++ b/pkg/migrations/op_create_table_test.go
@@ -665,6 +665,38 @@ func TestCreateTableValidation(t *testing.T) {
 			},
 			wantStartErr: migrations.InvalidIdentifierLengthError{Name: invalidName},
 		},
+		{
+			name: "missing column list in unique constraint",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_create_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "table1",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name:   "name",
+									Type:   "varchar(255)",
+									Unique: true,
+								},
+							},
+							Constraints: []migrations.Constraint{
+								{
+									Name: "unique_name",
+									Type: migrations.ConstraintTypeUnique,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStartErr: migrations.FieldRequiredError{Name: "columns"},
+		},
 	})
 }
 

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -52,11 +52,14 @@ type Constraint struct {
 	// Columns to add constraint to
 	Columns []string `json:"columns,omitempty"`
 
-	// Defferable constraint
-	Defferable *bool `json:"defferable,omitempty"`
+	// Deferable constraint
+	Deferable *bool `json:"deferable,omitempty"`
 
 	// Exclude constraint
 	Exclude *ConstraintExclude `json:"exclude,omitempty"`
+
+	// IncludeColumns corresponds to the JSON schema field "include_columns".
+	IncludeColumns []string `json:"include_columns,omitempty"`
 
 	// Initially deferred constraint
 	InitiallyDeferred *bool `json:"initially_deferred,omitempty"`
@@ -73,6 +76,12 @@ type Constraint struct {
 	// Reference to the foreign key
 	References *ConstraintReferences `json:"references,omitempty"`
 
+	// StorageParameters corresponds to the JSON schema field "storage_parameters".
+	StorageParameters *string `json:"storage_parameters,omitempty"`
+
+	// Tablespace corresponds to the JSON schema field "tablespace".
+	Tablespace *string `json:"tablespace,omitempty"`
+
 	// Type of the constraint
 	Type ConstraintType `json:"type"`
 }
@@ -80,22 +89,13 @@ type Constraint struct {
 // Exclude constraint
 type ConstraintExclude struct {
 	// Elements corresponds to the JSON schema field "elements".
-	Elements []string `json:"elements,omitempty"`
-
-	// IncludeColumns corresponds to the JSON schema field "include_columns".
-	IncludeColumns []string `json:"include_columns,omitempty"`
+	Elements string `json:"elements"`
 
 	// IndexMethod corresponds to the JSON schema field "index_method".
-	IndexMethod *string `json:"index_method,omitempty"`
+	IndexMethod string `json:"index_method"`
 
 	// Predicate corresponds to the JSON schema field "predicate".
 	Predicate *string `json:"predicate,omitempty"`
-
-	// StorageParameters corresponds to the JSON schema field "storage_parameters".
-	StorageParameters *string `json:"storage_parameters,omitempty"`
-
-	// Tablespace corresponds to the JSON schema field "tablespace".
-	Tablespace *string `json:"tablespace,omitempty"`
 }
 
 // Reference to the foreign key

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -46,20 +46,14 @@ type Column struct {
 
 // Constraint definition
 type Constraint struct {
-	// Check constraint expression
-	Check *string `json:"check,omitempty"`
-
 	// Columns to add constraint to
 	Columns []string `json:"columns,omitempty"`
 
 	// Deferable constraint
-	Deferable *bool `json:"deferable,omitempty"`
+	Deferrable *bool `json:"deferrable,omitempty"`
 
-	// Exclude constraint
-	Exclude *ConstraintExclude `json:"exclude,omitempty"`
-
-	// IncludeColumns corresponds to the JSON schema field "include_columns".
-	IncludeColumns []string `json:"include_columns,omitempty"`
+	// IndexParameters corresponds to the JSON schema field "index_parameters".
+	IndexParameters *ConstraintIndexParameters `json:"index_parameters,omitempty"`
 
 	// Initially deferred constraint
 	InitiallyDeferred *bool `json:"initially_deferred,omitempty"`
@@ -67,61 +61,26 @@ type Constraint struct {
 	// Name of the constraint
 	Name string `json:"name"`
 
-	// No inherit constraint
-	NoInherit *bool `json:"no_inherit,omitempty"`
-
 	// Nulls not distinct constraint
 	NullsNotDistinct *bool `json:"nulls_not_distinct,omitempty"`
 
-	// Reference to the foreign key
-	References *ConstraintReferences `json:"references,omitempty"`
+	// Type of the constraint
+	Type ConstraintType `json:"type"`
+}
+
+type ConstraintIndexParameters struct {
+	// IncludeColumns corresponds to the JSON schema field "include_columns".
+	IncludeColumns []string `json:"include_columns,omitempty"`
 
 	// StorageParameters corresponds to the JSON schema field "storage_parameters".
 	StorageParameters *string `json:"storage_parameters,omitempty"`
 
 	// Tablespace corresponds to the JSON schema field "tablespace".
 	Tablespace *string `json:"tablespace,omitempty"`
-
-	// Type of the constraint
-	Type ConstraintType `json:"type"`
-}
-
-// Exclude constraint
-type ConstraintExclude struct {
-	// Elements corresponds to the JSON schema field "elements".
-	Elements string `json:"elements"`
-
-	// IndexMethod corresponds to the JSON schema field "index_method".
-	IndexMethod string `json:"index_method"`
-
-	// Predicate corresponds to the JSON schema field "predicate".
-	Predicate *string `json:"predicate,omitempty"`
-}
-
-// Reference to the foreign key
-type ConstraintReferences struct {
-	// Columns to reference
-	Columns []string `json:"columns"`
-
-	// Match type of the foreign key constraint
-	MatchType *string `json:"match_type,omitempty"`
-
-	// On delete behavior of the foreign key constraint
-	OnDelete ForeignKeyReferenceOnDelete `json:"on_delete,omitempty"`
-
-	// On update behavior of the foreign key constraint
-	OnUpdate ForeignKeyReferenceOnDelete `json:"on_update,omitempty"`
-
-	// Name of the table
-	Table string `json:"table"`
 }
 
 type ConstraintType string
 
-const ConstraintTypeCheck ConstraintType = "check"
-const ConstraintTypeExclude ConstraintType = "exclude"
-const ConstraintTypeForeignKey ConstraintType = "foreign_key"
-const ConstraintTypePrimaryKey ConstraintType = "primary_key"
 const ConstraintTypeUnique ConstraintType = "unique"
 
 // Foreign key reference definition

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -44,6 +44,86 @@ type Column struct {
 	Unique bool `json:"unique,omitempty"`
 }
 
+// Constraint definition
+type Constraint struct {
+	// Check constraint expression
+	Check *string `json:"check,omitempty"`
+
+	// Columns to add constraint to
+	Columns []string `json:"columns,omitempty"`
+
+	// Defferable constraint
+	Defferable *bool `json:"defferable,omitempty"`
+
+	// Exclude constraint
+	Exclude *ConstraintExclude `json:"exclude,omitempty"`
+
+	// Initially deferred constraint
+	InitiallyDeferred *bool `json:"initially_deferred,omitempty"`
+
+	// Name of the constraint
+	Name string `json:"name"`
+
+	// No inherit constraint
+	NoInherit *bool `json:"no_inherit,omitempty"`
+
+	// Nulls not distinct constraint
+	NullsNotDistinct *bool `json:"nulls_not_distinct,omitempty"`
+
+	// Reference to the foreign key
+	References *ConstraintReferences `json:"references,omitempty"`
+
+	// Type of the constraint
+	Type ConstraintType `json:"type"`
+}
+
+// Exclude constraint
+type ConstraintExclude struct {
+	// Elements corresponds to the JSON schema field "elements".
+	Elements []string `json:"elements,omitempty"`
+
+	// IncludeColumns corresponds to the JSON schema field "include_columns".
+	IncludeColumns []string `json:"include_columns,omitempty"`
+
+	// IndexMethod corresponds to the JSON schema field "index_method".
+	IndexMethod *string `json:"index_method,omitempty"`
+
+	// Predicate corresponds to the JSON schema field "predicate".
+	Predicate *string `json:"predicate,omitempty"`
+
+	// StorageParameters corresponds to the JSON schema field "storage_parameters".
+	StorageParameters *string `json:"storage_parameters,omitempty"`
+
+	// Tablespace corresponds to the JSON schema field "tablespace".
+	Tablespace *string `json:"tablespace,omitempty"`
+}
+
+// Reference to the foreign key
+type ConstraintReferences struct {
+	// Columns to reference
+	Columns []string `json:"columns"`
+
+	// Match type of the foreign key constraint
+	MatchType *string `json:"match_type,omitempty"`
+
+	// On delete behavior of the foreign key constraint
+	OnDelete ForeignKeyReferenceOnDelete `json:"on_delete,omitempty"`
+
+	// On update behavior of the foreign key constraint
+	OnUpdate ForeignKeyReferenceOnDelete `json:"on_update,omitempty"`
+
+	// Name of the table
+	Table string `json:"table"`
+}
+
+type ConstraintType string
+
+const ConstraintTypeCheck ConstraintType = "check"
+const ConstraintTypeExclude ConstraintType = "exclude"
+const ConstraintTypeForeignKey ConstraintType = "foreign_key"
+const ConstraintTypePrimaryKey ConstraintType = "primary_key"
+const ConstraintTypeUnique ConstraintType = "unique"
+
 // Foreign key reference definition
 type ForeignKeyReference struct {
 	// Name of the referenced column
@@ -211,6 +291,9 @@ type OpCreateTable struct {
 
 	// Postgres comment for the table
 	Comment *string `json:"comment,omitempty"`
+
+	// Constraints corresponds to the JSON schema field "constraints".
+	Constraints []Constraint `json:"constraints,omitempty"`
 
 	// Name of the table
 	Name string `json:"name"`

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -50,19 +50,19 @@ type Constraint struct {
 	Columns []string `json:"columns,omitempty"`
 
 	// Deferable constraint
-	Deferrable *bool `json:"deferrable,omitempty"`
+	Deferrable bool `json:"deferrable,omitempty"`
 
 	// IndexParameters corresponds to the JSON schema field "index_parameters".
 	IndexParameters *ConstraintIndexParameters `json:"index_parameters,omitempty"`
 
 	// Initially deferred constraint
-	InitiallyDeferred *bool `json:"initially_deferred,omitempty"`
+	InitiallyDeferred bool `json:"initially_deferred,omitempty"`
 
 	// Name of the constraint
 	Name string `json:"name"`
 
 	// Nulls not distinct constraint
-	NullsNotDistinct *bool `json:"nulls_not_distinct,omitempty"`
+	NullsNotDistinct bool `json:"nulls_not_distinct,omitempty"`
 
 	// Type of the constraint
 	Type ConstraintType `json:"type"`
@@ -73,10 +73,10 @@ type ConstraintIndexParameters struct {
 	IncludeColumns []string `json:"include_columns,omitempty"`
 
 	// StorageParameters corresponds to the JSON schema field "storage_parameters".
-	StorageParameters *string `json:"storage_parameters,omitempty"`
+	StorageParameters string `json:"storage_parameters,omitempty"`
 
 	// Tablespace corresponds to the JSON schema field "tablespace".
-	Tablespace *string `json:"tablespace,omitempty"`
+	Tablespace string `json:"tablespace,omitempty"`
 }
 
 type ConstraintType string

--- a/pkg/sql2pgroll/convert.go
+++ b/pkg/sql2pgroll/convert.go
@@ -20,6 +20,7 @@ func Convert(sql string) (migrations.Operations, error) {
 	}
 
 	if ops == nil {
+		fmt.Println("ops is nil")
 		return makeRawSQLOperation(sql), nil
 	}
 

--- a/pkg/sql2pgroll/convert.go
+++ b/pkg/sql2pgroll/convert.go
@@ -20,7 +20,6 @@ func Convert(sql string) (migrations.Operations, error) {
 	}
 
 	if ops == nil {
-		fmt.Println("ops is nil")
 		return makeRawSQLOperation(sql), nil
 	}
 

--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -15,7 +15,6 @@ import (
 func convertCreateStmt(stmt *pgq.CreateStmt) (migrations.Operations, error) {
 	// Check if the statement can be converted
 	if !canConvertCreateStatement(stmt) {
-		fmt.Println("cannot convert create statement")
 		return nil, nil
 	}
 

--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -39,13 +39,13 @@ func convertCreateStmt(stmt *pgq.CreateStmt) (migrations.Operations, error) {
 		}
 	}
 
-	var constraints []migrations.Constraint
-	for _, c := range stmt.Constraints {
+	constraints := make([]migrations.Constraint, len(stmt.Constraints))
+	for i, c := range stmt.Constraints {
 		constraint, err := convertConstraint(c.GetConstraint())
 		if err != nil {
 			return nil, fmt.Errorf("error converting table constraint: %w", err)
 		}
-		constraints = append(constraints, *constraint)
+		constraints[i] = *constraint
 	}
 
 	return migrations.Operations{

--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -40,6 +40,9 @@ func convertCreateStmt(stmt *pgq.CreateStmt) (migrations.Operations, error) {
 			if err != nil {
 				return nil, fmt.Errorf("error converting table constraint: %w", err)
 			}
+			if constraint == nil {
+				return nil, nil
+			}
 			constraints = append(constraints, *constraint)
 		default:
 			return nil, nil
@@ -207,7 +210,7 @@ func convertConstraint(c *pgq.Constraint) (*migrations.Constraint, error) {
 		constraintType = migrations.ConstraintTypeUnique
 		nullsNotDistinct = ptr(c.NullsNotDistinct)
 	default:
-		return nil, fmt.Errorf("unsupported constraint type: %s", c.Contype)
+		return nil, nil
 	}
 
 	columns := make([]string, len(c.Keys))

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -3,7 +3,6 @@
 package sql2pgroll_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -3,6 +3,7 @@
 package sql2pgroll_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -181,6 +182,7 @@ func TestConvertCreateTableStatements(t *testing.T) {
 
 			require.Len(t, ops, 1)
 
+			fmt.Println(ops[0])
 			createTableOp, ok := ops[0].(*migrations.OpCreateTable)
 			require.True(t, ok)
 

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -182,7 +182,6 @@ func TestConvertCreateTableStatements(t *testing.T) {
 
 			require.Len(t, ops, 1)
 
-			fmt.Println(ops[0])
 			createTableOp, ok := ops[0].(*migrations.OpCreateTable)
 			require.True(t, ok)
 

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -165,11 +165,11 @@ func TestConvertCreateTableStatements(t *testing.T) {
 			expectedOp: expect.CreateTableOp21,
 		},
 		{
-			sql:        "CREATE TABLE foo(a serial PRIMARY KEY, b text, c text, UNIQUE (b, c)",
+			sql:        "CREATE TABLE foo(a serial PRIMARY KEY, b text, c text, UNIQUE (b, c))",
 			expectedOp: expect.CreateTableOp22,
 		},
 		{
-			sql:        "CREATE TABLE foo(b text, c text, UNIQUE (b) include (c) with (fillfactor = 70))",
+			sql:        "CREATE TABLE foo(b text, c text, UNIQUE (b) include (c) with (fillfactor = 70) using index tablespace my_tablespace)",
 			expectedOp: expect.CreateTableOp23,
 		},
 	}

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -170,7 +170,7 @@ func TestConvertCreateTableStatements(t *testing.T) {
 			expectedOp: expect.CreateTableOp22,
 		},
 		{
-			sql:        "CREATE TABLE foo(b text, c text, UNIQUE (b) include (c) with (fillfactor = 70) using index tablespace my_tablespace)",
+			sql:        "CREATE TABLE foo(b text, c text, UNIQUE (b) INCLUDE (c) WITH (fillfactor = 70) USING INDEX TABLESPACE my_tablespace)",
 			expectedOp: expect.CreateTableOp23,
 		},
 	}

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -164,6 +164,14 @@ func TestConvertCreateTableStatements(t *testing.T) {
 			sql:        "CREATE TABLE foo(a serial PRIMARY KEY, b int DEFAULT 100 CHECK (b > 0), c text NOT NULL UNIQUE)",
 			expectedOp: expect.CreateTableOp21,
 		},
+		{
+			sql:        "CREATE TABLE foo(a serial PRIMARY KEY, b text, c text, UNIQUE (b, c)",
+			expectedOp: expect.CreateTableOp22,
+		},
+		{
+			sql:        "CREATE TABLE foo(b text, c text, UNIQUE (b) include (c) with (fillfactor = 70))",
+			expectedOp: expect.CreateTableOp23,
+		},
 	}
 
 	for _, tc := range tests {
@@ -232,11 +240,9 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 
 		// Table constraints, named and unnamed, are not supported
 		"CREATE TABLE foo(a int, CONSTRAINT foo_check CHECK (a > 0))",
-		"CREATE TABLE foo(a int, CONSTRAINT foo_unique UNIQUE (a))",
 		"CREATE TABLE foo(a int, CONSTRAINT foo_pk PRIMARY KEY (a))",
 		"CREATE TABLE foo(a int, CONSTRAINT foo_fk FOREIGN KEY (a) REFERENCES bar(b))",
 		"CREATE TABLE foo(a int, CHECK (a > 0))",
-		"CREATE TABLE foo(a int, UNIQUE (a))",
 		"CREATE TABLE foo(a int, PRIMARY KEY (a))",
 		"CREATE TABLE foo(a int, FOREIGN KEY (a) REFERENCES bar(b))",
 

--- a/pkg/sql2pgroll/expect/create_table.go
+++ b/pkg/sql2pgroll/expect/create_table.go
@@ -348,7 +348,7 @@ var CreateTableOp23 = &migrations.OpCreateTable{
 			InitiallyDeferred: false,
 			IndexParameters: &migrations.ConstraintIndexParameters{
 				IncludeColumns:    []string{"c"},
-				StorageParameters: "fillfactor = '70'",
+				StorageParameters: "fillfactor=70",
 				Tablespace:        "my_tablespace",
 			},
 		},

--- a/pkg/sql2pgroll/expect/create_table.go
+++ b/pkg/sql2pgroll/expect/create_table.go
@@ -304,18 +304,23 @@ var CreateTableOp22 = &migrations.OpCreateTable{
 			Pk:   true,
 		},
 		{
-			Name: "b",
-			Type: "text",
+			Name:     "b",
+			Type:     "text",
+			Nullable: true,
 		},
 		{
-			Name: "c",
-			Type: "text",
+			Name:     "c",
+			Type:     "text",
+			Nullable: true,
 		},
 	},
 	Constraints: []migrations.Constraint{
 		{
-			Type:    migrations.ConstraintTypeUnique,
-			Columns: []string{"b", "c"},
+			Type:              migrations.ConstraintTypeUnique,
+			Columns:           []string{"b", "c"},
+			NullsNotDistinct:  ptr(false),
+			Deferrable:        ptr(false),
+			InitiallyDeferred: ptr(false),
 		},
 	},
 }
@@ -324,21 +329,26 @@ var CreateTableOp23 = &migrations.OpCreateTable{
 	Name: "foo",
 	Columns: []migrations.Column{
 		{
-			Name: "b",
-			Type: "text",
+			Name:     "b",
+			Type:     "text",
+			Nullable: true,
 		},
 		{
-			Name: "c",
-			Type: "text",
+			Name:     "c",
+			Type:     "text",
+			Nullable: true,
 		},
 	},
 	Constraints: []migrations.Constraint{
 		{
-			Type:    migrations.ConstraintTypeUnique,
-			Columns: []string{"b"},
+			Type:              migrations.ConstraintTypeUnique,
+			Columns:           []string{"b"},
+			NullsNotDistinct:  ptr(false),
+			Deferrable:        ptr(false),
+			InitiallyDeferred: ptr(false),
 			IndexParameters: &migrations.ConstraintIndexParameters{
 				IncludeColumns:    []string{"c"},
-				StorageParameters: ptr("fillfactor=70"),
+				StorageParameters: ptr("fillfactor = '70'"),
 				Tablespace:        ptr("my_tablespace"),
 			},
 		},

--- a/pkg/sql2pgroll/expect/create_table.go
+++ b/pkg/sql2pgroll/expect/create_table.go
@@ -294,3 +294,53 @@ var CreateTableOp21 = &migrations.OpCreateTable{
 		},
 	},
 }
+
+var CreateTableOp22 = &migrations.OpCreateTable{
+	Name: "foo",
+	Columns: []migrations.Column{
+		{
+			Name: "a",
+			Type: "serial",
+			Pk:   true,
+		},
+		{
+			Name: "b",
+			Type: "text",
+		},
+		{
+			Name: "c",
+			Type: "text",
+		},
+	},
+	Constraints: []migrations.Constraint{
+		{
+			Type:    migrations.ConstraintTypeUnique,
+			Columns: []string{"b", "c"},
+		},
+	},
+}
+
+var CreateTableOp23 = &migrations.OpCreateTable{
+	Name: "foo",
+	Columns: []migrations.Column{
+		{
+			Name: "b",
+			Type: "text",
+		},
+		{
+			Name: "c",
+			Type: "text",
+		},
+	},
+	Constraints: []migrations.Constraint{
+		{
+			Type:    migrations.ConstraintTypeUnique,
+			Columns: []string{"b"},
+			IndexParameters: &migrations.ConstraintIndexParameters{
+				IncludeColumns:    []string{"c"},
+				StorageParameters: ptr("fillfactor=70"),
+				Tablespace:        ptr("my_tablespace"),
+			},
+		},
+	},
+}

--- a/pkg/sql2pgroll/expect/create_table.go
+++ b/pkg/sql2pgroll/expect/create_table.go
@@ -318,9 +318,9 @@ var CreateTableOp22 = &migrations.OpCreateTable{
 		{
 			Type:              migrations.ConstraintTypeUnique,
 			Columns:           []string{"b", "c"},
-			NullsNotDistinct:  ptr(false),
-			Deferrable:        ptr(false),
-			InitiallyDeferred: ptr(false),
+			NullsNotDistinct:  false,
+			Deferrable:        false,
+			InitiallyDeferred: false,
 		},
 	},
 }
@@ -343,13 +343,13 @@ var CreateTableOp23 = &migrations.OpCreateTable{
 		{
 			Type:              migrations.ConstraintTypeUnique,
 			Columns:           []string{"b"},
-			NullsNotDistinct:  ptr(false),
-			Deferrable:        ptr(false),
-			InitiallyDeferred: ptr(false),
+			NullsNotDistinct:  false,
+			Deferrable:        false,
+			InitiallyDeferred: false,
 			IndexParameters: &migrations.ConstraintIndexParameters{
 				IncludeColumns:    []string{"c"},
-				StorageParameters: ptr("fillfactor = '70'"),
-				Tablespace:        ptr("my_tablespace"),
+				StorageParameters: "fillfactor = '70'",
+				Tablespace:        "my_tablespace",
 			},
 		},
 	},

--- a/schema.json
+++ b/schema.json
@@ -155,8 +155,8 @@
             }
           }
         },
-        "defferable": {
-          "description": "Defferable constraint",
+        "deferable": {
+          "description": "Deferable constraint",
           "type": "boolean"
         },
         "initially_deferred": {
@@ -171,36 +171,34 @@
           "description": "Nulls not distinct constraint",
           "type": "boolean"
         },
+        "tablespace": {
+          "type": "string"
+        },
+        "storage_parameters": {
+          "type": "string"
+        },
+        "include_columns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "exclude": {
           "description": "Exclude constraint",
           "additionalProperties": false,
           "type": "object",
           "properties": {
             "elements": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+              "type": "string"
             },
             "index_method": {
               "type": "string"
             },
-            "include_columns": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "storage_parameters": {
-              "type": "string"
-            },
             "predicate": {
               "type": "string"
-            },
-            "tablespace": {
-              "type": "string"
             }
-          }
+          },
+          "required": ["index_method", "elements"]
         }
       },
       "required": ["name", "type"],

--- a/schema.json
+++ b/schema.json
@@ -98,6 +98,58 @@
       "type": "string",
       "enum": ["NO ACTION", "RESTRICT", "CASCADE", "SET NULL", "SET DEFAULT"]
     },
+    "Constraint": {
+      "additionalProperties": false,
+      "description": "Constraint definition",
+      "properties": {
+        "name": {
+          "description": "Name of the constraint",
+          "type": "string"
+        },
+        "columns": {
+          "description": "Columns to add constraint to",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "description": "Type of the constraint",
+          "type": "string",
+          "enum": ["unique", "check", "foreign_key"]
+        },
+        "check": {
+          "description": "Check constraint expression",
+          "type": "string"
+        },
+        "references": {
+          "description": "Reference to the foreign key",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["table", "columns"],
+          "properties": {
+            "table": {
+              "description": "Name of the table",
+              "type": "string"
+            },
+            "columns": {
+              "description": "Columns to reference",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "on_delete": {
+              "description": "On delete behavior of the foreign key constraint",
+              "$ref": "#/$defs/ForeignKeyReferenceOnDelete",
+              "default": "NO ACTION"
+            }
+          }
+        }
+      },
+      "required": ["name", "type"],
+      "type": "object"
+    },
     "OpAddColumn": {
       "additionalProperties": false,
       "description": "Add column operation",
@@ -279,6 +331,13 @@
         "comment": {
           "description": "Postgres comment for the table",
           "type": "string"
+        },
+        "constraints": {
+          "items": {
+            "$ref": "#/$defs/Constraint",
+            "description": "Constraints to add to the table"
+          },
+          "type": "array"
         }
       },
       "required": ["columns", "name"],

--- a/schema.json
+++ b/schema.json
@@ -116,7 +116,7 @@
         "type": {
           "description": "Type of the constraint",
           "type": "string",
-          "enum": ["unique", "check", "foreign_key"]
+          "enum": ["unique", "check", "primary_key", "foreign_key", "exclude"]
         },
         "check": {
           "description": "Check constraint expression",
@@ -143,6 +143,62 @@
               "description": "On delete behavior of the foreign key constraint",
               "$ref": "#/$defs/ForeignKeyReferenceOnDelete",
               "default": "NO ACTION"
+            },
+            "on_update": {
+              "description": "On update behavior of the foreign key constraint",
+              "$ref": "#/$defs/ForeignKeyReferenceOnDelete",
+              "default": "NO ACTION"
+            },
+            "match_type": {
+              "description": "Match type of the foreign key constraint",
+              "type": "string"
+            }
+          }
+        },
+        "defferable": {
+          "description": "Defferable constraint",
+          "type": "boolean"
+        },
+        "initially_deferred": {
+          "description": "Initially deferred constraint",
+          "type": "boolean"
+        },
+        "no_inherit": {
+          "description": "No inherit constraint",
+          "type": "boolean"
+        },
+        "nulls_not_distinct": {
+          "description": "Nulls not distinct constraint",
+          "type": "boolean"
+        },
+        "exclude": {
+          "description": "Exclude constraint",
+          "additionalProperties": false,
+          "type": "object",
+          "properties": {
+            "elements": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "index_method": {
+              "type": "string"
+            },
+            "include_columns": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "storage_parameters": {
+              "type": "string"
+            },
+            "predicate": {
+              "type": "string"
+            },
+            "tablespace": {
+              "type": "string"
             }
           }
         }

--- a/schema.json
+++ b/schema.json
@@ -120,25 +120,30 @@
         },
         "deferrable": {
           "description": "Deferable constraint",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "initially_deferred": {
           "description": "Initially deferred constraint",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "nulls_not_distinct": {
           "description": "Nulls not distinct constraint",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "index_parameters": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
             "tablespace": {
-              "type": "string"
+              "type": "string",
+              "default": ""
             },
             "storage_parameters": {
-              "type": "string"
+              "type": "string",
+              "default": ""
             },
             "include_columns": {
               "type": "array",

--- a/schema.json
+++ b/schema.json
@@ -116,46 +116,9 @@
         "type": {
           "description": "Type of the constraint",
           "type": "string",
-          "enum": ["unique", "check", "primary_key", "foreign_key", "exclude"]
+          "enum": ["unique"]
         },
-        "check": {
-          "description": "Check constraint expression",
-          "type": "string"
-        },
-        "references": {
-          "description": "Reference to the foreign key",
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["table", "columns"],
-          "properties": {
-            "table": {
-              "description": "Name of the table",
-              "type": "string"
-            },
-            "columns": {
-              "description": "Columns to reference",
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "on_delete": {
-              "description": "On delete behavior of the foreign key constraint",
-              "$ref": "#/$defs/ForeignKeyReferenceOnDelete",
-              "default": "NO ACTION"
-            },
-            "on_update": {
-              "description": "On update behavior of the foreign key constraint",
-              "$ref": "#/$defs/ForeignKeyReferenceOnDelete",
-              "default": "NO ACTION"
-            },
-            "match_type": {
-              "description": "Match type of the foreign key constraint",
-              "type": "string"
-            }
-          }
-        },
-        "deferable": {
+        "deferrable": {
           "description": "Deferable constraint",
           "type": "boolean"
         },
@@ -163,42 +126,27 @@
           "description": "Initially deferred constraint",
           "type": "boolean"
         },
-        "no_inherit": {
-          "description": "No inherit constraint",
-          "type": "boolean"
-        },
         "nulls_not_distinct": {
           "description": "Nulls not distinct constraint",
           "type": "boolean"
         },
-        "tablespace": {
-          "type": "string"
-        },
-        "storage_parameters": {
-          "type": "string"
-        },
-        "include_columns": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "exclude": {
-          "description": "Exclude constraint",
-          "additionalProperties": false,
+        "index_parameters": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "elements": {
+            "tablespace": {
               "type": "string"
             },
-            "index_method": {
+            "storage_parameters": {
               "type": "string"
             },
-            "predicate": {
-              "type": "string"
+            "include_columns": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
-          },
-          "required": ["index_method", "elements"]
+          }
         }
       },
       "required": ["name", "type"],


### PR DESCRIPTION
This PR adds support for a new option of `create_table` operation named `constraints`.
It expects a list of `constraints` that is defined on the table when the table is created.

At the moment the only constraint we support is `unique`. But it includes support for all options
of unique constraints including `NULLS NOT DISTINCT`, index configuration settings, constraint deference, etc. Once I am done with these table constraints, I will open a follow-up PR to extend the constraint options for column constraints and `create_constraint` operation.

Example migration:
```json
{
  "name": "50_create_table_with_table_constraint",
  "operations": [
    {
      "create_table": {
        "name": "phonebook",
        "columns": [
          {
            "name": "id",
            "type": "serial",
            "pk": true
          },
          {
            "name": "name",
            "type": "varchar(255)"
          },
          {
            "name": "city",
            "type": "varchar(255)"
          },
          {
            "name": "phone",
            "type": "varchar(255)"
          }
        ],
        "constraints": [
          {
            "name": "unique_numbers",
            "type": "unique",
            "columns": ["phone"],
            "index_parameters": {
              "include_columns": ["name"]
            }
          }
        ]
      }
    }
  ]
}
```

The table definition above turns into this table in PostgreSQL:

```
postgres=# \d phonebook
                                    Table "public.phonebook"
 Column |          Type          | Collation | Nullable |                Default
--------+------------------------+-----------+----------+---------------------------------------
 id     | integer                |           | not null | nextval('phonebook_id_seq'::regclass)
 name   | character varying(255) |           | not null |
 city   | character varying(255) |           | not null |
 phone  | character varying(255) |           | not null |
Indexes:
    "phonebook_pkey" PRIMARY KEY, btree (id)
    "unique_numbers" UNIQUE CONSTRAINT, btree (phone) INCLUDE (name)
```

Part of https://github.com/xataio/pgroll/issues/580
