### PR TITLE
Retry creating unique index

### DIFF
--- a/pkg/migrations/duplicate_test.go
+++ b/pkg/migrations/duplicate_test.go
@@ -228,7 +228,7 @@ func TestCreateIndexConcurrentlySqlGeneration(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			stmt := getCreateUniqueIndexConcurrentlySql(testCases.indexName, testCases.schemaName, testCases.tableName, testCases.columns)
+			stmt := getCreateUniqueIndexConcurrentlySQL(testCases.indexName, testCases.schemaName, testCases.tableName, testCases.columns)
 			assert.Equal(t, testCases.expectedStmt, stmt)
 		})
 	}

--- a/pkg/migrations/duplicate_test.go
+++ b/pkg/migrations/duplicate_test.go
@@ -102,47 +102,6 @@ func TestDuplicateStmtBuilderCheckConstraints(t *testing.T) {
 	}
 }
 
-func TestDuplicateStmtBuilderUniqueConstraints(t *testing.T) {
-	d := &duplicatorStmtBuilder{table}
-	for name, testCases := range map[string]struct {
-		columns       []string
-		expectedStmts []string
-	}{
-		"single column duplicated": {
-			columns:       []string{"city"},
-			expectedStmts: []string{},
-		},
-		"single-column constraint with single column duplicated": {
-			columns:       []string{"email"},
-			expectedStmts: []string{`CREATE UNIQUE INDEX CONCURRENTLY "_pgroll_dup_unique_email" ON "test_table" ("_pgroll_new_email")`},
-		},
-		"single-column constraint with multiple column duplicated": {
-			columns:       []string{"email", "description"},
-			expectedStmts: []string{`CREATE UNIQUE INDEX CONCURRENTLY "_pgroll_dup_unique_email" ON "test_table" ("_pgroll_new_email")`},
-		},
-		"multi-column constraint with single column duplicated": {
-			columns:       []string{"name"},
-			expectedStmts: []string{`CREATE UNIQUE INDEX CONCURRENTLY "_pgroll_dup_unique_name_nick" ON "test_table" ("_pgroll_new_name", "nick")`},
-		},
-		"multi-column constraint with multiple unrelated column duplicated": {
-			columns:       []string{"name", "description"},
-			expectedStmts: []string{`CREATE UNIQUE INDEX CONCURRENTLY "_pgroll_dup_unique_name_nick" ON "test_table" ("_pgroll_new_name", "nick")`},
-		},
-		"multi-column constraint with multiple columns": {
-			columns:       []string{"name", "nick"},
-			expectedStmts: []string{`CREATE UNIQUE INDEX CONCURRENTLY "_pgroll_dup_unique_name_nick" ON "test_table" ("_pgroll_new_name", "_pgroll_new_nick")`},
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			stmts := d.duplicateUniqueConstraints(nil, testCases.columns...)
-			assert.Equal(t, len(testCases.expectedStmts), len(stmts))
-			for _, stmt := range stmts {
-				assert.True(t, slices.Contains(testCases.expectedStmts, stmt))
-			}
-		})
-	}
-}
-
 func TestDuplicateStmtBuilderForeignKeyConstraints(t *testing.T) {
 	d := &duplicatorStmtBuilder{table}
 	for name, testCases := range map[string]struct {

--- a/pkg/migrations/index.go
+++ b/pkg/migrations/index.go
@@ -20,8 +20,8 @@ func createUniqueIndexConcurrently(ctx context.Context, conn db.DB, schemaName s
 	for retryCount := 0; retryCount < 5; retryCount++ {
 		// Add a unique index to the new column
 		// Indexes are created in the same schema with the table automatically. Instead of the qualified one, just pass the index name.
-		createIndexSql := getCreateUniqueIndexConcurrentlySql(indexName, schemaName, tableName, columnNames)
-		if _, err := conn.ExecContext(ctx, createIndexSql); err != nil {
+		createIndexSQL := getCreateUniqueIndexConcurrentlySQL(indexName, schemaName, tableName, columnNames)
+		if _, err := conn.ExecContext(ctx, createIndexSQL); err != nil {
 			return fmt.Errorf("failed to add unique index %q: %w", indexName, err)
 		}
 
@@ -64,7 +64,7 @@ func createUniqueIndexConcurrently(ctx context.Context, conn db.DB, schemaName s
 	return fmt.Errorf("failed to create unique index %q", indexName)
 }
 
-func getCreateUniqueIndexConcurrentlySql(indexName string, schemaName string, tableName string, columnNames []string) string {
+func getCreateUniqueIndexConcurrentlySQL(indexName string, schemaName string, tableName string, columnNames []string) string {
 	// create unique index concurrently
 	qualifiedTableName := pq.QuoteIdentifier(tableName)
 	if schemaName != "" {

--- a/pkg/migrations/index.go
+++ b/pkg/migrations/index.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/xataio/pgroll/pkg/db"
+)
+
+func createUniqueIndexConcurrently(ctx context.Context, conn db.DB, schemaName string, indexName string, tableName string, columnNames []string) error {
+	quotedQualifiedIndexName := pq.QuoteIdentifier(indexName)
+	if schemaName != "" {
+		quotedQualifiedIndexName = fmt.Sprintf("%s.%s", pq.QuoteIdentifier(schemaName), pq.QuoteIdentifier(indexName))
+	}
+	for retryCount := 0; retryCount < 5; retryCount++ {
+		// Add a unique index to the new column
+		// Indexes are created in the same schema with the table automatically. Instead of the qualified one, just pass the index name.
+		if err := executeCreateUniqueIndexConcurrently(ctx, conn, indexName, schemaName, tableName, columnNames); err != nil {
+			return fmt.Errorf("failed to add unique index %q: %w", indexName, err)
+		}
+
+		// Make sure Postgres is done creating the index
+		isInProgress, err := isIndexInProgress(ctx, conn, quotedQualifiedIndexName)
+		if err != nil {
+			return err
+		}
+
+		ticker := time.NewTicker(500 * time.Millisecond)
+		for isInProgress {
+			<-ticker.C
+			isInProgress, err = isIndexInProgress(ctx, conn, quotedQualifiedIndexName)
+			if err != nil {
+				return err
+			}
+		}
+		ticker.Stop()
+
+		// Check pg_index to see if it's valid or not. Break if it's valid.
+		isValid, err := isIndexValid(ctx, conn, quotedQualifiedIndexName)
+		if err != nil {
+			return err
+		}
+
+		if isValid {
+			// success
+			return nil
+		}
+
+		// If not valid, since Postgres has already given up validating the index,
+		// it will remain invalid forever. Drop it and try again.
+		_, err = conn.ExecContext(ctx, fmt.Sprintf("DROP INDEX IF EXISTS %s", quotedQualifiedIndexName))
+		if err != nil {
+			return fmt.Errorf("failed to drop index: %w", err)
+		}
+	}
+
+	// ran out of retries, return an error
+	return fmt.Errorf("failed to create unique index %q", indexName)
+}
+
+func executeCreateUniqueIndexConcurrently(ctx context.Context, conn db.DB, indexName string, schemaName string, tableName string, columnNames []string) error {
+	// create unique index concurrently
+	qualifiedTableName := pq.QuoteIdentifier(tableName)
+	if schemaName != "" {
+		qualifiedTableName = fmt.Sprintf("%s.%s", pq.QuoteIdentifier(schemaName), pq.QuoteIdentifier(tableName))
+	}
+
+	indexQuery := fmt.Sprintf(
+		"CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS %s ON %s (%s)",
+		indexName,
+		qualifiedTableName,
+		strings.Join(quoteColumnNames(columnNames), ", "),
+	)
+
+	_, err := conn.ExecContext(ctx, indexQuery)
+
+	return err
+}
+
+func isIndexInProgress(ctx context.Context, conn db.DB, quotedQualifiedIndexName string) (bool, error) {
+	rows, err := conn.QueryContext(ctx, `SELECT EXISTS(
+			SELECT * FROM pg_catalog.pg_stat_progress_create_index
+			WHERE index_relid = $1::regclass
+			)`, quotedQualifiedIndexName)
+	if err != nil {
+		return false, fmt.Errorf("getting index in progress with name %q: %w", quotedQualifiedIndexName, err)
+	}
+	if rows == nil {
+		// if rows == nil && err != nil, then it means we have queried a `FakeDB`.
+		// In that case, we can safely return false.
+		return false, nil
+	}
+	var isInProgress bool
+	if err := db.ScanFirstValue(rows, &isInProgress); err != nil {
+		return false, fmt.Errorf("scanning index in progress with name %q: %w", quotedQualifiedIndexName, err)
+	}
+
+	return isInProgress, nil
+}
+
+func isIndexValid(ctx context.Context, conn db.DB, quotedQualifiedIndexName string) (bool, error) {
+	rows, err := conn.QueryContext(ctx, `SELECT indisvalid
+		FROM pg_catalog.pg_index
+		WHERE indexrelid = $1::regclass`,
+		quotedQualifiedIndexName)
+	if err != nil {
+		return false, fmt.Errorf("getting index with name %q: %w", quotedQualifiedIndexName, err)
+	}
+	if rows == nil {
+		// if rows == nil && err != nil, then it means we have queried a fake db.
+		// In that case, we can safely return true.
+		return true, nil
+	}
+	var isValid bool
+	if err := db.ScanFirstValue(rows, &isValid); err != nil {
+		return false, fmt.Errorf("scanning index with name %q: %w", quotedQualifiedIndexName, err)
+	}
+
+	return isValid, nil
+}

--- a/pkg/migrations/index.go
+++ b/pkg/migrations/index.go
@@ -73,7 +73,7 @@ func getCreateUniqueIndexConcurrentlySql(indexName string, schemaName string, ta
 
 	indexQuery := fmt.Sprintf(
 		"CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS %s ON %s (%s)",
-		indexName,
+		pq.QuoteIdentifier(indexName),
 		qualifiedTableName,
 		strings.Join(quoteColumnNames(columnNames), ", "),
 	)

--- a/pkg/migrations/index.go
+++ b/pkg/migrations/index.go
@@ -31,6 +31,7 @@ func createUniqueIndexConcurrently(ctx context.Context, conn db.DB, schemaName s
 		}
 
 		ticker := time.NewTicker(500 * time.Millisecond)
+		defer ticker.Stop()
 		for isInProgress {
 			<-ticker.C
 			isInProgress, err = isIndexInProgress(ctx, conn, quotedQualifiedIndexName)
@@ -38,7 +39,6 @@ func createUniqueIndexConcurrently(ctx context.Context, conn db.DB, schemaName s
 				return err
 			}
 		}
-		ticker.Stop()
 
 		// Check pg_index to see if it's valid or not. Break if it's valid.
 		isValid, err := isIndexValid(ctx, conn, quotedQualifiedIndexName)

--- a/pkg/migrations/op_create_constraint.go
+++ b/pkg/migrations/op_create_constraint.go
@@ -67,7 +67,11 @@ func (o *OpCreateConstraint) Start(ctx context.Context, conn db.DB, latestSchema
 
 	switch o.Type {
 	case OpCreateConstraintTypeUnique:
-		return table, createUniqueIndexConcurrently(ctx, conn, s.Name, o.Name, o.Table, quotedTemporaryNames(o.Columns))
+		temporaryColumnNames := make([]string, len(o.Columns))
+		for i, col := range o.Columns {
+			temporaryColumnNames[i] = TemporaryName(col)
+		}
+		return table, createUniqueIndexConcurrently(ctx, conn, s.Name, o.Name, o.Table, temporaryColumnNames)
 	case OpCreateConstraintTypeCheck:
 		return table, o.addCheckConstraint(ctx, conn)
 	case OpCreateConstraintTypeForeignKey:

--- a/pkg/migrations/op_set_unique.go
+++ b/pkg/migrations/op_set_unique.go
@@ -33,7 +33,7 @@ func (o *OpSetUnique) Start(ctx context.Context, conn db.DB, latestSchema string
 		}
 
 		// Make sure Postgres is done creating the index
-		var isInProgress bool = true
+		isInProgress := true
 		for isInProgress {
 			var err error
 			isInProgress, err = isIndexInProgress(ctx, conn, s.Name, o.Name)

--- a/pkg/migrations/op_set_unique.go
+++ b/pkg/migrations/op_set_unique.go
@@ -51,7 +51,7 @@ func (o *OpSetUnique) Start(ctx context.Context, conn db.DB, latestSchema string
 		}
 
 		if isValid {
-			break
+			return table, nil
 		}
 
 		// If not valid, since Postgres has already given up validating the index,
@@ -62,7 +62,7 @@ func (o *OpSetUnique) Start(ctx context.Context, conn db.DB, latestSchema string
 		}
 	}
 
-	return table, nil
+	return nil, fmt.Errorf("failed to create unique index: %q", o.Name)
 }
 
 func (o *OpSetUnique) Complete(ctx context.Context, conn db.DB, tr SQLTransformer, s *schema.Schema) error {


### PR DESCRIPTION
Introduce a retry mechanism for creating unique indexes.
First, create unique index concurrently. Then wait until Postgres is done with the index creation, periodically checking the view `pg_stat_progress_create_index`. Once it is done, lookup pg_index to see if the index is validated or not. If it is, we are good to go. If not, drop the index and try again.

Since we are running select queries on `pg_stat_progress_create_index` and `pg_index` and we are expecting a real output to see the progress, this approach doesn't work with fake db. I have added hardcoded responses for the fake db scenario, so that we can safely process migrations to update virtual schema as well.
Not sure if this is a good solution or not. Open for discussions.

Tested manually with high load, while 10m rows being inserted. But I wonder if there's a way to add a test for the "high load" scenario.