### PR TITLE
Pin Goreleaser version to `2.5.1`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: '~> v2'
+          version: 'v2.5.1'
           args: build --snapshot
 
       - uses: actions/upload-artifact@v4
@@ -265,7 +265,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v6
       with:
         distribution: goreleaser
-        version: '~> v2'
+        version: 'v2.5.1'
         args: release --clean
       env:
         # We use two GitHub tokens here:


### PR DESCRIPTION
Goreleaser `2.6.0`, [released yesterday](https://github.com/goreleaser/goreleaser/releases/tag/v2.6.0), appears to break our cross-platform builds.

Pin to `2.5.1` until we can investigate further.