### PR TITLE
Multi-operation migration support for `drop_table` operations

### DIFF
--- a/pkg/migrations/op_drop_table.go
+++ b/pkg/migrations/op_drop_table.go
@@ -37,5 +37,7 @@ func (o *OpDropTable) Validate(ctx context.Context, s *schema.Schema) error {
 	if table == nil {
 		return TableDoesNotExistError{Name: o.Name}
 	}
+
+	s.RemoveTable(table.Name)
 	return nil
 }

--- a/pkg/migrations/op_drop_table.go
+++ b/pkg/migrations/op_drop_table.go
@@ -25,6 +25,9 @@ func (o *OpDropTable) Complete(ctx context.Context, conn db.DB, tr SQLTransforme
 }
 
 func (o *OpDropTable) Rollback(ctx context.Context, conn db.DB, tr SQLTransformer, s *schema.Schema) error {
+	// Mark the table as no longer deleted so that it is visible to preceding
+	// Rollbacks in the same migration
+	s.UnRemoveTable(o.Name)
 	return nil
 }
 

--- a/pkg/migrations/op_drop_table_test.go
+++ b/pkg/migrations/op_drop_table_test.go
@@ -125,3 +125,47 @@ func TestDropTableInMultiOperationMigrations(t *testing.T) {
 		},
 	})
 }
+
+func TestDropTableValidationInMultiOperationMigrations(t *testing.T) {
+	t.Parallel()
+
+	ExecuteTests(t, TestCases{
+		{
+			name: "drop table, rename table fails to validate",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_create_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "items",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name: "name",
+									Type: "varchar(255)",
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_multi_operation",
+					Operations: migrations.Operations{
+						&migrations.OpDropTable{
+							Name: "items",
+						},
+						&migrations.OpRenameTable{
+							From: "items",
+							To:   "products",
+						},
+					},
+				},
+			},
+			wantStartErr: migrations.TableDoesNotExistError{Name: "items"},
+		},
+	})
+}

--- a/pkg/migrations/op_drop_table_test.go
+++ b/pkg/migrations/op_drop_table_test.go
@@ -177,6 +177,42 @@ func TestDropTableValidationInMultiOperationMigrations(t *testing.T) {
 
 	ExecuteTests(t, TestCases{
 		{
+			name: "drop table, drop table fails to validate",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_create_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "items",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name: "name",
+									Type: "varchar(255)",
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_multi_operation",
+					Operations: migrations.Operations{
+						&migrations.OpDropTable{
+							Name: "items",
+						},
+						&migrations.OpDropTable{
+							Name: "items",
+						},
+					},
+				},
+			},
+			wantStartErr: migrations.TableDoesNotExistError{Name: "items"},
+		},
+		{
 			name: "drop table, rename table fails to validate",
 			migrations: []migrations.Migration{
 				{

--- a/pkg/migrations/op_drop_table_test.go
+++ b/pkg/migrations/op_drop_table_test.go
@@ -62,3 +62,66 @@ func TestDropTable(t *testing.T) {
 		},
 	})
 }
+
+func TestDropTableInMultiOperationMigrations(t *testing.T) {
+	t.Parallel()
+
+	ExecuteTests(t, TestCases{
+		{
+			name: "create table, rename table, drop table",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_multi_operation",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "items",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name: "name",
+									Type: "varchar(255)",
+								},
+							},
+						},
+						&migrations.OpRenameTable{
+							From: "items",
+							To:   "products",
+						},
+						&migrations.OpDropTable{
+							Name: "products",
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
+				// OpDropTable drops tables on migration completion, so the table
+				// created by OpCreateTable is present after migration start.
+				TableMustExist(t, db, schema, "items")
+
+				// There is no view for the "items" table in the new schema
+				ViewMustNotExist(t, db, schema, "01_multi_operation", "items")
+
+				// There is no view for the "products" table in the new schema
+				ViewMustNotExist(t, db, schema, "01_multi_operation", "products")
+			},
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
+				// The table is not present
+				TableMustNotExist(t, db, schema, "items")
+			},
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+				// The table is not present
+				TableMustNotExist(t, db, schema, "items")
+
+				// There is no view for the "items" table in the new schema
+				ViewMustNotExist(t, db, schema, "01_multi_operation", "items")
+
+				// There is no view for the "products" table in the new schema
+				ViewMustNotExist(t, db, schema, "01_multi_operation", "products")
+			},
+		},
+	})
+}

