### PR TITLE
Multi-operation migration support for `alter_column` rename operations

### DIFF
--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -153,6 +153,7 @@ func (o *OpAlterColumn) Complete(ctx context.Context, conn db.DB, tr SQLTransfor
 
 func (o *OpAlterColumn) Rollback(ctx context.Context, conn db.DB, tr SQLTransformer, s *schema.Schema) error {
 	ops := o.subOperations()
+	table := s.GetTable(o.Table)
 
 	// Perform any operation specific rollback steps
 	for _, ops := range ops {
@@ -186,6 +187,12 @@ func (o *OpAlterColumn) Rollback(ctx context.Context, conn db.DB, tr SQLTransfor
 		if err != nil {
 			return err
 		}
+	}
+
+	// Rename the column back to its original name in the virtual schema if
+	// required
+	if o.Name != nil {
+		table.RenameColumn(*o.Name, o.Column)
 	}
 
 	return nil

--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -251,6 +251,12 @@ func (o *OpAlterColumn) Validate(ctx context.Context, s *schema.Schema) error {
 		}
 	}
 
+	// Rename the column in the virtual schema if required so that subsequent
+	// operations can validate using the new column name
+	if o.Name != nil {
+		table.RenameColumn(o.Column, *o.Name)
+	}
+
 	return nil
 }
 

--- a/pkg/migrations/op_alter_column_test.go
+++ b/pkg/migrations/op_alter_column_test.go
@@ -505,6 +505,92 @@ func TestAlterColumnMultipleSubOperations(t *testing.T) {
 	})
 }
 
+func TestAlterColumnInMultiOperationMigrations(t *testing.T) {
+	t.Parallel()
+
+	ExecuteTests(t, TestCases{
+		{
+			name: "add column, rename column",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_create_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "items",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name: "name",
+									Type: "varchar(255)",
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_multi_operation",
+					Operations: migrations.Operations{
+						&migrations.OpAddColumn{
+							Table: "items",
+							Column: migrations.Column{
+								Name:     "description",
+								Type:     "text",
+								Nullable: true,
+							},
+						},
+						&migrations.OpAlterColumn{
+							Table:  "items",
+							Column: "description",
+							Name:   ptr("item_description"),
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
+				// Can insert into the new column under its new name
+				MustInsert(t, db, schema, "02_multi_operation", "items", map[string]string{
+					"name":             "apples",
+					"item_description": "amazing",
+				})
+
+				// Can't insert into the new column under its old name
+				MustNotInsert(t, db, schema, "02_multi_operation", "items", map[string]string{
+					"name":        "bananas",
+					"description": "brilliant",
+				}, testutils.UndefinedColumnErrorCode)
+
+				// The table has the expected rows in the new schema
+				rows := MustSelect(t, db, schema, "02_multi_operation", "items")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "name": "apples", "item_description": "amazing"},
+				}, rows)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
+				// The table has been cleaned up
+				TableMustBeCleanedUp(t, db, schema, "items", "description")
+			},
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+				// Can insert into the new column under its new name
+				MustInsert(t, db, schema, "02_multi_operation", "items", map[string]string{
+					"name":             "bananas",
+					"item_description": "brilliant",
+				})
+
+				// The table has the expected rows in the new schema
+				rows := MustSelect(t, db, schema, "02_multi_operation", "items")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "name": "apples", "item_description": nil},
+					{"id": 2, "name": "bananas", "item_description": "brilliant"},
+				}, rows)
+			},
+		},
+	})
+}
+
 func TestIsRenameOnly(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Ensure that `alter_column` rename column operations can be used as part of multi-operation migrations:

Add testcases for:
* add column, rename column
* rename table, rename column on the renamed table
* rename column, drop rename column

Update the `Rollback` and `Validate` methods to be aware of the effect of previous operations in the same migration and make sure their own changes are visible to other operations in the same migration.

Part of https://github.com/xataio/pgroll/issues/239