### PR TITLE
Use official `goreleaser/goreleaser-cross` image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,7 +231,7 @@ jobs:
   release:
     runs-on: ubuntu-24.04
     container:
-      image: surjection/goreleaser-cross:v1.23-v2.4.8
+      image: goreleaser/goreleaser-cross:v1.24
     needs: [test, lint, examples-schema-validation, examples, license-check, type-generation, dead-code-check, check-ledger, cross-build]
     if: startsWith(github.ref, 'refs/tags/')
     env:


### PR DESCRIPTION
Stop using the custom `goreleaser-cross` image that was built as part of used as the container in which to build the project for multiple platforms. The image provides C toolchains for all the platforms supported by `pgroll`.

The official image now uses `goreleaser` `v2.4.8` which contains the fix for the bug (https://github.com/goreleaser/goreleaser/pull/5298) that we were using the custom image to work around.

Follow up to #604 that updated the image elsewhere in the workflow but forgot to update this one.