### PR TITLE
Add support for `alter_table` set `NOT NULL` operations with `rename_column` operations

### DIFF
--- a/pkg/migrations/duplicate.go
+++ b/pkg/migrations/duplicate.go
@@ -84,6 +84,12 @@ func (d *Duplicator) WithoutNotNull(columnName string) *Duplicator {
 	return d
 }
 
+// WithName sets the name of the new column.
+func (d *Duplicator) WithName(columnName, asName string) *Duplicator {
+	d.columns[columnName].asName = asName
+	return d
+}
+
 // Duplicate duplicates a column in the table, including all constraints and
 // comments.
 func (d *Duplicator) Duplicate(ctx context.Context) error {

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -116,6 +116,13 @@ func (o *OpAddColumn) Complete(ctx context.Context, conn db.DB, tr SQLTransforme
 		}
 	}
 
+	// Add the column to the in-memory schema so that Complete steps in subsequent
+	// operations can see the new column.
+	table := s.GetTable(o.Table)
+	table.AddColumn(o.Column.Name, &schema.Column{
+		Name: o.Column.Name,
+	})
+
 	return err
 }
 

--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -20,7 +20,8 @@ func (o *OpAlterColumn) Start(ctx context.Context, conn db.DB, latestSchema stri
 	ops := o.subOperations()
 
 	// Duplicate the column on the underlying table.
-	d := duplicatorForOperations(ops, conn, table, column)
+	d := duplicatorForOperations(ops, conn, table, column).
+		WithName(column.Name, TemporaryName(o.Column))
 	if err := d.Duplicate(ctx); err != nil {
 		return nil, fmt.Errorf("failed to duplicate column: %w", err)
 	}

--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -116,6 +116,7 @@ func (o *OpAlterColumn) Complete(ctx context.Context, conn db.DB, tr SQLTransfor
 
 func (o *OpAlterColumn) Rollback(ctx context.Context, conn db.DB, tr SQLTransformer, s *schema.Schema) error {
 	table := s.GetTable(o.Table)
+	column := table.GetColumn(o.Column)
 
 	// Perform any operation specific rollback steps
 	ops := o.subOperations()
@@ -128,7 +129,7 @@ func (o *OpAlterColumn) Rollback(ctx context.Context, conn db.DB, tr SQLTransfor
 	// Drop the new column
 	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s DROP COLUMN IF EXISTS %s",
 		pq.QuoteIdentifier(table.Name),
-		pq.QuoteIdentifier(TemporaryName(o.Column)),
+		pq.QuoteIdentifier(column.Name),
 	))
 	if err != nil {
 		return err

--- a/pkg/migrations/op_rename_column.go
+++ b/pkg/migrations/op_rename_column.go
@@ -27,6 +27,16 @@ func (o *OpRenameColumn) Complete(ctx context.Context, conn db.DB, tr SQLTransfo
 		pq.QuoteIdentifier(o.From),
 		pq.QuoteIdentifier(o.To)))
 
+	// Update the in-memory schema to reflect the column rename so that it is
+	// visible to subsequent operations' Complete steps.
+	table := s.GetTable(o.Table)
+	table.RenameColumn(o.From, o.To)
+
+	// Update the physical name of the column in the virtual schema now that it
+	// has really been renamed.
+	column := table.GetColumn(o.To)
+	column.Name = o.To
+
 	return err
 }
 

--- a/pkg/migrations/op_set_notnull.go
+++ b/pkg/migrations/op_set_notnull.go
@@ -22,9 +22,10 @@ var _ Operation = (*OpSetNotNull)(nil)
 
 func (o *OpSetNotNull) Start(ctx context.Context, conn db.DB, latestSchema string, tr SQLTransformer, s *schema.Schema, cbs ...CallbackFn) (*schema.Table, error) {
 	table := s.GetTable(o.Table)
+	column := table.GetColumn(o.Column)
 
 	// Add an unchecked NOT NULL constraint to the new column.
-	if err := addNotNullConstraint(ctx, conn, table.Name, o.Column, TemporaryName(o.Column)); err != nil {
+	if err := addNotNullConstraint(ctx, conn, table.Name, o.Column, column.Name); err != nil {
 		return nil, fmt.Errorf("failed to add not null constraint: %w", err)
 	}
 


### PR DESCRIPTION
Ensure that multi-operation migrations combining `alter_column` `SET NOT NULL` and `rename_column` operations work as expected.

```json
{
  "name": "06_multi_operation",
  "operations": [
    {
      "rename_column": {
        "table": "items",
        "from": "name",
        "to": "item_name"
      }
    },
    {
      "alter_column": {
        "table": "items",
        "column": "item_name",
        "nullable": false,
        "up": "SELECT CASE WHEN item_name IS NULL THEN 'anonymous' ELSE item_name END",
        "down": "item_name || '_from_down_trigger'"
      }
    }
  ]
}
```

This migration renames a column and then sets the renamed column's `nullability`.

Previously the migration would fail as the `alter_column` operation was unaware of the changes made by the preceding operation.

Part of #239 