### PR TITLE
Add extra validation checks to `OpRenameColumn`

### DIFF
--- a/pkg/migrations/op_rename_column.go
+++ b/pkg/migrations/op_rename_column.go
@@ -51,6 +51,16 @@ func (o *OpRenameColumn) Rollback(ctx context.Context, conn db.DB, tr SQLTransfo
 func (o *OpRenameColumn) Validate(ctx context.Context, s *schema.Schema) error {
 	table := s.GetTable(o.Table)
 
+	// Ensure that the `from` field is not empty
+	if o.From == "" {
+		return FieldRequiredError{Name: "from"}
+	}
+
+	// Ensure that the `to` field is not empty
+	if o.To == "" {
+		return FieldRequiredError{Name: "to"}
+	}
+
 	// Ensure that the table exists.
 	if table == nil {
 		return TableDoesNotExistError{Name: o.Table}

--- a/pkg/migrations/op_rename_column_test.go
+++ b/pkg/migrations/op_rename_column_test.go
@@ -343,6 +343,38 @@ func TestOpRenameColumnValidation(t *testing.T) {
 
 	ExecuteTests(t, TestCases{
 		{
+			name: "from field must be specified",
+			migrations: []migrations.Migration{
+				createTableMigration,
+				{
+					Name: "02_rename_column",
+					Operations: migrations.Operations{
+						&migrations.OpRenameColumn{
+							Table: "users",
+							To:    "name",
+						},
+					},
+				},
+			},
+			wantStartErr: migrations.FieldRequiredError{Name: "from"},
+		},
+		{
+			name: "to field must be specified",
+			migrations: []migrations.Migration{
+				createTableMigration,
+				{
+					Name: "02_rename_column",
+					Operations: migrations.Operations{
+						&migrations.OpRenameColumn{
+							Table: "users",
+							From:  "username",
+						},
+					},
+				},
+			},
+			wantStartErr: migrations.FieldRequiredError{Name: "to"},
+		},
+		{
 			name: "table must exist",
 			migrations: []migrations.Migration{
 				createTableMigration,


### PR DESCRIPTION
Validate that `from` and `to` fields are not empty during validation of `OpRenameColumn` operations