### PR TITLE
Use official `goreleaser/goreleaser-cross` image for cross-platform builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     name: cross-platform build
     runs-on: ubuntu-24.04
     container:
-      image: surjection/goreleaser-cross:v1.23-v2.4.8
+      image: goreleaser/goreleaser-cross:v1.24
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Stop using the custom `goreleaser-cross` image that was built as part of #525 and use an official `gorelaser-cross` image instead. The image is used as the container in which to build the project for multiple platforms. The image provides C toolchains for all the platforms supported by `pgroll`.

The official image now uses `goreleaser` `v2.4.8` which contains the fix for the bug (https://github.com/goreleaser/goreleaser/pull/5298) that we were using the custom image to work around.