--- a/pkg/migrations/op_rename_table.go
+++ b/pkg/migrations/op_rename_table.go
@@ -26,6 +26,7 @@ func (o *OpRenameTable) Complete(ctx context.Context, conn db.DB, tr SQLTransfor
 }
 
 func (o *OpRenameTable) Rollback(ctx context.Context, conn db.DB, tr SQLTransformer, s *schema.Schema) error {
+	s.RenameTable(o.To, o.From)
 	return nil
 }
 

--- a/pkg/migrations/op_rename_table.go
+++ b/pkg/migrations/op_rename_table.go
@@ -40,5 +40,6 @@ func (o *OpRenameTable) Validate(ctx context.Context, s *schema.Schema) error {
 		return err
 	}
 
+	s.RenameTable(o.From, o.To)
 	return nil
 }

--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -132,6 +132,9 @@ func (m *Roll) ensureViews(ctx context.Context, schema *schema.Schema, version s
 
 	// create views in the new schema
 	for name, table := range schema.Tables {
+		if table.Deleted {
+			continue
+		}
 		err = m.ensureView(ctx, version, name, table)
 		if err != nil {
 			return fmt.Errorf("unable to create view: %w", err)

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -58,6 +58,9 @@ type Table struct {
 
 	// UniqueConstraints is a map of all unique constraints defined on the table
 	UniqueConstraints map[string]*UniqueConstraint `json:"uniqueConstraints"`
+
+	// Whether or not the table has been deleted in the virtual schema
+	Deleted bool `json:"-"`
 }
 
 // Column represents a column in a table
@@ -145,7 +148,7 @@ func (s *Schema) GetTable(name string) *Table {
 		return nil
 	}
 	t, ok := s.Tables[name]
-	if !ok {
+	if !ok || t.Deleted {
 		return nil
 	}
 	return t
@@ -175,9 +178,19 @@ func (s *Schema) RenameTable(from, to string) error {
 	return nil
 }
 
-// RemoveTable removes a table from the schema
+// RemoveTable removes a table from the schema by marking it as deleted
 func (s *Schema) RemoveTable(name string) {
-	delete(s.Tables, name)
+	if tbl, ok := s.Tables[name]; ok {
+		tbl.Deleted = true
+	}
+}
+
+// UnRemoveTable unremoves a previously removed table by marking it as not
+// deleted
+func (s *Schema) UnRemoveTable(name string) {
+	if tbl, ok := s.Tables[name]; ok {
+		tbl.Deleted = false
+	}
 }
 
 // GetColumn returns a column by name


### PR DESCRIPTION
Ensure that `drop_table` operations can be used as part of multi-operation migrations:

Add testcases for:
* **Create table, rename table, drop table**: 
  * Make `OpRenameTable.Validate` update the in-memory schema so that the following operation can validate using the new name of the table
  * Make`OpDropTable` soft delete the table from the virtual schema, so that `OpDropTable.Rollback` can un-drop the table, making it visible to preceding operations in the table when the migration is rolled back.
  * Make `OpRenameTable` undo the table rename, so that the table is visible under its old name for preceding operations in the rollback.
* **Drop table, rename table** and **drop table, drop table**:
  * Make `OpDropTable.Validate` remove the table from the virtual schema so that validation of the subsequent operation fails.

Theses changes ensure that `drop_table` operations can be used as part of multi-operation migrations.

Part of https://github.com/xataio/pgroll/issues/239