### PR TITLE
Add pg type type info to schema

### DIFF
--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -83,6 +83,9 @@ type Column struct {
 
 	// Whether or not the column has been deleted in the virtual schema
 	Deleted bool `json:"-"`
+
+	// Postgres type type, e.g enum, composite, range
+	PostgresType string `json:"postgresType"`
 }
 
 // Index represents an index on a table

--- a/pkg/state/init.sql
+++ b/pkg/state/init.sql
@@ -163,17 +163,21 @@ BEGIN
                                         array_agg(e.enumlabel ORDER BY e.enumsortorder)
                                     FROM pg_enum AS e
                                 WHERE
-                                    e.enumtypid = tp.oid) AS enumValues,
-                                CASE 
-                                    WHEN tp.typtype='b' THEN 'base'
-                                    WHEN tp.typtype='c' THEN 'composite'
-                                    WHEN tp.typtype='d' THEN 'domain'
-                                    WHEN tp.typtype='e' THEN 'enum'
-                                    WHEN tp.typtype='p' THEN 'pseudo'
-                                    WHEN tp.typtype='r' THEN 'range'
-                                    WHEN tp.typtype='m' THEN 'multirange'
-                                END AS postgresType
-                                FROM pg_attribute AS attr
+                                    e.enumtypid = tp.oid) AS enumValues, CASE WHEN tp.typtype = 'b' THEN
+                                    'base'
+                                WHEN tp.typtype = 'c' THEN
+                                    'composite'
+                                WHEN tp.typtype = 'd' THEN
+                                    'domain'
+                                WHEN tp.typtype = 'e' THEN
+                                    'enum'
+                                WHEN tp.typtype = 'p' THEN
+                                    'pseudo'
+                                WHEN tp.typtype = 'r' THEN
+                                    'range'
+                                WHEN tp.typtype = 'm' THEN
+                                    'multirange'
+                                END AS postgresType FROM pg_attribute AS attr
                                 INNER JOIN pg_type AS tp ON attr.atttypid = tp.oid
                                 LEFT JOIN pg_attrdef AS def ON attr.attrelid = def.adrelid
                                     AND attr.attnum = def.adnum

--- a/pkg/state/init.sql
+++ b/pkg/state/init.sql
@@ -163,7 +163,17 @@ BEGIN
                                         array_agg(e.enumlabel ORDER BY e.enumsortorder)
                                     FROM pg_enum AS e
                                 WHERE
