### PR TITLE
Add support for `alter_table` set `NOT NULL` operations with `create_table` operations

### DIFF
--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -181,11 +181,13 @@ func (o *OpCreateTable) updateSchema(s *schema.Schema) *schema.Schema {
 			Name:     col.Name,
 			Unique:   col.Unique,
 			Nullable: col.Nullable,
+			Type:     col.Type,
 		}
 		if col.Pk {
 			primaryKeys = append(primaryKeys, col.Name)
 		}
 	}
+
 	uniqueConstraints := make(map[string]*schema.UniqueConstraint, 0)
 	checkConstraints := make(map[string]*schema.CheckConstraint, 0)
 	for _, c := range o.Constraints {


### PR DESCRIPTION
Ensure that multi-operation migrations combining `alter_column` `SET NOT NULL` and `create_table` operations work as expected.

```json
{
  "name": "06_multi_operation",
  "operations": [
    {
      "create_table": {
        "name": "items",
        "columns": [
          {
            "name": "id",
            "type": "serial",
            "pk": true
          },
          {
            "name": "name",
            "type": "text",
            "nullable": true
          }
        ]
      }
    },
    {
      "alter_column": {
        "table": "items",
        "column": "name",
        "nullable": false,
        "up": "SELECT CASE WHEN name IS NULL THEN 'anonymous' ELSE name END",
        "down": "name || '_from_down_trigger'"
      }
    }
  ]
}
```

This migration creates a table and then sets a column's `nullability`.

Previously the migration would fail as the `alter_column` operation was unaware of the changes made by the preceding operation.

Part of #239 