### PR TITLE
Add support for `alter_table` set `default` operations in multi-operation migrations

### DIFF
--- a/pkg/migrations/op_set_default.go
+++ b/pkg/migrations/op_set_default.go
@@ -23,16 +23,16 @@ type OpSetDefault struct {
 var _ Operation = (*OpSetDefault)(nil)
 
 func (o *OpSetDefault) Start(ctx context.Context, conn db.DB, latestSchema string, tr SQLTransformer, s *schema.Schema, cbs ...CallbackFn) (*schema.Table, error) {
-	tbl := s.GetTable(o.Table)
+	table := s.GetTable(o.Table)
 
 	var err error
 	if o.Default == nil {
 		_, err = conn.ExecContext(ctx, fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN %s DROP DEFAULT`,
-			pq.QuoteIdentifier(o.Table),
+			pq.QuoteIdentifier(table.Name),
 			pq.QuoteIdentifier(TemporaryName(o.Column))))
 	} else {
 		_, err = conn.ExecContext(ctx, fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN %s SET DEFAULT %s`,
-			pq.QuoteIdentifier(o.Table),
+			pq.QuoteIdentifier(table.Name),
 			pq.QuoteIdentifier(TemporaryName(o.Column)),
 			*o.Default))
 	}
@@ -40,7 +40,7 @@ func (o *OpSetDefault) Start(ctx context.Context, conn db.DB, latestSchema strin
 		return nil, err
 	}
 
-	return tbl, nil
+	return table, nil
 }
 
 func (o *OpSetDefault) Complete(ctx context.Context, conn db.DB, tr SQLTransformer, s *schema.Schema) error {

--- a/pkg/migrations/op_set_default.go
+++ b/pkg/migrations/op_set_default.go
@@ -24,16 +24,17 @@ var _ Operation = (*OpSetDefault)(nil)
 
 func (o *OpSetDefault) Start(ctx context.Context, conn db.DB, latestSchema string, tr SQLTransformer, s *schema.Schema, cbs ...CallbackFn) (*schema.Table, error) {
 	table := s.GetTable(o.Table)
+	column := table.GetColumn(o.Column)
 
 	var err error
 	if o.Default == nil {
 		_, err = conn.ExecContext(ctx, fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN %s DROP DEFAULT`,
 			pq.QuoteIdentifier(table.Name),
-			pq.QuoteIdentifier(TemporaryName(o.Column))))
+			pq.QuoteIdentifier(column.Name)))
 	} else {
 		_, err = conn.ExecContext(ctx, fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN %s SET DEFAULT %s`,
 			pq.QuoteIdentifier(table.Name),
-			pq.QuoteIdentifier(TemporaryName(o.Column)),
+			pq.QuoteIdentifier(column.Name),
 			*o.Default))
 	}
 	if err != nil {

--- a/pkg/migrations/op_set_default_test.go
+++ b/pkg/migrations/op_set_default_test.go
@@ -518,5 +518,97 @@ func TestSetDefaultInMultiOperationMigrations(t *testing.T) {
 				TableMustBeCleanedUp(t, db, schema, "products", "name")
 			},
 		},
+		{
+			name: "rename table, rename column, set default",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_create_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "items",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "int",
+									Pk:   true,
+								},
+								{
+									Name: "name",
+									Type: "varchar(255)",
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_multi_operation",
+					Operations: migrations.Operations{
+						&migrations.OpRenameTable{
+							From: "items",
+							To:   "products",
+						},
+						&migrations.OpRenameColumn{
+							Table: "products",
+							From:  "name",
+							To:    "item_name",
+						},
+						&migrations.OpAlterColumn{
+							Table:   "products",
+							Column:  "item_name",
+							Default: nullable.NewNullableWithValue("'unknown'"),
+							Up:      "item_name",
+							Down:    "item_name",
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
+				// Can insert a row into the new schema that uses the default
+				MustInsert(t, db, schema, "02_multi_operation", "products", map[string]string{
+					"id": "1",
+				})
+
+				// Can insert a row into the old schema
+				MustInsert(t, db, schema, "01_create_table", "items", map[string]string{
+					"id":   "2",
+					"name": "apple",
+				})
+
+				// The new view has the expected rows
+				rows := MustSelect(t, db, schema, "02_multi_operation", "products")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "item_name": "unknown"},
+					{"id": 2, "item_name": "apple"},
+				}, rows)
+
+				// The old view has the expected rows
+				rows = MustSelect(t, db, schema, "01_create_table", "items")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "name": "unknown"},
+					{"id": 2, "name": "apple"},
+				}, rows)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
+				// The table has been cleaned up
+				TableMustBeCleanedUp(t, db, schema, "items", "name")
+			},
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+				// Can insert a row into the new schema that uses the default
+				MustInsert(t, db, schema, "02_multi_operation", "products", map[string]string{
+					"id": "3",
+				})
+
+				// The new view has the expected rows
+				rows := MustSelect(t, db, schema, "02_multi_operation", "products")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "item_name": "unknown"},
+					{"id": 2, "item_name": "apple"},
+					{"id": 3, "item_name": "unknown"},
+				}, rows)
+
+				// The table has been cleaned up
+				TableMustBeCleanedUp(t, db, schema, "products", "name")
+			},
+		},
 	})
 }


### PR DESCRIPTION
Ensure that multi-operation migrations combining `alter_column` operations setting column defaults work in combination with other operations.

Add testcases for:

* rename table, set column default
* rename table, rename column, set default

Previously these migrations would fail as the `alter_column` operation was unaware of the changes made by the preceding operation.

Part of #239 