### PR TITLE
Add `defer rows.Close()` to `getRowCount` function

### DIFF
--- a/pkg/migrations/backfill.go
+++ b/pkg/migrations/backfill.go
@@ -69,6 +69,8 @@ func getRowCount(ctx context.Context, conn db.DB, tableName string) (int64, erro
 	if err != nil {
 		return 0, fmt.Errorf("getting current schema: %w", err)
 	}
+	defer rows.Close()
+
 	if err := db.ScanFirstValue(rows, &currentSchema); err != nil {
 		return 0, fmt.Errorf("scanning current schema: %w", err)
 	}


### PR DESCRIPTION
Add a mising `defer rows.Close()` to the `getRowCount` function.

The leak was causing occasional test failures:

```
pq: sorry, too many clients already
```