### PR TITLE
Add new subcommand `sql-folder` to transform SQL files into pgroll operations

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,6 +80,7 @@ func Execute() error {
 	rootCmd.AddCommand(pullCmd())
 	rootCmd.AddCommand(latestCmd())
 	rootCmd.AddCommand(sqlCmd())
+	rootCmd.AddCommand(sqlFolderCmd())
 
 	return rootCmd.Execute()
 }

--- a/cmd/sql-folder.go
+++ b/cmd/sql-folder.go
@@ -31,7 +31,9 @@ func sqlFolderCmd() *cobra.Command {
 			for _, sql := range sqls {
 				ops, err := sql2pgroll.Convert(sql)
 				if err != nil {
-					return fmt.Errorf("failed to convert SQL statement: %w", err)
+					fmt.Fprintf(os.Stderr, fmt.Errorf("failed to convert SQL statement: %w", err).Error())
+					fmt.Fprintf(os.Stderr, "%s", sql)
+					continue
 				}
 
 				enc := json.NewEncoder(os.Stdout)

--- a/cmd/sql-folder.go
+++ b/cmd/sql-folder.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/xataio/pgroll/pkg/sql2pgroll"
+)
+
+func sqlFolderCmd() *cobra.Command {
+	sqlFolderCmd := &cobra.Command{
+		Use:    "sql-folder <path to file with migrations>",
+		Short:  "Convert SQL statements to pgroll operations from SQL files in a folder",
+		Args:   cobra.ExactArgs(1),
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			folder := args[0]
+
+			sqls, err := readSQLFromFolder(folder)
+			if err != nil {
+				return err
+			}
+
+			for _, sql := range sqls {
+				ops, err := sql2pgroll.Convert(sql)
+				if err != nil {
+					return fmt.Errorf("failed to convert SQL statement: %w", err)
+				}
+
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				if err := enc.Encode(ops); err != nil {
+					return fmt.Errorf("failed to encode operations: %w", err)
+				}
+			}
+
+			return nil
+		},
+	}
+
+	return sqlFolderCmd
+}
+
+func readSQLFromFolder(folder string) ([]string, error) {
+	sqlStatements := make([]string, 0)
+	files, err := os.ReadDir(folder)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		// open file reader
+		reader, err := os.Open(filepath.Join(folder, file.Name()))
+		if err != nil {
+			return nil, err
+		}
+
+		// read file and remove sql comments from lines
+		contentsWithoutComments := ""
+		scanner := bufio.NewScanner(reader)
+		for scanner.Scan() {
+			if strings.HasPrefix(scanner.Text(), "--") {
+				continue
+			}
+			contentsWithoutComments += scanner.Text()
+		}
+
+		for _, sqlStatement := range strings.Split(contentsWithoutComments, ";") {
+			if sqlStatement == "" {
+				continue
+			}
+			sqlStatements = append(sqlStatements, sqlStatement)
+		}
+	}
+	return sqlStatements, nil
+
+}


### PR DESCRIPTION
This PR adds a new subcommand called `sql-folder`.
It expects an argument, the path to the migrations folder. This folder must contain more folderes with migration files.

Example layout:

```
target-folder
  01_first_migration
    migration.sql
  02_second_migration
    migration.sql
```

The code is messy, but I put it up, so if someone else wants to test migration folders, they can use this cmd.