-                                    e.enumtypid = tp.oid) AS enumValues FROM pg_attribute AS attr
+                                    e.enumtypid = tp.oid) AS enumValues,
+                                CASE 
+                                    WHEN tp.typtype='b' THEN 'base'
+                                    WHEN tp.typtype='c' THEN 'composite'
+                                    WHEN tp.typtype='d' THEN 'domain'
+                                    WHEN tp.typtype='e' THEN 'enum'
+                                    WHEN tp.typtype='p' THEN 'pseudo'
+                                    WHEN tp.typtype='r' THEN 'range'
+                                    WHEN tp.typtype='m' THEN 'multirange'
+                                END AS postgresType
+                                FROM pg_attribute AS attr
                                 INNER JOIN pg_type AS tp ON attr.atttypid = tp.oid
                                 LEFT JOIN pg_attrdef AS def ON attr.attrelid = def.adrelid
                                     AND attr.attnum = def.adnum

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -408,9 +408,10 @@ func TestReadSchema(t *testing.T) {
 							Name: "table1",
 							Columns: map[string]*schema.Column{
 								"id": {
-									Name:     "id",
-									Type:     "integer",
-									Nullable: true,
+									Name:         "id",
+									Type:         "integer",
+									Nullable:     true,
+									PostgresType: "base",
 								},
 							},
 							PrimaryKey:        []string{},
@@ -432,10 +433,11 @@ func TestReadSchema(t *testing.T) {
 							Name: "table1",
 							Columns: map[string]*schema.Column{
 								"id": {
-									Name:     "id",
-									Type:     "integer",
-									Nullable: false,
-									Unique:   true,
+									Name:         "id",
+									Type:         "integer",
+									Nullable:     false,
+									Unique:       true,
+									PostgresType: "base",
 								},
 							},
 							PrimaryKey: []string{},
@@ -470,14 +472,16 @@ func TestReadSchema(t *testing.T) {
 							Name: "table1",
 							Columns: map[string]*schema.Column{
 								"id": {
-									Name:     "id",
-									Type:     "integer",
-									Nullable: true,
+									Name:         "id",
+									Type:         "integer",
+									Nullable:     true,
+									PostgresType: "base",
 								},
 								"name": {
-									Name:     "name",
-									Type:     "text",
-									Nullable: true,
+									Name:         "name",
+									Type:         "text",
+									Nullable:     true,
+									PostgresType: "base",
 								},
 							},
 							PrimaryKey: []string{},
@@ -507,10 +511,11 @@ func TestReadSchema(t *testing.T) {
 							Name: "table1",
 							Columns: map[string]*schema.Column{
 								"id": {
-									Name:     "id",
-									Type:     "integer",
-									Nullable: false,
-									Unique:   true,
+									Name:         "id",
+									Type:         "integer",
+									Nullable:     false,
+									Unique:       true,
+									PostgresType: "base",
 								},
 							},
 							PrimaryKey: []string{"id"},
@@ -531,9 +536,10 @@ func TestReadSchema(t *testing.T) {
 							Name: "table2",
 							Columns: map[string]*schema.Column{
 								"fk": {
-									Name:     "fk",
-									Type:     "integer",
-									Nullable: false,
+									Name:         "fk",
+									Type:         "integer",
+									Nullable:     false,
+									PostgresType: "base",
 								},
 							},
 							PrimaryKey: []string{},
@@ -563,10 +569,11 @@ func TestReadSchema(t *testing.T) {
 							Name: "table1",
 							Columns: map[string]*schema.Column{
 								"id": {
-									Name:     "id",
-									Type:     "integer",
-									Nullable: false,
-									Unique:   true,
+									Name:         "id",
+									Type:         "integer",
+									Nullable:     false,
+									Unique:       true,
+									PostgresType: "base",
 								},
 							},
 							PrimaryKey: []string{"id"},
@@ -587,9 +594,10 @@ func TestReadSchema(t *testing.T) {
 							Name: "table2",
 							Columns: map[string]*schema.Column{
 								"fk": {
-									Name:     "fk",
-									Type:     "integer",
-									Nullable: false,
+									Name:         "fk",
+									Type:         "integer",
+									Nullable:     false,
+									PostgresType: "base",
 								},
 							},
 							PrimaryKey: []string{},
@@ -619,15 +627,17 @@ func TestReadSchema(t *testing.T) {
 							Name: "table1",
 							Columns: map[string]*schema.Column{
 								"id": {
-									Name:     "id",
-									Type:     "integer",
-									Nullable: false,
-									Unique:   true,
+									Name:         "id",
+									Type:         "integer",
+									Nullable:     false,
+									Unique:       true,
+									PostgresType: "base",
 								},
 								"age": {
-									Name:     "age",
-									Type:     "integer",
-									Nullable: true,
+									Name:         "age",
+									Type:         "integer",
+									Nullable:     true,
+									PostgresType: "base",
 								},
 							},
 							PrimaryKey: []string{"id"},
@@ -663,16 +673,18 @@ func TestReadSchema(t *testing.T) {
 							Name: "table1",
 							Columns: map[string]*schema.Column{
 								"id": {
-									Name:     "id",
-									Type:     "integer",
-									Nullable: false,
-									Unique:   true,
+									Name:         "id",
+									Type:         "integer",
+									Nullable:     false,
+									Unique:       true,
+									PostgresType: "base",
 								},
 								"name": {
-									Name:     "name",
-									Type:     "text",
-									Unique:   true,
-									Nullable: true,
+									Name:         "name",
+									Type:         "text",
+									Unique:       true,
+									Nullable:     true,
+									PostgresType: "base",
 								},
 							},
 							PrimaryKey: []string{"id"},
@@ -714,16 +726,18 @@ func TestReadSchema(t *testing.T) {
 							Name: "table1",
 							Columns: map[string]*schema.Column{
 								"id": {
-									Name:     "id",
-									Type:     "integer",
-									Nullable: false,
-									Unique:   true,
+									Name:         "id",
+									Type:         "integer",
+									Nullable:     false,
+									Unique:       true,
+									PostgresType: "base",
 								},
 								"name": {
-									Name:     "name",
-									Type:     "text",
-									Nullable: true,
-									Unique:   false,
+									Name:         "name",
+									Type:         "text",
+									Nullable:     true,
+									Unique:       false,
+									PostgresType: "base",
 								},
 							},
 							PrimaryKey: []string{"id"},
@@ -773,14 +787,16 @@ func TestReadSchema(t *testing.T) {
 							Name: "products",
 							Columns: map[string]*schema.Column{
 								"customer_id": {
-									Name:     "customer_id",
-									Type:     "integer",
-									Nullable: false,
+									Name:         "customer_id",
+									Type:         "integer",
+									Nullable:     false,
+									PostgresType: "base",
 								},
 								"product_id": {
-									Name:     "product_id",
-									Type:     "integer",
-									Nullable: false,
+									Name:         "product_id",
+									Type:         "integer",
+									Nullable:     false,
+									PostgresType: "base",
 								},
 							},
 							PrimaryKey: []string{"customer_id", "product_id"},
@@ -801,14 +817,16 @@ func TestReadSchema(t *testing.T) {
 							Name: "orders",
 							Columns: map[string]*schema.Column{
 								"customer_id": {
-									Name:     "customer_id",
-									Type:     "integer",
-									Nullable: false,
+									Name:         "customer_id",
+									Type:         "integer",
+									Nullable:     false,
+									PostgresType: "base",
 								},
 								"product_id": {
-									Name:     "product_id",
-									Type:     "integer",
-									Nullable: false,
+									Name:         "product_id",
+									Type:         "integer",
+									Nullable:     false,
+									PostgresType: "base",
 								},
 							},
 							PrimaryKey: []string{},
@@ -838,14 +856,16 @@ func TestReadSchema(t *testing.T) {
 							Name: "table1",
 							Columns: map[string]*schema.Column{
 								"a": {
-									Name:     "a",
-									Type:     "text",
-									Nullable: true,
+									Name:         "a",
+									Type:         "text",
+									Nullable:     true,
+									PostgresType: "base",
 								},
 								"b": {
-									Name:     "b",
-									Type:     "text",
-									Nullable: true,
+									Name:         "b",
+									Type:         "text",
+									Nullable:     true,
+									PostgresType: "base",
 								},
 							},
 							PrimaryKey: []string{},
@@ -875,9 +895,10 @@ func TestReadSchema(t *testing.T) {
 							Name: "table1",
 							Columns: map[string]*schema.Column{
 								"a": {
-									Name:     "a",
-									Type:     "public.email_type",
-									Nullable: true,
+									Name:         "a",
+									Type:         "public.email_type",
+									Nullable:     true,
+									PostgresType: "domain",
 								},
 							},
 							PrimaryKey:        []string{},
@@ -899,15 +920,76 @@ func TestReadSchema(t *testing.T) {
 							Name: "table1",
 							Columns: map[string]*schema.Column{
 								"name": {
-									Name:     "name",
-									Type:     "text",
-									Nullable: true,
+									Name:         "name",
+									Type:         "text",
+									Nullable:     true,
+									PostgresType: "base",
 								},
 								"review": {
-									Name:       "review",
-									Type:       "public.review",
-									Nullable:   true,
-									EnumValues: []string{"good", "bad", "ugly"},
+									Name:         "review",
+									Type:         "public.review",
+									Nullable:     true,
+									EnumValues:   []string{"good", "bad", "ugly"},
+									PostgresType: "enum",
+								},
+							},
+							PrimaryKey:        []string{},
+							Indexes:           map[string]*schema.Index{},
+							ForeignKeys:       map[string]*schema.ForeignKey{},
+							CheckConstraints:  map[string]*schema.CheckConstraint{},
+							UniqueConstraints: map[string]*schema.UniqueConstraint{},
+						},
+					},
+				},
+			},
+			{
+				name: "postgres type types",
+				createStmt: `
+					CREATE TYPE comptype AS (f1 int, f2 text);
+					CREATE TYPE review AS ENUM ('good', 'bad', 'ugly');
+					CREATE TYPE float8_range AS RANGE (subtype = float8, subtype_diff = float8mi);
+					CREATE DOMAIN us_postal_code AS TEXT
+						CHECK(
+							VALUE ~ '^\d{5}$'
+							OR VALUE ~ '^\d{5}-\d{4}$'
+						);
+					CREATE TABLE public.table1 (id bigint, comp_col comptype, enum_col review, range_col float8_range, domain_col us_postal_code);`,
+				wantSchema: &schema.Schema{
+					Name: "public",
+					Tables: map[string]*schema.Table{
+						"table1": {
+							Name: "table1",
+							Columns: map[string]*schema.Column{
+								"id": {
+									Name:         "id",
+									Type:         "bigint",
+									Nullable:     true,
+									PostgresType: "base",
+								},
+								"comp_col": {
+									Name:         "comp_col",
+									Type:         "public.comptype",
+									Nullable:     true,
+									PostgresType: "composite",
+								},
+								"enum_col": {
+									Name:         "enum_col",
+									Type:         "public.review",
+									Nullable:     true,
+									PostgresType: "enum",
+									EnumValues:   []string{"good", "bad", "ugly"},
+								},
+								"range_col": {
+									Name:         "range_col",
+									Type:         "public.float8_range",
+									Nullable:     true,
+									PostgresType: "range",
+								},
+								"domain_col": {
+									Name:         "domain_col",
+									Type:         "public.us_postal_code",
+									Nullable:     true,
+									PostgresType: "domain",
 								},
 							},
 							PrimaryKey:        []string{},


### PR DESCRIPTION
Adding `PostgresType` into read_schema output and filling it with info obtained from `typtype` column of `pg_catalog.pg_type`. Adding a test with different type types and fixing the already existing ones.

partially fixes #385 

for reference: 
> `typtype char`
typtype is b for a base type, c for a composite type (e.g., a table's row type), d for a domain, e for an enum type, p for a pseudo-type, r for a range type, or m for a multirange type. See also typrelid and typbasetype.

from: https://www.postgresql.org/docs/current/catalog-pg-type.html#CATALOG-PG-TYPE