### PR TITLE
Add support for `CHECK` constraints in `create_table` operation

### DIFF
--- a/docs/operations/create_table.mdx
+++ b/docs/operations/create_table.mdx
@@ -9,7 +9,8 @@ description: A create table operation creates a new table in the database.
 {
   "create_table": {
     "name": "name of new table",
-    "columns": [...]
+    "columns": [...],
+    "constraints": [...]
   }
 }
 ```
@@ -39,6 +40,26 @@ Each `column` is defined as:
 ```
 
 Default values are subject to the usual rules for quoting SQL expressions. In particular, string literals should be surrounded with single quotes.
+
+Each `constraint` is defined as:
+
+```json
+{
+  "name": "constraint name",
+  "type": "constraint type",
+  "columns": ["list", "of", "columns"],
+  "nulls_not_distinct": true|false,
+  "deferrable": true|false,
+  "initially_deferred": true|false,
+  "index_parameters": {
+    "tablespace": "index_tablespace",
+    "storage_parameters": "parameter=value",
+    "include_columns": ["list", "of", "columns", "included in index"]
+  },
+},
+```
+
+Supported constraint types: `unique`.
 
 ## Examples
 
@@ -98,3 +119,9 @@ Create a table with a `CHECK` constraint on one column:
 Create a table with different `DEFAULT` values:
 
 <ExampleSnippet example="28_different_defaults.json" language="json" />
+
+### Create a table with table level unique constraint
+
+Create a table with table level constraints:
+
+<ExampleSnippet example="50_create_table_with_table_constraint.json" language="json" />

--- a/docs/operations/create_table.mdx
+++ b/docs/operations/create_table.mdx
@@ -48,9 +48,11 @@ Each `constraint` is defined as:
   "name": "constraint name",
   "type": "constraint type",
   "columns": ["list", "of", "columns"],
+  "check": "condition of CHECK constraint",
   "nulls_not_distinct": true|false,
   "deferrable": true|false,
   "initially_deferred": true|false,
