### PR TITLE
Multi-operation migration support for `drop_column` operations

### DIFF
--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -121,11 +121,11 @@ func (o *OpAddColumn) Complete(ctx context.Context, conn db.DB, tr SQLTransforme
 
 func (o *OpAddColumn) Rollback(ctx context.Context, conn db.DB, tr SQLTransformer, s *schema.Schema) error {
 	table := s.GetTable(o.Table)
-	tempName := TemporaryName(o.Column.Name)
+	column := table.GetColumn(o.Column.Name)
 
 	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s DROP COLUMN IF EXISTS %s",
 		pq.QuoteIdentifier(table.Name),
-		pq.QuoteIdentifier(tempName)))
+		pq.QuoteIdentifier(column.Name)))
 	if err != nil {
 		return err
 	}

--- a/pkg/migrations/op_drop_column.go
+++ b/pkg/migrations/op_drop_column.go
@@ -52,6 +52,10 @@ func (o *OpDropColumn) Rollback(ctx context.Context, conn db.DB, tr SQLTransform
 	_, err := conn.ExecContext(ctx, fmt.Sprintf("DROP FUNCTION IF EXISTS %s CASCADE",
 		pq.QuoteIdentifier(TriggerFunctionName(o.Table, o.Column))))
 
+	// Mark the column as no longer deleted so thats it's visible to preceding
+	// rollback operations in the same migration
+	s.GetTable(o.Table).UnRemoveColumn(o.Column)
+
 	return err
 }
 

--- a/pkg/migrations/op_drop_column.go
+++ b/pkg/migrations/op_drop_column.go
@@ -21,7 +21,7 @@ func (o *OpDropColumn) Start(ctx context.Context, conn db.DB, latestSchema strin
 			Columns:        s.GetTable(o.Table).Columns,
 			SchemaName:     s.Name,
 			LatestSchema:   latestSchema,
-			TableName:      o.Table,
+			TableName:      s.GetTable(o.Table).Name,
 			PhysicalColumn: o.Column,
 			SQL:            o.Down,
 		})

--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -278,7 +278,9 @@ func (m *Roll) Rollback(ctx context.Context) error {
 func (m *Roll) ensureView(ctx context.Context, version, name string, table *schema.Table) error {
 	columns := make([]string, 0, len(table.Columns))
 	for k, v := range table.Columns {
-		columns = append(columns, fmt.Sprintf("%s AS %s", pq.QuoteIdentifier(v.Name), pq.QuoteIdentifier(k)))
+		if !v.Deleted {
+			columns = append(columns, fmt.Sprintf("%s AS %s", pq.QuoteIdentifier(v.Name), pq.QuoteIdentifier(k)))
+		}
 	}
 
 	// Create view with security_invoker option for PG 15+

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -80,6 +80,9 @@ type Column struct {
 
 	// Will contain possible enum values if the type is an enum
 	EnumValues []string `json:"enumValues"`
+
+	// Whether or not the column has been deleted in the virtual schema
+	Deleted bool `json:"-"`
 }
 
 // Index represents an index on a table
@@ -199,7 +202,7 @@ func (t *Table) GetColumn(name string) *Column {
 		return nil
 	}
 	c, ok := t.Columns[name]
-	if !ok {
+	if !ok || c.Deleted {
 		return nil
 	}
 	return c
@@ -255,9 +258,19 @@ func (t *Table) AddColumn(name string, c *Column) {
 	t.Columns[name] = c
 }
 
-// RemoveColumn removes a column from the table
+// RemoveColumn removes a column from the table by marking it as deleted
 func (t *Table) RemoveColumn(column string) {
-	delete(t.Columns, column)
+	if col, ok := t.Columns[column]; ok {
+		col.Deleted = true
+	}
+}
+
+// UnRemoveColumn unremoves a previously removed column by marking it as not
+// deleted
+func (t *Table) UnRemoveColumn(column string) {
+	if col, ok := t.Columns[column]; ok {
+		col.Deleted = false
+	}
 }
 
 // RenameColumn renames a column in the table


### PR DESCRIPTION
Ensure that `drop_column` operations can be used as part of multi-operation migrations:

Add testcases for:
* **rename table, drop column**
* **add column, drop column**

Theses changes help ensure that `drop_column` operations can be used as part of multi-operation migrations.

Part of https://github.com/xataio/pgroll/issues/239