+  "no_inherit": true|false,
   "index_parameters": {
     "tablespace": "index_tablespace",
     "storage_parameters": "parameter=value",
@@ -59,7 +61,7 @@ Each `constraint` is defined as:
 },
 ```
 
-Supported constraint types: `unique`.
+Supported constraint types: `unique`, `check`.
 
 ## Examples
 
@@ -120,7 +122,7 @@ Create a table with different `DEFAULT` values:
 
 <ExampleSnippet example="28_different_defaults.json" language="json" />
 
-### Create a table with table level unique constraint
+### Create a table with multiple table level constraints
 
 Create a table with table level constraints:
 

--- a/examples/.ledger
+++ b/examples/.ledger
@@ -47,3 +47,4 @@
 47_add_table_foreign_key_constraint.json
 48_drop_tickets_check.json
 49_unset_not_null_on_indexed_column.json
+50_create_table_with_table_constraint.json

--- a/examples/50_create_table_with_table_constraint.json
+++ b/examples/50_create_table_with_table_constraint.json
@@ -35,6 +35,11 @@
                 "name"
               ]
             }
+          },
+          {
+            "name": "name_must_be_present",
+            "type": "check",
+            "check": "length(name) > 0"
           }
         ]
       }

--- a/examples/50_create_table_with_table_constraint.json
+++ b/examples/50_create_table_with_table_constraint.json
@@ -1,0 +1,39 @@
+{
+  "name": "50_create_table_with_table_constraint",
+  "operations": [
+    {
+      "create_table": {
+        "name": "phonebook",
+        "columns": [
+          {
+            "name": "id",
+            "type": "serial",
+            "pk": true
+          },
+          {
+            "name": "name",
+            "type": "varchar(255)"
+          },
+          {
+            "name": "city",
+            "type": "varchar(255)"
+          },
+          {
+            "name": "phone",
+            "type": "varchar(255)"
+          }
+        ],
+        "constraints": [
+          {
+            "name": "unique_numbers",
+            "type": "unique",
+            "columns": ["phone"],
+            "index_parameters": {
+              "include_columns": ["name"]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/50_create_table_with_table_constraint.json
+++ b/examples/50_create_table_with_table_constraint.json
@@ -27,9 +27,13 @@
           {
             "name": "unique_numbers",
             "type": "unique",
-            "columns": ["phone"],
+            "columns": [
+              "phone"
+            ],
             "index_parameters": {
-              "include_columns": ["name"]
+              "include_columns": [
+                "name"
+              ]
             }
           }
         ]

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/oapi-codegen/nullable v1.1.0
 	github.com/pterm/pterm v0.12.80
-	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/docker v27.1.1+incompatible h1:hO/M4MtV36kzKldqnA37IWhebRA+LnqqcqDja6kVaKY=
 github.com/docker/docker v27.1.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
@@ -168,8 +170,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
-github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 h1:PKK9DyHxif4LZo+uQSgXNqs0jj5+xZwwfKHgph2lxBw=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shirou/gopsutil/v3 v3.24.5 h1:i0t8kL+kQTvpAYToeuiVk3TgDeKOFioZO3Ztz/iZ9pI=

--- a/internal/jsonschema/jsonschema_test.go
+++ b/internal/jsonschema/jsonschema_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/santhosh-tekuri/jsonschema/v5"
+	"github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/tools/txtar"
 )
@@ -23,7 +23,9 @@ const (
 func TestJSONSchemaValidation(t *testing.T) {
 	t.Parallel()
 
-	sch := jsonschema.MustCompile(schemaPath)
+	compiler := jsonschema.NewCompiler()
+	sch, err := compiler.Compile(schemaPath)
+	assert.NoError(t, err)
 
 	files, err := os.ReadDir(testDataDir)
 	assert.NoError(t, err)

--- a/internal/jsonschema/testdata/create-table-10-invalid-unique-missing-columns.txtar
+++ b/internal/jsonschema/testdata/create-table-10-invalid-unique-missing-columns.txtar
@@ -1,0 +1,34 @@
+This is an invalid 'create_table' migration.
+Unique constraint must have list of columns configured
+
+-- create_table.json --
+{
+  "name": "migration_name",
+  "operations": [
+    {
+      "create_table": {
+        "name": "posts",
+        "columns": [
+          {
+            "name": "title",
+            "type": "varchar(255)"
+          },
+          {
+            "name": "user_id",
+            "type": "integer",
+            "nullable": true
+          }
+        ],
+        "constraints": [
+          {
+            "name": "my_invalid_unique",
+            "type": "unique"
+          }
+        ]
+      }
+    }
+  ]
+}
+
+-- valid --
+false

--- a/internal/jsonschema/testdata/create-table-2-check-constraints.txtar
+++ b/internal/jsonschema/testdata/create-table-2-check-constraints.txtar
@@ -1,0 +1,39 @@
+This is a valid 'create_table' migration.
+
+-- create_table.json --
+{
+  "name": "migration_name",
+  "operations": [
+    {
+      "create_table": {
+        "name": "posts",
+        "columns": [
+          {
+            "name": "id",
+            "type": "serial",
+            "pk": true
+          },
+          {
+            "name": "title",
+            "type": "varchar(255)"
+          },
+          {
+            "name": "user_id",
+            "type": "integer",
+            "nullable": true
+          }
+        ],
+        "constraints": [
+          {
+            "name": "my_check",
+            "type": "check",
+            "check": "lenth(title) > 30"
+          }
+        ]
+      }
+    }
+  ]
+}
+
+-- valid --
+true

--- a/internal/jsonschema/testdata/create-table-3-invalid-check-constraints.txtar
+++ b/internal/jsonschema/testdata/create-table-3-invalid-check-constraints.txtar
@@ -1,0 +1,34 @@
+This is an invalid 'create_table' migration.
+Check constraint is missing the expression
+
+-- create_table.json --
+{
+  "name": "migration_name",
+  "operations": [
+    {
+      "create_table": {
+        "name": "posts",
+        "columns": [
+          {
+            "name": "title",
+            "type": "varchar(255)"
+          },
+          {
+            "name": "user_id",
+            "type": "integer",
+            "nullable": true
+          }
+        ],
+        "constraints": [
+          {
+            "name": "my_invalid_check",
+            "type": "check"
+          }
+        ]
+      }
+    }
+  ]
+}
+
+-- valid --
+false

--- a/internal/jsonschema/testdata/create-table-3-unique-constraint.txtar
+++ b/internal/jsonschema/testdata/create-table-3-unique-constraint.txtar
@@ -1,0 +1,34 @@
+This is a valid 'create_table' migration.
+
+-- create_table.json --
+{
+  "name": "migration_name",
+  "operations": [
+    {
+      "create_table": {
+        "name": "posts",
+        "columns": [
+          {
+            "name": "title",
+            "type": "varchar(255)"
+          },
+          {
+            "name": "user_id",
+            "type": "integer",
+            "nullable": true
+          }
+        ],
+        "constraints": [
+          {
+            "name": "my_invalid_unique",
+            "type": "unique",
+            "columns": ["title"]
+          }
+        ]
+      }
+    }
+  ]
+}
+
+-- valid --
+true

--- a/internal/jsonschema/testdata/create-table-4-invalid-check-options-deferrable.txtar
+++ b/internal/jsonschema/testdata/create-table-4-invalid-check-options-deferrable.txtar
@@ -1,0 +1,36 @@
+This is an invalid 'create_table' migration.
+Check constraint is not deferrable
+
+-- create_table.json --
+{
+  "name": "migration_name",
+  "operations": [
+    {
+      "create_table": {
+        "name": "posts",
+        "columns": [
+          {
+            "name": "title",
+            "type": "varchar(255)"
+          },
+          {
+            "name": "user_id",
+            "type": "integer",
+            "nullable": true
+          }
+        ],
+        "constraints": [
+          {
+            "name": "my_invalid_check",
+            "type": "check",
+            "check": "length(title) > 10",
+            "deferrable": true
+          }
+        ]
+      }
+    }
+  ]
+}
+
+-- valid --
+false

--- a/internal/jsonschema/testdata/create-table-5-invalid-check-options-initially-defer.txtar
+++ b/internal/jsonschema/testdata/create-table-5-invalid-check-options-initially-defer.txtar
@@ -1,0 +1,36 @@
+This is an invalid 'create_table' migration.
+Check constraint is not deferrable
+
+-- create_table.json --
+{
+  "name": "migration_name",
+  "operations": [
+    {
+      "create_table": {
+        "name": "posts",
+        "columns": [
+          {
+            "name": "title",
+            "type": "varchar(255)"
+          },
+          {
+            "name": "user_id",
+            "type": "integer",
+            "nullable": true
+          }
+        ],
+        "constraints": [
+          {
+            "name": "my_invalid_check",
+            "type": "check",
+            "check": "length(title) > 10",
+            "initially_deferred": true
+          }
+        ]
+      }
+    }
+  ]
+}
+
+-- valid --
+false

--- a/internal/jsonschema/testdata/create-table-6-invalid-check-options-nulls-not-distinct.txtar
+++ b/internal/jsonschema/testdata/create-table-6-invalid-check-options-nulls-not-distinct.txtar
@@ -1,0 +1,36 @@
+This is an invalid 'create_table' migration.
+Check constraint does not support nulls not distinct option
+
+-- create_table.json --
+{
+  "name": "migration_name",
+  "operations": [
+    {
+      "create_table": {
+        "name": "posts",
+        "columns": [
+          {
+            "name": "title",
+            "type": "varchar(255)"
+          },
+          {
+            "name": "user_id",
+            "type": "integer",
+            "nullable": true
+          }
+        ],
+        "constraints": [
+          {
+            "name": "my_invalid_check",
+            "type": "check",
+            "check": "length(title) > 10",
+            "nulls_not_distinct": true
+          }
+        ]
+      }
+    }
+  ]
+}
+
+-- valid --
+false

--- a/internal/jsonschema/testdata/create-table-7-invalid-check-options-forbidden-index-params.txtar
+++ b/internal/jsonschema/testdata/create-table-7-invalid-check-options-forbidden-index-params.txtar
@@ -1,0 +1,40 @@
+This is an invalid 'create_table' migration.
+Check constraint does not support index settings
+
+-- create_table.json --
+{
+  "name": "migration_name",
+  "operations": [
+    {
+      "create_table": {
+        "name": "posts",
+        "columns": [
+          {
+            "name": "title",
+            "type": "varchar(255)"
+          },
+          {
+            "name": "user_id",
+            "type": "integer",
+            "nullable": true
+          }
+        ],
+        "constraints": [
+          {
+            "name": "my_invalid_check",
+            "type": "check",
+            "check": "length(title) > 10",
+            "index_params": {
+              "include_columns": [
+                "title"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+
+-- valid --
+false

--- a/internal/jsonschema/testdata/create-table-8-invalid-unique-forbidden-check-param.txtar
+++ b/internal/jsonschema/testdata/create-table-8-invalid-unique-forbidden-check-param.txtar
@@ -1,0 +1,36 @@
+This is an invalid 'create_table' migration.
+Unique constraint cannot have a check expression
+
+-- create_table.json --
+{
+  "name": "migration_name",
+  "operations": [
+    {
+      "create_table": {
+        "name": "posts",
+        "columns": [
+          {
+            "name": "title",
+            "type": "varchar(255)"
+          },
+          {
+            "name": "user_id",
+            "type": "integer",
+            "nullable": true
+          }
+        ],
+        "constraints": [
+          {
+            "name": "my_invalid_unique",
+            "type": "unique",
+            "columns": ["title"],
+            "check": "length(title) > 10"
+          }
+        ]
+      }
+    }
+  ]
+}
+
+-- valid --
+false

--- a/internal/jsonschema/testdata/create-table-9-invalid-unique-forbidden-no-inherit.txtar
+++ b/internal/jsonschema/testdata/create-table-9-invalid-unique-forbidden-no-inherit.txtar
@@ -1,0 +1,36 @@
+This is an invalid 'create_table' migration.
+Unique constraint does not support inheritance settings
+
+-- create_table.json --
+{
+  "name": "migration_name",
+  "operations": [
+    {
+      "create_table": {
+        "name": "posts",
+        "columns": [
+          {
+            "name": "title",
+            "type": "varchar(255)"
+          },
+          {
+            "name": "user_id",
+            "type": "integer",
+            "nullable": true
+          }
+        ],
+        "constraints": [
+          {
+            "name": "my_invalid_unique",
+            "type": "unique",
+            "columns": ["title"],
+            "no_inherit": true
+          }
+        ]
+      }
+    }
+  ]
+}
+
+-- valid --
+false

--- a/pkg/migrations/errors.go
+++ b/pkg/migrations/errors.go
@@ -134,6 +134,7 @@ func (e ColumnReferenceError) Error() string {
 type CheckConstraintError struct {
 	Table  string
 	Column string
+	Name   string
 	Err    error
 }
 
@@ -143,7 +144,8 @@ func (e CheckConstraintError) Unwrap() error {
 
 func (e CheckConstraintError) Error() string {
 	if e.Column == "" {
-		return fmt.Sprintf("check constraint in table %q is invalid: %s",
+		return fmt.Sprintf("check constraint %s in table %q is invalid: %s",
+			e.Name,
 			e.Table,
 			e.Err.Error())
 	}

--- a/pkg/migrations/errors.go
+++ b/pkg/migrations/errors.go
@@ -144,7 +144,7 @@ func (e CheckConstraintError) Unwrap() error {
 
 func (e CheckConstraintError) Error() string {
 	if e.Column == "" {
-		return fmt.Sprintf("check constraint %s in table %q is invalid: %s",
+		return fmt.Sprintf("check constraint %q in table %q is invalid: %s",
 			e.Name,
 			e.Table,
 			e.Err.Error())

--- a/pkg/migrations/errors.go
+++ b/pkg/migrations/errors.go
@@ -142,6 +142,12 @@ func (e CheckConstraintError) Unwrap() error {
 }
 
 func (e CheckConstraintError) Error() string {
+	if e.Column == "" {
+		return fmt.Sprintf("check constraint in table %q is invalid: %s",
+			e.Table,
+			e.Err.Error())
+	}
+
 	return fmt.Sprintf("check constraint on column %q in table %q is invalid: %s",
 		e.Table,
 		e.Column,

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -129,7 +129,7 @@ func (o *OpCreateTable) Validate(ctx context.Context, s *schema.Schema) error {
 				return CheckConstraintError{
 					Table: o.Name,
 					Name:  c.Name,
-					Err:   fmt.Errorf("CHECK constraints cannot be marked DEFERABLE"),
+					Err:   fmt.Errorf("CHECK constraints cannot be marked DEFERRABLE"),
 				}
 			}
 			if c.IndexParameters != nil {
@@ -287,7 +287,6 @@ func (w *ConstraintSQLWriter) WriteCheck(check string, noInherit bool) string {
 	if noInherit {
 		constraint += " NO INHERIT"
 	}
-	constraint += w.addDeferrable()
 	return constraint
 }
 

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -230,11 +230,15 @@ type ConstraintSQLWriter struct {
 }
 
 func (w *ConstraintSQLWriter) WriteUnique(nullsNotDistinct *bool) string {
+	var constraint string
+	if w.Name != "" {
+		constraint = fmt.Sprintf("CONSTRAINT %s ", pq.QuoteIdentifier(w.Name))
+	}
 	nullsDistinct := ""
 	if nullsNotDistinct != nil && *nullsNotDistinct {
 		nullsDistinct = "NULLS NOT DISTINCT"
 	}
-	constraint := fmt.Sprintf("CONSTRAINT %s UNIQUE %s (%s)", pq.QuoteIdentifier(w.Name), nullsDistinct, strings.Join(quoteColumnNames(w.Columns), ", "))
+	constraint += fmt.Sprintf("UNIQUE %s (%s)", nullsDistinct, strings.Join(quoteColumnNames(w.Columns), ", "))
 	constraint += w.addIndexParameters()
 	constraint += w.addDeferrable()
 	return constraint

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -128,18 +128,21 @@ func (o *OpCreateTable) Validate(ctx context.Context, s *schema.Schema) error {
 			if c.Deferrable || c.InitiallyDeferred {
 				return CheckConstraintError{
 					Table: o.Name,
+					Name:  c.Name,
 					Err:   fmt.Errorf("CHECK constraints cannot be marked DEFERABLE"),
 				}
 			}
 			if c.IndexParameters != nil {
 				return CheckConstraintError{
 					Table: o.Name,
+					Name:  c.Name,
 					Err:   fmt.Errorf("CHECK constraints cannot have index parameters"),
 				}
 			}
 			if c.NullsNotDistinct {
 				return CheckConstraintError{
 					Table: o.Name,
+					Name:  c.Name,
 					Err:   fmt.Errorf("CHECK constraints cannot have NULLS NOT DISTINCT"),
 				}
 			}
@@ -280,7 +283,7 @@ func (w *ConstraintSQLWriter) WriteCheck(check string, noInherit bool) string {
 	if w.Name != "" {
 		constraint = fmt.Sprintf("CONSTRAINT %s ", pq.QuoteIdentifier(w.Name))
 	}
-	constraint += fmt.Sprintf("CHECK %s", check)
+	constraint += fmt.Sprintf("CHECK (%s)", check)
 	if noInherit {
 		constraint += " NO INHERIT"
 	}

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -165,22 +165,16 @@ func (o *OpCreateTable) updateSchema(s *schema.Schema) *schema.Schema {
 			Name: col.Name,
 		}
 	}
-	var uniqueConstraints map[string]*schema.UniqueConstraint
-	var checkConstraints map[string]*schema.CheckConstraint
+	uniqueConstraints := make(map[string]*schema.UniqueConstraint, 0)
+	checkConstraints := make(map[string]*schema.CheckConstraint, 0)
 	for _, c := range o.Constraints {
 		switch c.Type {
 		case ConstraintTypeUnique:
-			if uniqueConstraints == nil {
-				uniqueConstraints = make(map[string]*schema.UniqueConstraint)
-			}
 			uniqueConstraints[c.Name] = &schema.UniqueConstraint{
 				Name:    c.Name,
 				Columns: c.Columns,
 			}
 		case ConstraintTypeCheck:
-			if checkConstraints == nil {
-				checkConstraints = make(map[string]*schema.CheckConstraint)
-			}
 			checkConstraints[c.Name] = &schema.CheckConstraint{
 				Name:       c.Name,
 				Columns:    c.Columns,

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -195,9 +195,11 @@ func constraintsToSQL(constraints []Constraint) (string, error) {
 			Columns:           c.Columns,
 			InitiallyDeferred: c.InitiallyDeferred,
 			Deferrable:        c.Deferrable,
-			IncludeColumns:    c.IndexParameters.IncludeColumns,
-			StorageParameters: c.IndexParameters.StorageParameters,
-			Tablespace:        c.IndexParameters.Tablespace,
+		}
+		if c.IndexParameters != nil {
+			writer.IncludeColumns = c.IndexParameters.IncludeColumns
+			writer.StorageParameters = c.IndexParameters.StorageParameters
+			writer.Tablespace = c.IndexParameters.Tablespace
 		}
 
 		switch c.Type { //nolint:gocritic // more cases are coming soon

--- a/pkg/migrations/op_create_table_test.go
+++ b/pkg/migrations/op_create_table_test.go
@@ -4,6 +4,7 @@ package migrations_test
 
 import (
 	"database/sql"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -384,7 +385,7 @@ func TestCreateTable(t *testing.T) {
 			},
 		},
 		{
-			name: "create table with a check constraint",
+			name: "create table with a check constraint on column",
 			migrations: []migrations.Migration{
 				{
 					Name: "01_create_table",
@@ -440,6 +441,108 @@ func TestCreateTable(t *testing.T) {
 				MustNotInsert(t, db, schema, "01_create_table", "users", map[string]string{
 					"name": "c",
 				}, testutils.CheckViolationErrorCode)
+			},
+		},
+		{
+			name: "create table with a table check constraint",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_create_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name: "name",
+									Type: "text",
+								},
+							},
+							Constraints: []migrations.Constraint{
+								{
+									Name:  "check_name_length",
+									Check: "length(name) > 3",
+								},
+							},
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
+				// The check constraint exists on the new table.
+				CheckConstraintMustExist(t, db, schema, "users", "check_name_length")
+
+				// Inserting a row into the table succeeds when the check constraint is satisfied.
+				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
+					"name": "alice",
+				})
+
+				// Inserting a row into the table fails when the check constraint is not satisfied.
+				MustNotInsert(t, db, schema, "01_create_table", "users", map[string]string{
+					"name": "b",
+				}, testutils.CheckViolationErrorCode)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
+				// The table has been dropped, so the check constraint is gone.
+			},
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+				// The check constraint exists on the new table.
+				CheckConstraintMustExist(t, db, schema, "users", "check_name_length")
+
+				// Inserting a row into the table succeeds when the check constraint is satisfied.
+				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
+					"name": "bobby",
+				})
+
+				// Inserting a row into the table fails when the check constraint is not satisfied.
+				MustNotInsert(t, db, schema, "01_create_table", "users", map[string]string{
+					"name": "c",
+				}, testutils.CheckViolationErrorCode)
+			},
+		},
+		{
+			name: "create table with column and table comments",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_create_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name:    "users",
+							Comment: ptr("the users table"),
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name:    "name",
+									Type:    "varchar(255)",
+									Unique:  true,
+									Comment: ptr("the username"),
+								},
+							},
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
+				// The comment has been added to the underlying table.
+				TableMustHaveComment(t, db, schema, "users", "the users table")
+				// The comment has been added to the underlying column.
+				ColumnMustHaveComment(t, db, schema, "users", "name", "the username")
+			},
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
+			},
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+				// The comment is still present on the underlying table.
+				TableMustHaveComment(t, db, schema, "users", "the users table")
+				// The comment is still present on the underlying column.
+				ColumnMustHaveComment(t, db, schema, "users", "name", "the username")
 			},
 		},
 		{
@@ -696,6 +799,40 @@ func TestCreateTableValidation(t *testing.T) {
 				},
 			},
 			wantStartErr: migrations.FieldRequiredError{Name: "columns"},
+		},
+		{
+			name: "check constraint is not deferrable",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_create_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "table1",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name:   "name",
+									Type:   "varchar(255)",
+									Unique: true,
+								},
+							},
+							Constraints: []migrations.Constraint{
+								{
+									Name:       "check_name",
+									Type:       migrations.ConstraintTypeCheck,
+									Check:      "length(name) > 0",
+									Deferrable: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStartErr: migrations.CheckConstraintError{Table: "table1", Err: fmt.Errorf("CHECK constraints cannot be marked DEFERABLE")},
 		},
 	})
 }

--- a/pkg/migrations/op_create_table_test.go
+++ b/pkg/migrations/op_create_table_test.go
@@ -546,47 +546,6 @@ func TestCreateTable(t *testing.T) {
 			},
 		},
 		{
-			name: "create table with column and table comments",
-			migrations: []migrations.Migration{
-				{
-					Name: "01_create_table",
-					Operations: migrations.Operations{
-						&migrations.OpCreateTable{
-							Name:    "users",
-							Comment: ptr("the users table"),
-							Columns: []migrations.Column{
-								{
-									Name: "id",
-									Type: "serial",
-									Pk:   true,
-								},
-								{
-									Name:    "name",
-									Type:    "varchar(255)",
-									Unique:  true,
-									Comment: ptr("the username"),
-								},
-							},
-						},
-					},
-				},
-			},
-			afterStart: func(t *testing.T, db *sql.DB, schema string) {
-				// The comment has been added to the underlying table.
-				TableMustHaveComment(t, db, schema, "users", "the users table")
-				// The comment has been added to the underlying column.
-				ColumnMustHaveComment(t, db, schema, "users", "name", "the username")
-			},
-			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
-			},
-			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
-				// The comment is still present on the underlying table.
-				TableMustHaveComment(t, db, schema, "users", "the users table")
-				// The comment is still present on the underlying column.
-				ColumnMustHaveComment(t, db, schema, "users", "name", "the username")
-			},
-		},
-		{
 			name: "create table with a unique table constraint",
 			migrations: []migrations.Migration{
 				{

--- a/pkg/migrations/op_create_table_test.go
+++ b/pkg/migrations/op_create_table_test.go
@@ -4,7 +4,6 @@ package migrations_test
 
 import (
 	"database/sql"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -465,6 +464,7 @@ func TestCreateTable(t *testing.T) {
 							Constraints: []migrations.Constraint{
 								{
 									Name:  "check_name_length",
+									Type:  "check",
 									Check: "length(name) > 3",
 								},
 							},
@@ -801,7 +801,7 @@ func TestCreateTableValidation(t *testing.T) {
 			wantStartErr: migrations.FieldRequiredError{Name: "columns"},
 		},
 		{
-			name: "check constraint is not deferrable",
+			name: "check constraint missing expression",
 			migrations: []migrations.Migration{
 				{
 					Name: "01_create_table",
@@ -822,17 +822,15 @@ func TestCreateTableValidation(t *testing.T) {
 							},
 							Constraints: []migrations.Constraint{
 								{
-									Name:       "check_name",
-									Type:       migrations.ConstraintTypeCheck,
-									Check:      "length(name) > 0",
-									Deferrable: true,
+									Name: "check_name",
+									Type: migrations.ConstraintTypeCheck,
 								},
 							},
 						},
 					},
 				},
 			},
-			wantStartErr: fmt.Errorf("migration is invalid: %w", migrations.CheckConstraintError{Table: "table1", Name: "check_name", Err: fmt.Errorf("CHECK constraints cannot be marked DEFERABLE")}),
+			wantStartErr: migrations.FieldRequiredError{Name: "check"},
 		},
 	})
 }

--- a/pkg/migrations/op_create_table_test.go
+++ b/pkg/migrations/op_create_table_test.go
@@ -832,7 +832,7 @@ func TestCreateTableValidation(t *testing.T) {
 					},
 				},
 			},
-			wantStartErr: migrations.CheckConstraintError{Table: "table1", Err: fmt.Errorf("CHECK constraints cannot be marked DEFERABLE")},
+			wantStartErr: fmt.Errorf("migration is invalid: %w", migrations.CheckConstraintError{Table: "table1", Name: "check_name", Err: fmt.Errorf("CHECK constraints cannot be marked DEFERABLE")}),
 		},
 	})
 }

--- a/pkg/migrations/op_create_table_test.go
+++ b/pkg/migrations/op_create_table_test.go
@@ -665,6 +665,38 @@ func TestCreateTableValidation(t *testing.T) {
 			},
 			wantStartErr: migrations.InvalidIdentifierLengthError{Name: invalidName},
 		},
+		{
+			name: "missing column list in unique constraint",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_create_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "table1",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name:   "name",
+									Type:   "varchar(255)",
+									Unique: true,
+								},
+							},
+							Constraints: []migrations.Constraint{
+								{
+									Name: "unique_name",
+									Type: migrations.ConstraintTypeUnique,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStartErr: migrations.FieldRequiredError{Name: "columns"},
+		},
 	})
 }
 

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -52,11 +52,14 @@ type Constraint struct {
 	// Columns to add constraint to
 	Columns []string `json:"columns,omitempty"`
 
-	// Defferable constraint
-	Defferable *bool `json:"defferable,omitempty"`
+	// Deferable constraint
+	Deferable *bool `json:"deferable,omitempty"`
 
 	// Exclude constraint
 	Exclude *ConstraintExclude `json:"exclude,omitempty"`
+
+	// IncludeColumns corresponds to the JSON schema field "include_columns".
+	IncludeColumns []string `json:"include_columns,omitempty"`
 
 	// Initially deferred constraint
 	InitiallyDeferred *bool `json:"initially_deferred,omitempty"`
@@ -73,6 +76,12 @@ type Constraint struct {
 	// Reference to the foreign key
 	References *ConstraintReferences `json:"references,omitempty"`
 
+	// StorageParameters corresponds to the JSON schema field "storage_parameters".
+	StorageParameters *string `json:"storage_parameters,omitempty"`
+
+	// Tablespace corresponds to the JSON schema field "tablespace".
+	Tablespace *string `json:"tablespace,omitempty"`
+
 	// Type of the constraint
 	Type ConstraintType `json:"type"`
 }
@@ -80,22 +89,13 @@ type Constraint struct {
 // Exclude constraint
 type ConstraintExclude struct {
 	// Elements corresponds to the JSON schema field "elements".
-	Elements []string `json:"elements,omitempty"`
-
-	// IncludeColumns corresponds to the JSON schema field "include_columns".
-	IncludeColumns []string `json:"include_columns,omitempty"`
+	Elements string `json:"elements"`
 
 	// IndexMethod corresponds to the JSON schema field "index_method".
-	IndexMethod *string `json:"index_method,omitempty"`
+	IndexMethod string `json:"index_method"`
 
 	// Predicate corresponds to the JSON schema field "predicate".
 	Predicate *string `json:"predicate,omitempty"`
-
-	// StorageParameters corresponds to the JSON schema field "storage_parameters".
-	StorageParameters *string `json:"storage_parameters,omitempty"`
-
-	// Tablespace corresponds to the JSON schema field "tablespace".
-	Tablespace *string `json:"tablespace,omitempty"`
 }
 
 // Reference to the foreign key

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -46,6 +46,9 @@ type Column struct {
 
 // Constraint definition
 type Constraint struct {
+	// Check constraint expression
+	Check string `json:"check,omitempty"`
+
 	// Columns to add constraint to
 	Columns []string `json:"columns,omitempty"`
 
@@ -60,6 +63,9 @@ type Constraint struct {
 
 	// Name of the constraint
 	Name string `json:"name"`
+
+	// Do not propagate constraint to child tables
+	NoInherit bool `json:"no_inherit,omitempty"`
 
 	// Nulls not distinct constraint
 	NullsNotDistinct bool `json:"nulls_not_distinct,omitempty"`
@@ -81,6 +87,7 @@ type ConstraintIndexParameters struct {
 
 type ConstraintType string
 
+const ConstraintTypeCheck ConstraintType = "check"
 const ConstraintTypeUnique ConstraintType = "unique"
 
 // Foreign key reference definition

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -46,20 +46,14 @@ type Column struct {
 
 // Constraint definition
 type Constraint struct {
-	// Check constraint expression
-	Check *string `json:"check,omitempty"`
-
 	// Columns to add constraint to
 	Columns []string `json:"columns,omitempty"`
 
 	// Deferable constraint
-	Deferable *bool `json:"deferable,omitempty"`
+	Deferrable *bool `json:"deferrable,omitempty"`
 
-	// Exclude constraint
-	Exclude *ConstraintExclude `json:"exclude,omitempty"`
-
-	// IncludeColumns corresponds to the JSON schema field "include_columns".
-	IncludeColumns []string `json:"include_columns,omitempty"`
+	// IndexParameters corresponds to the JSON schema field "index_parameters".
+	IndexParameters *ConstraintIndexParameters `json:"index_parameters,omitempty"`
 
 	// Initially deferred constraint
 	InitiallyDeferred *bool `json:"initially_deferred,omitempty"`
@@ -67,61 +61,26 @@ type Constraint struct {
 	// Name of the constraint
 	Name string `json:"name"`
 
-	// No inherit constraint
-	NoInherit *bool `json:"no_inherit,omitempty"`
-
 	// Nulls not distinct constraint
 	NullsNotDistinct *bool `json:"nulls_not_distinct,omitempty"`
 
-	// Reference to the foreign key
-	References *ConstraintReferences `json:"references,omitempty"`
+	// Type of the constraint
+	Type ConstraintType `json:"type"`
+}
+
+type ConstraintIndexParameters struct {
+	// IncludeColumns corresponds to the JSON schema field "include_columns".
+	IncludeColumns []string `json:"include_columns,omitempty"`
 
 	// StorageParameters corresponds to the JSON schema field "storage_parameters".
 	StorageParameters *string `json:"storage_parameters,omitempty"`
 
 	// Tablespace corresponds to the JSON schema field "tablespace".
 	Tablespace *string `json:"tablespace,omitempty"`
-
-	// Type of the constraint
-	Type ConstraintType `json:"type"`
-}
-
-// Exclude constraint
-type ConstraintExclude struct {
-	// Elements corresponds to the JSON schema field "elements".
-	Elements string `json:"elements"`
-
-	// IndexMethod corresponds to the JSON schema field "index_method".
-	IndexMethod string `json:"index_method"`
-
-	// Predicate corresponds to the JSON schema field "predicate".
-	Predicate *string `json:"predicate,omitempty"`
-}
-
-// Reference to the foreign key
-type ConstraintReferences struct {
-	// Columns to reference
-	Columns []string `json:"columns"`
-
-	// Match type of the foreign key constraint
-	MatchType *string `json:"match_type,omitempty"`
-
-	// On delete behavior of the foreign key constraint
-	OnDelete ForeignKeyReferenceOnDelete `json:"on_delete,omitempty"`
-
-	// On update behavior of the foreign key constraint
-	OnUpdate ForeignKeyReferenceOnDelete `json:"on_update,omitempty"`
-
-	// Name of the table
-	Table string `json:"table"`
 }
 
 type ConstraintType string
 
-const ConstraintTypeCheck ConstraintType = "check"
-const ConstraintTypeExclude ConstraintType = "exclude"
-const ConstraintTypeForeignKey ConstraintType = "foreign_key"
-const ConstraintTypePrimaryKey ConstraintType = "primary_key"
 const ConstraintTypeUnique ConstraintType = "unique"
 
 // Foreign key reference definition

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -44,6 +44,86 @@ type Column struct {
 	Unique bool `json:"unique,omitempty"`
 }
 
+// Constraint definition
+type Constraint struct {
+	// Check constraint expression
+	Check *string `json:"check,omitempty"`
+
+	// Columns to add constraint to
+	Columns []string `json:"columns,omitempty"`
+
+	// Defferable constraint
+	Defferable *bool `json:"defferable,omitempty"`
+
+	// Exclude constraint
+	Exclude *ConstraintExclude `json:"exclude,omitempty"`
+
+	// Initially deferred constraint
+	InitiallyDeferred *bool `json:"initially_deferred,omitempty"`
+
+	// Name of the constraint
+	Name string `json:"name"`
+
+	// No inherit constraint
+	NoInherit *bool `json:"no_inherit,omitempty"`
+
+	// Nulls not distinct constraint
+	NullsNotDistinct *bool `json:"nulls_not_distinct,omitempty"`
+
+	// Reference to the foreign key
+	References *ConstraintReferences `json:"references,omitempty"`
+
+	// Type of the constraint
+	Type ConstraintType `json:"type"`
+}
+
+// Exclude constraint
+type ConstraintExclude struct {
+	// Elements corresponds to the JSON schema field "elements".
+	Elements []string `json:"elements,omitempty"`
+
+	// IncludeColumns corresponds to the JSON schema field "include_columns".
+	IncludeColumns []string `json:"include_columns,omitempty"`
+
+	// IndexMethod corresponds to the JSON schema field "index_method".
+	IndexMethod *string `json:"index_method,omitempty"`
+
+	// Predicate corresponds to the JSON schema field "predicate".
+	Predicate *string `json:"predicate,omitempty"`
+
+	// StorageParameters corresponds to the JSON schema field "storage_parameters".
+	StorageParameters *string `json:"storage_parameters,omitempty"`
+
+	// Tablespace corresponds to the JSON schema field "tablespace".
+	Tablespace *string `json:"tablespace,omitempty"`
+}
+
+// Reference to the foreign key
+type ConstraintReferences struct {
+	// Columns to reference
+	Columns []string `json:"columns"`
+
+	// Match type of the foreign key constraint
+	MatchType *string `json:"match_type,omitempty"`
+
+	// On delete behavior of the foreign key constraint
+	OnDelete ForeignKeyReferenceOnDelete `json:"on_delete,omitempty"`
+
+	// On update behavior of the foreign key constraint
+	OnUpdate ForeignKeyReferenceOnDelete `json:"on_update,omitempty"`
+
+	// Name of the table
+	Table string `json:"table"`
+}
+
+type ConstraintType string
+
+const ConstraintTypeCheck ConstraintType = "check"
+const ConstraintTypeExclude ConstraintType = "exclude"
+const ConstraintTypeForeignKey ConstraintType = "foreign_key"
+const ConstraintTypePrimaryKey ConstraintType = "primary_key"
+const ConstraintTypeUnique ConstraintType = "unique"
+
 // Foreign key reference definition
 type ForeignKeyReference struct {
 	// Name of the referenced column
@@ -211,6 +291,9 @@ type OpCreateTable struct {
 
 	// Postgres comment for the table
 	Comment *string `json:"comment,omitempty"`
+
+	// Constraints corresponds to the JSON schema field "constraints".
+	Constraints []Constraint `json:"constraints,omitempty"`
 
 	// Name of the table
 	Name string `json:"name"`

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -50,19 +50,19 @@ type Constraint struct {
 	Columns []string `json:"columns,omitempty"`
 
 	// Deferable constraint
-	Deferrable *bool `json:"deferrable,omitempty"`
+	Deferrable bool `json:"deferrable,omitempty"`
 
 	// IndexParameters corresponds to the JSON schema field "index_parameters".
 	IndexParameters *ConstraintIndexParameters `json:"index_parameters,omitempty"`
 
 	// Initially deferred constraint
-	InitiallyDeferred *bool `json:"initially_deferred,omitempty"`
+	InitiallyDeferred bool `json:"initially_deferred,omitempty"`
 
 	// Name of the constraint
 	Name string `json:"name"`
 
 	// Nulls not distinct constraint
-	NullsNotDistinct *bool `json:"nulls_not_distinct,omitempty"`
+	NullsNotDistinct bool `json:"nulls_not_distinct,omitempty"`
 
 	// Type of the constraint
 	Type ConstraintType `json:"type"`
@@ -73,10 +73,10 @@ type ConstraintIndexParameters struct {
 	IncludeColumns []string `json:"include_columns,omitempty"`
 
 	// StorageParameters corresponds to the JSON schema field "storage_parameters".
-	StorageParameters *string `json:"storage_parameters,omitempty"`
+	StorageParameters string `json:"storage_parameters,omitempty"`
 
 	// Tablespace corresponds to the JSON schema field "tablespace".
-	Tablespace *string `json:"tablespace,omitempty"`
+	Tablespace string `json:"tablespace,omitempty"`
 }
 
 type ConstraintType string

--- a/pkg/sql2pgroll/convert.go
+++ b/pkg/sql2pgroll/convert.go
@@ -20,6 +20,7 @@ func Convert(sql string) (migrations.Operations, error) {
 	}
 
 	if ops == nil {
+		fmt.Println("ops is nil")
 		return makeRawSQLOperation(sql), nil
 	}
 

--- a/pkg/sql2pgroll/convert.go
+++ b/pkg/sql2pgroll/convert.go
@@ -20,7 +20,6 @@ func Convert(sql string) (migrations.Operations, error) {
 	}
 
 	if ops == nil {
-		fmt.Println("ops is nil")
 		return makeRawSQLOperation(sql), nil
 	}
 

--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -15,7 +15,6 @@ import (
 func convertCreateStmt(stmt *pgq.CreateStmt) (migrations.Operations, error) {
 	// Check if the statement can be converted
 	if !canConvertCreateStatement(stmt) {
-		fmt.Println("cannot convert create statement")
 		return nil, nil
 	}
 

--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -39,13 +39,13 @@ func convertCreateStmt(stmt *pgq.CreateStmt) (migrations.Operations, error) {
 		}
 	}
 
-	var constraints []migrations.Constraint
-	for _, c := range stmt.Constraints {
+	constraints := make([]migrations.Constraint, len(stmt.Constraints))
+	for i, c := range stmt.Constraints {
 		constraint, err := convertConstraint(c.GetConstraint())
 		if err != nil {
 			return nil, fmt.Errorf("error converting table constraint: %w", err)
 		}
-		constraints = append(constraints, *constraint)
+		constraints[i] = *constraint
 	}
 
 	return migrations.Operations{

--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -40,6 +40,9 @@ func convertCreateStmt(stmt *pgq.CreateStmt) (migrations.Operations, error) {
 			if err != nil {
 				return nil, fmt.Errorf("error converting table constraint: %w", err)
 			}
+			if constraint == nil {
+				return nil, nil
+			}
 			constraints = append(constraints, *constraint)
 		default:
 			return nil, nil
@@ -207,7 +210,7 @@ func convertConstraint(c *pgq.Constraint) (*migrations.Constraint, error) {
 		constraintType = migrations.ConstraintTypeUnique
 		nullsNotDistinct = ptr(c.NullsNotDistinct)
 	default:
-		return nil, fmt.Errorf("unsupported constraint type: %s", c.Contype)
+		return nil, nil
 	}
 
 	columns := make([]string, len(c.Keys))

--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -208,6 +208,8 @@ func convertConstraint(c *pgq.Constraint) (*migrations.Constraint, error) {
 	case pgq.ConstrType_CONSTR_UNIQUE:
 		constraintType = migrations.ConstraintTypeUnique
 		nullsNotDistinct = c.NullsNotDistinct
+	case pgq.ConstrType_CONSTR_CHECK:
+		constraintType = migrations.ConstraintTypeCheck
 	default:
 		return nil, nil
 	}
@@ -241,11 +243,14 @@ func convertConstraint(c *pgq.Constraint) (*migrations.Constraint, error) {
 		}
 	}
 
+	// TODO deparse CHECK expression
+
 	return &migrations.Constraint{
 		Name:              c.Conname,
 		Type:              constraintType,
 		Columns:           columns,
 		NullsNotDistinct:  nullsNotDistinct,
+		NoInherit:         c.IsNoInherit,
 		Deferrable:        c.Deferrable,
 		InitiallyDeferred: c.Initdeferred,
 		IndexParameters:   indexParameters,

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -3,7 +3,6 @@
 package sql2pgroll_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -3,6 +3,7 @@
 package sql2pgroll_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -181,6 +182,7 @@ func TestConvertCreateTableStatements(t *testing.T) {
 
 			require.Len(t, ops, 1)
 
+			fmt.Println(ops[0])
 			createTableOp, ok := ops[0].(*migrations.OpCreateTable)
 			require.True(t, ok)
 

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -182,7 +182,6 @@ func TestConvertCreateTableStatements(t *testing.T) {
 
 			require.Len(t, ops, 1)
 
-			fmt.Println(ops[0])
 			createTableOp, ok := ops[0].(*migrations.OpCreateTable)
 			require.True(t, ok)
 

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -165,11 +165,11 @@ func TestConvertCreateTableStatements(t *testing.T) {
 			expectedOp: expect.CreateTableOp21,
 		},
 		{
-			sql:        "CREATE TABLE foo(a serial PRIMARY KEY, b text, c text, UNIQUE (b, c)",
+			sql:        "CREATE TABLE foo(a serial PRIMARY KEY, b text, c text, UNIQUE (b, c))",
 			expectedOp: expect.CreateTableOp22,
 		},
 		{
-			sql:        "CREATE TABLE foo(b text, c text, UNIQUE (b) include (c) with (fillfactor = 70))",
+			sql:        "CREATE TABLE foo(b text, c text, UNIQUE (b) include (c) with (fillfactor = 70) using index tablespace my_tablespace)",
 			expectedOp: expect.CreateTableOp23,
 		},
 	}

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -170,7 +170,7 @@ func TestConvertCreateTableStatements(t *testing.T) {
 			expectedOp: expect.CreateTableOp22,
 		},
 		{
-			sql:        "CREATE TABLE foo(b text, c text, UNIQUE (b) include (c) with (fillfactor = 70) using index tablespace my_tablespace)",
+			sql:        "CREATE TABLE foo(b text, c text, UNIQUE (b) INCLUDE (c) WITH (fillfactor = 70) USING INDEX TABLESPACE my_tablespace)",
 			expectedOp: expect.CreateTableOp23,
 		},
 	}

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -173,11 +173,11 @@ func TestConvertCreateTableStatements(t *testing.T) {
 			expectedOp: expect.CreateTableOp23,
 		},
 		{
-			sql:        "CREATE TABLE foo(b text, c text, CHECK (b=c))",
+			sql:        "CREATE TABLE foo(a int, CHECK (a>0))",
 			expectedOp: expect.CreateTableOp24,
 		},
 		{
-			sql:        "CREATE TABLE foo(b text, c text, CHECK (b=c) NO INHERIT INITIALLY IMMEDIATE)",
+			sql:        "CREATE TABLE foo(b text, c text, CHECK (b=c) NO INHERIT)",
 			expectedOp: expect.CreateTableOp25,
 		},
 	}
@@ -247,10 +247,8 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 		"CREATE TABLE foo(a text COLLATE en_US)",
 
 		// Table constraints, named and unnamed, are not supported
-		"CREATE TABLE foo(a int, CONSTRAINT foo_check CHECK (a > 0))",
 		"CREATE TABLE foo(a int, CONSTRAINT foo_pk PRIMARY KEY (a))",
 		"CREATE TABLE foo(a int, CONSTRAINT foo_fk FOREIGN KEY (a) REFERENCES bar(b))",
-		"CREATE TABLE foo(a int, CHECK (a > 0))",
 		"CREATE TABLE foo(a int, PRIMARY KEY (a))",
 		"CREATE TABLE foo(a int, FOREIGN KEY (a) REFERENCES bar(b))",
 

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -164,6 +164,14 @@ func TestConvertCreateTableStatements(t *testing.T) {
 			sql:        "CREATE TABLE foo(a serial PRIMARY KEY, b int DEFAULT 100 CHECK (b > 0), c text NOT NULL UNIQUE)",
 			expectedOp: expect.CreateTableOp21,
 		},
+		{
+			sql:        "CREATE TABLE foo(a serial PRIMARY KEY, b text, c text, UNIQUE (b, c)",
+			expectedOp: expect.CreateTableOp22,
+		},
+		{
+			sql:        "CREATE TABLE foo(b text, c text, UNIQUE (b) include (c) with (fillfactor = 70))",
+			expectedOp: expect.CreateTableOp23,
+		},
 	}
 
 	for _, tc := range tests {
@@ -232,11 +240,9 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 
 		// Table constraints, named and unnamed, are not supported
 		"CREATE TABLE foo(a int, CONSTRAINT foo_check CHECK (a > 0))",
-		"CREATE TABLE foo(a int, CONSTRAINT foo_unique UNIQUE (a))",
 		"CREATE TABLE foo(a int, CONSTRAINT foo_pk PRIMARY KEY (a))",
 		"CREATE TABLE foo(a int, CONSTRAINT foo_fk FOREIGN KEY (a) REFERENCES bar(b))",
 		"CREATE TABLE foo(a int, CHECK (a > 0))",
-		"CREATE TABLE foo(a int, UNIQUE (a))",
 		"CREATE TABLE foo(a int, PRIMARY KEY (a))",
 		"CREATE TABLE foo(a int, FOREIGN KEY (a) REFERENCES bar(b))",
 

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -172,6 +172,14 @@ func TestConvertCreateTableStatements(t *testing.T) {
 			sql:        "CREATE TABLE foo(b text, c text, UNIQUE (b) INCLUDE (c) WITH (fillfactor = 70) USING INDEX TABLESPACE my_tablespace)",
 			expectedOp: expect.CreateTableOp23,
 		},
+		{
+			sql:        "CREATE TABLE foo(b text, c text, CHECK (b=c))",
+			expectedOp: expect.CreateTableOp24,
+		},
+		{
+			sql:        "CREATE TABLE foo(b text, c text, CHECK (b=c) NO INHERIT INITIALLY IMMEDIATE)",
+			expectedOp: expect.CreateTableOp25,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/sql2pgroll/expect/create_table.go
+++ b/pkg/sql2pgroll/expect/create_table.go
@@ -348,7 +348,7 @@ var CreateTableOp23 = &migrations.OpCreateTable{
 			InitiallyDeferred: false,
 			IndexParameters: &migrations.ConstraintIndexParameters{
 				IncludeColumns:    []string{"c"},
-				StorageParameters: "fillfactor = '70'",
+				StorageParameters: "fillfactor=70",
 				Tablespace:        "my_tablespace",
 			},
 		},

--- a/pkg/sql2pgroll/expect/create_table.go
+++ b/pkg/sql2pgroll/expect/create_table.go
@@ -304,18 +304,23 @@ var CreateTableOp22 = &migrations.OpCreateTable{
 			Pk:   true,
 		},
 		{
-			Name: "b",
-			Type: "text",
+			Name:     "b",
+			Type:     "text",
+			Nullable: true,
 		},
 		{
-			Name: "c",
-			Type: "text",
+			Name:     "c",
+			Type:     "text",
+			Nullable: true,
 		},
 	},
 	Constraints: []migrations.Constraint{
 		{
-			Type:    migrations.ConstraintTypeUnique,
-			Columns: []string{"b", "c"},
+			Type:              migrations.ConstraintTypeUnique,
+			Columns:           []string{"b", "c"},
+			NullsNotDistinct:  ptr(false),
+			Deferrable:        ptr(false),
+			InitiallyDeferred: ptr(false),
 		},
 	},
 }
@@ -324,21 +329,26 @@ var CreateTableOp23 = &migrations.OpCreateTable{
 	Name: "foo",
 	Columns: []migrations.Column{
 		{
-			Name: "b",
-			Type: "text",
+			Name:     "b",
+			Type:     "text",
+			Nullable: true,
 		},
 		{
-			Name: "c",
-			Type: "text",
+			Name:     "c",
+			Type:     "text",
+			Nullable: true,
 		},
 	},
 	Constraints: []migrations.Constraint{
 		{
-			Type:    migrations.ConstraintTypeUnique,
-			Columns: []string{"b"},
+			Type:              migrations.ConstraintTypeUnique,
+			Columns:           []string{"b"},
+			NullsNotDistinct:  ptr(false),
+			Deferrable:        ptr(false),
+			InitiallyDeferred: ptr(false),
 			IndexParameters: &migrations.ConstraintIndexParameters{
 				IncludeColumns:    []string{"c"},
-				StorageParameters: ptr("fillfactor=70"),
+				StorageParameters: ptr("fillfactor = '70'"),
 				Tablespace:        ptr("my_tablespace"),
 			},
 		},

--- a/pkg/sql2pgroll/expect/create_table.go
+++ b/pkg/sql2pgroll/expect/create_table.go
@@ -354,3 +354,55 @@ var CreateTableOp23 = &migrations.OpCreateTable{
 		},
 	},
 }
+
+var CreateTableOp24 = &migrations.OpCreateTable{
+	Name: "foo",
+	Columns: []migrations.Column{
+		{
+			Name:     "b",
+			Type:     "text",
+			Nullable: true,
+		},
+		{
+			Name:     "c",
+			Type:     "text",
+			Nullable: true,
+		},
+	},
+	Constraints: []migrations.Constraint{
+		{
+			Type:              migrations.ConstraintTypeCheck,
+			Columns:           []string{"b", "c"},
+			NullsNotDistinct:  false,
+			Deferrable:        false,
+			InitiallyDeferred: false,
+			NoInherit:         false,
+		},
+	},
+}
+
+var CreateTableOp25 = &migrations.OpCreateTable{
+	Name: "foo",
+	Columns: []migrations.Column{
+		{
+			Name:     "b",
+			Type:     "text",
+			Nullable: true,
+		},
+		{
+			Name:     "c",
+			Type:     "text",
+			Nullable: true,
+		},
+	},
+	Constraints: []migrations.Constraint{
+		{
+			Type:              migrations.ConstraintTypeCheck,
+			Columns:           []string{"b", "c"},
+			NullsNotDistinct:  false,
+			Deferrable:        false,
+			InitiallyDeferred: true,
+			NoInherit:         true,
+		},
+	},
+}

--- a/pkg/sql2pgroll/expect/create_table.go
+++ b/pkg/sql2pgroll/expect/create_table.go
@@ -294,3 +294,53 @@ var CreateTableOp21 = &migrations.OpCreateTable{
 		},
 	},
 }
+
+var CreateTableOp22 = &migrations.OpCreateTable{
+	Name: "foo",
+	Columns: []migrations.Column{
+		{
+			Name: "a",
+			Type: "serial",
+			Pk:   true,
+		},
+		{
+			Name: "b",
+			Type: "text",
+		},
+		{
+			Name: "c",
+			Type: "text",
+		},
+	},
+	Constraints: []migrations.Constraint{
+		{
+			Type:    migrations.ConstraintTypeUnique,
+			Columns: []string{"b", "c"},
+		},
+	},
+}
+
+var CreateTableOp23 = &migrations.OpCreateTable{
+	Name: "foo",
+	Columns: []migrations.Column{
+		{
+			Name: "b",
+			Type: "text",
+		},
+		{
+			Name: "c",
+			Type: "text",
+		},
+	},
+	Constraints: []migrations.Constraint{
+		{
+			Type:    migrations.ConstraintTypeUnique,
+			Columns: []string{"b"},
+			IndexParameters: &migrations.ConstraintIndexParameters{
+				IncludeColumns:    []string{"c"},
+				StorageParameters: ptr("fillfactor=70"),
+				Tablespace:        ptr("my_tablespace"),
+			},
+		},
+	},
+}

--- a/pkg/sql2pgroll/expect/create_table.go
+++ b/pkg/sql2pgroll/expect/create_table.go
@@ -318,9 +318,9 @@ var CreateTableOp22 = &migrations.OpCreateTable{
 		{
 			Type:              migrations.ConstraintTypeUnique,
 			Columns:           []string{"b", "c"},
-			NullsNotDistinct:  ptr(false),
-			Deferrable:        ptr(false),
-			InitiallyDeferred: ptr(false),
+			NullsNotDistinct:  false,
+			Deferrable:        false,
+			InitiallyDeferred: false,
 		},
 	},
 }
@@ -343,13 +343,13 @@ var CreateTableOp23 = &migrations.OpCreateTable{
 		{
 			Type:              migrations.ConstraintTypeUnique,
 			Columns:           []string{"b"},
-			NullsNotDistinct:  ptr(false),
-			Deferrable:        ptr(false),
-			InitiallyDeferred: ptr(false),
+			NullsNotDistinct:  false,
+			Deferrable:        false,
+			InitiallyDeferred: false,
 			IndexParameters: &migrations.ConstraintIndexParameters{
 				IncludeColumns:    []string{"c"},
-				StorageParameters: ptr("fillfactor = '70'"),
-				Tablespace:        ptr("my_tablespace"),
+				StorageParameters: "fillfactor = '70'",
+				Tablespace:        "my_tablespace",
 			},
 		},
 	},

--- a/pkg/sql2pgroll/expect/create_table.go
+++ b/pkg/sql2pgroll/expect/create_table.go
@@ -359,20 +359,16 @@ var CreateTableOp24 = &migrations.OpCreateTable{
 	Name: "foo",
 	Columns: []migrations.Column{
 		{
-			Name:     "b",
-			Type:     "text",
-			Nullable: true,
-		},
-		{
-			Name:     "c",
-			Type:     "text",
+			Name:     "a",
+			Type:     "int",
 			Nullable: true,
 		},
 	},
 	Constraints: []migrations.Constraint{
 		{
 			Type:              migrations.ConstraintTypeCheck,
-			Columns:           []string{"b", "c"},
+			Check:             "a > 0",
+			Columns:           []string{},
 			NullsNotDistinct:  false,
 			Deferrable:        false,
 			InitiallyDeferred: false,
@@ -398,10 +394,11 @@ var CreateTableOp25 = &migrations.OpCreateTable{
 	Constraints: []migrations.Constraint{
 		{
 			Type:              migrations.ConstraintTypeCheck,
-			Columns:           []string{"b", "c"},
+			Check:             "b = c",
+			Columns:           []string{},
 			NullsNotDistinct:  false,
 			Deferrable:        false,
-			InitiallyDeferred: true,
+			InitiallyDeferred: false,
 			NoInherit:         true,
 		},
 	},

--- a/schema.json
+++ b/schema.json
@@ -164,6 +164,57 @@
           }
         }
       },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "unique"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "check": {
+                  "const": "",
+              },
+              "no_inherit": {
+                "const": false
+              }
+            },
+            "required": ["columns"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "check"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "check": {
+                "type": "string"
+              },
+              "index_parameters": {
+                "const": {}
+              },
+              "deferrable": {
+                "const": false
+              },
+              "initially_deferred": {
+                "const": false
+              },
+              "nulls_not_distinct": {
+                "const": false
+              }
+            },
+            "required": ["check"]
+          }
+        }
+      ],
       "required": ["name", "type"],
       "type": "object"
     },

--- a/schema.json
+++ b/schema.json
@@ -155,8 +155,8 @@
             }
           }
         },
-        "defferable": {
-          "description": "Defferable constraint",
+        "deferable": {
+          "description": "Deferable constraint",
           "type": "boolean"
         },
         "initially_deferred": {
@@ -171,36 +171,34 @@
           "description": "Nulls not distinct constraint",
           "type": "boolean"
         },
+        "tablespace": {
+          "type": "string"
+        },
+        "storage_parameters": {
+          "type": "string"
+        },
+        "include_columns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "exclude": {
           "description": "Exclude constraint",
           "additionalProperties": false,
           "type": "object",
           "properties": {
             "elements": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+              "type": "string"
             },
             "index_method": {
               "type": "string"
             },
-            "include_columns": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "storage_parameters": {
-              "type": "string"
-            },
             "predicate": {
               "type": "string"
-            },
-            "tablespace": {
-              "type": "string"
             }
-          }
+          },
+          "required": ["index_method", "elements"]
         }
       },
       "required": ["name", "type"],

--- a/schema.json
+++ b/schema.json
@@ -98,6 +98,58 @@
       "type": "string",
       "enum": ["NO ACTION", "RESTRICT", "CASCADE", "SET NULL", "SET DEFAULT"]
     },
+    "Constraint": {
+      "additionalProperties": false,
+      "description": "Constraint definition",
+      "properties": {
+        "name": {
+          "description": "Name of the constraint",
+          "type": "string"
+        },
+        "columns": {
+          "description": "Columns to add constraint to",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "description": "Type of the constraint",
+          "type": "string",
+          "enum": ["unique", "check", "foreign_key"]
+        },
+        "check": {
+          "description": "Check constraint expression",
+          "type": "string"
+        },
+        "references": {
+          "description": "Reference to the foreign key",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["table", "columns"],
+          "properties": {
+            "table": {
+              "description": "Name of the table",
+              "type": "string"
+            },
+            "columns": {
+              "description": "Columns to reference",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "on_delete": {
+              "description": "On delete behavior of the foreign key constraint",
+              "$ref": "#/$defs/ForeignKeyReferenceOnDelete",
+              "default": "NO ACTION"
+            }
+          }
+        }
+      },
+      "required": ["name", "type"],
+      "type": "object"
+    },
     "OpAddColumn": {
       "additionalProperties": false,
       "description": "Add column operation",
@@ -279,6 +331,13 @@
         "comment": {
           "description": "Postgres comment for the table",
           "type": "string"
+        },
+        "constraints": {
+          "items": {
+            "$ref": "#/$defs/Constraint",
+            "description": "Constraints to add to the table"
+          },
+          "type": "array"
         }
       },
       "required": ["columns", "name"],

--- a/schema.json
+++ b/schema.json
@@ -116,7 +116,7 @@
         "type": {
           "description": "Type of the constraint",
           "type": "string",
-          "enum": ["unique", "check", "foreign_key"]
+          "enum": ["unique", "check", "primary_key", "foreign_key", "exclude"]
         },
         "check": {
           "description": "Check constraint expression",
@@ -143,6 +143,62 @@
               "description": "On delete behavior of the foreign key constraint",
               "$ref": "#/$defs/ForeignKeyReferenceOnDelete",
               "default": "NO ACTION"
+            },
+            "on_update": {
+              "description": "On update behavior of the foreign key constraint",
+              "$ref": "#/$defs/ForeignKeyReferenceOnDelete",
+              "default": "NO ACTION"
+            },
+            "match_type": {
+              "description": "Match type of the foreign key constraint",
+              "type": "string"
+            }
+          }
+        },
+        "defferable": {
+          "description": "Defferable constraint",
+          "type": "boolean"
+        },
+        "initially_deferred": {
+          "description": "Initially deferred constraint",
+          "type": "boolean"
+        },
+        "no_inherit": {
+          "description": "No inherit constraint",
+          "type": "boolean"
+        },
+        "nulls_not_distinct": {
+          "description": "Nulls not distinct constraint",
+          "type": "boolean"
+        },
+        "exclude": {
+          "description": "Exclude constraint",
+          "additionalProperties": false,
+          "type": "object",
+          "properties": {
+            "elements": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "index_method": {
+              "type": "string"
+            },
+            "include_columns": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "storage_parameters": {
+              "type": "string"
+            },
+            "predicate": {
+              "type": "string"
+            },
+            "tablespace": {
+              "type": "string"
             }
           }
         }

--- a/schema.json
+++ b/schema.json
@@ -176,7 +176,7 @@
           "then": {
             "properties": {
               "check": {
-                  "const": "",
+                "const": ""
               },
               "no_inherit": {
                 "const": false

--- a/schema.json
+++ b/schema.json
@@ -120,25 +120,30 @@
         },
         "deferrable": {
           "description": "Deferable constraint",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "initially_deferred": {
           "description": "Initially deferred constraint",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "nulls_not_distinct": {
           "description": "Nulls not distinct constraint",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "index_parameters": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
             "tablespace": {
-              "type": "string"
+              "type": "string",
+              "default": ""
             },
             "storage_parameters": {
-              "type": "string"
+              "type": "string",
+              "default": ""
             },
             "include_columns": {
               "type": "array",

--- a/schema.json
+++ b/schema.json
@@ -116,7 +116,7 @@
         "type": {
           "description": "Type of the constraint",
           "type": "string",
-          "enum": ["unique"]
+          "enum": ["unique", "check"]
         },
         "deferrable": {
           "description": "Deferable constraint",
@@ -132,6 +132,16 @@
           "description": "Nulls not distinct constraint",
           "type": "boolean",
           "default": false
+        },
+        "no_inherit": {
+          "description": "Do not propagate constraint to child tables",
+          "type": "boolean",
+          "default": false
+        },
+        "check": {
+          "description": "Check constraint expression",
+          "type": "string",
+          "default": ""
         },
         "index_parameters": {
           "type": "object",

--- a/schema.json
+++ b/schema.json
@@ -116,46 +116,9 @@
         "type": {
           "description": "Type of the constraint",
           "type": "string",
-          "enum": ["unique", "check", "primary_key", "foreign_key", "exclude"]
+          "enum": ["unique"]
         },
-        "check": {
-          "description": "Check constraint expression",
-          "type": "string"
-        },
-        "references": {
-          "description": "Reference to the foreign key",
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["table", "columns"],
-          "properties": {
-            "table": {
-              "description": "Name of the table",
-              "type": "string"
-            },
-            "columns": {
-              "description": "Columns to reference",
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "on_delete": {
-              "description": "On delete behavior of the foreign key constraint",
-              "$ref": "#/$defs/ForeignKeyReferenceOnDelete",
-              "default": "NO ACTION"
-            },
-            "on_update": {
-              "description": "On update behavior of the foreign key constraint",
-              "$ref": "#/$defs/ForeignKeyReferenceOnDelete",
-              "default": "NO ACTION"
-            },
-            "match_type": {
-              "description": "Match type of the foreign key constraint",
-              "type": "string"
-            }
-          }
-        },
-        "deferable": {
+        "deferrable": {
           "description": "Deferable constraint",
           "type": "boolean"
         },
@@ -163,42 +126,27 @@
           "description": "Initially deferred constraint",
           "type": "boolean"
         },
-        "no_inherit": {
-          "description": "No inherit constraint",
-          "type": "boolean"
-        },
         "nulls_not_distinct": {
           "description": "Nulls not distinct constraint",
           "type": "boolean"
         },
-        "tablespace": {
-          "type": "string"
-        },
-        "storage_parameters": {
-          "type": "string"
-        },
-        "include_columns": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "exclude": {
-          "description": "Exclude constraint",
-          "additionalProperties": false,
+        "index_parameters": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "elements": {
+            "tablespace": {
               "type": "string"
             },
-            "index_method": {
+            "storage_parameters": {
               "type": "string"
             },
-            "predicate": {
-              "type": "string"
+            "include_columns": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
-          },
-          "required": ["index_method", "elements"]
+          }
         }
       },
       "required": ["name", "type"],


### PR DESCRIPTION
This PR adds a new type of constraints to `create_table` operation, named `check`. So from now, it is possible to configure table level check constraints.

Available settings:
* `check`: required, check expression
* `no_inherit`: disable constraint inheritance in child tables (default: `false`)

Example:
```json
{
  "name": "50_create_table_with_table_constraint",
  "operations": [
    {
      "create_table": {
        "name": "phonebook",
        "columns": [
          {
            "name": "id",
            "type": "serial",
            "pk": true
          },
          {
            "name": "name",
            "type": "varchar(255)"
          }
        ],
        "constraints": [
          {
            "name": "name_must_be_present",
            "type": "check",
            "check": "length(name) > 0"
          }
        ]
      }
    }
  ]
}
```

Part of https://github.com/xataio/pgroll/issues/580