### PR TITLE
Make backfill batch selection exclude rows inserted or updated after backfill start

### DIFF
--- a/pkg/backfill/backfill.go
+++ b/pkg/backfill/backfill.go
@@ -71,6 +71,7 @@ func (bf *Backfill) Start(ctx context.Context, table *schema.Table) error {
 			PrimaryKey:    identityColumns,
 			BatchSize:     bf.batchSize,
 			TransactionID: xid,
+			Schema:        bf.schema,
 			StateSchema:   bf.stateSchema,
 		},
 	}

--- a/pkg/backfill/backfill.go
+++ b/pkg/backfill/backfill.go
@@ -15,10 +15,11 @@ import (
 )
 
 type Backfill struct {
-	conn       db.DB
-	batchSize  int
-	batchDelay time.Duration
-	callbacks  []CallbackFn
+	conn        db.DB
+	batchSize   int
+	batchDelay  time.Duration
+	callbacks   []CallbackFn
+	stateSchema string
 }
 
 type CallbackFn func(done int64, total int64)
@@ -27,8 +28,9 @@ type CallbackFn func(done int64, total int64)
 // not started until `Start` is invoked.
 func New(conn db.DB, opts ...OptionFn) *Backfill {
 	b := &Backfill{
-		conn:      conn,
-		batchSize: 1000,
+		conn:        conn,
+		batchSize:   1000,
+		stateSchema: "pgroll",
 	}
 
 	for _, opt := range opts {
@@ -68,6 +70,7 @@ func (bf *Backfill) Start(ctx context.Context, table *schema.Table) error {
 			PrimaryKey:    identityColumns,
 			BatchSize:     bf.batchSize,
 			TransactionID: xid,
+			StateSchema:   bf.stateSchema,
 		},
 	}
 

--- a/pkg/backfill/backfill.go
+++ b/pkg/backfill/backfill.go
@@ -19,6 +19,7 @@ type Backfill struct {
 	batchSize   int
 	batchDelay  time.Duration
 	callbacks   []CallbackFn
+	schema      string
 	stateSchema string
 }
 

--- a/pkg/backfill/options.go
+++ b/pkg/backfill/options.go
@@ -34,3 +34,10 @@ func WithStateSchema(schema string) OptionFn {
 		o.stateSchema = schema
 	}
 }
+
+// WithSchema sets the schema in which the table resides.
+func WithSchema(schema string) OptionFn {
+	return func(o *Backfill) {
+		o.schema = schema
+	}
+}

--- a/pkg/backfill/options.go
+++ b/pkg/backfill/options.go
@@ -27,3 +27,10 @@ func WithCallbacks(cbs ...CallbackFn) OptionFn {
 		o.callbacks = cbs
 	}
 }
+
+// WithStateSchema sets in which `pgroll` stores its internal state.
+func WithStateSchema(schema string) OptionFn {
+	return func(o *Backfill) {
+		o.stateSchema = schema
+	}
+}

--- a/pkg/backfill/templates/build.go
+++ b/pkg/backfill/templates/build.go
@@ -16,6 +16,7 @@ type BatchConfig struct {
 	LastValue     []string
 	BatchSize     int
 	TransactionID int64
+	StateSchema   string
 }
 
 func BuildSQL(cfg BatchConfig) (string, error) {

--- a/pkg/backfill/templates/build.go
+++ b/pkg/backfill/templates/build.go
@@ -16,6 +16,7 @@ type BatchConfig struct {
 	LastValue     []string
 	BatchSize     int
 	TransactionID int64
+	Schema        string
 	StateSchema   string
 }
 

--- a/pkg/backfill/templates/build.go
+++ b/pkg/backfill/templates/build.go
@@ -11,10 +11,11 @@ import (
 )
 
 type BatchConfig struct {
-	TableName  string
-	PrimaryKey []string
-	LastValue  []string
-	BatchSize  int
+	TableName     string
+	PrimaryKey    []string
+	LastValue     []string
+	BatchSize     int
+	TransactionID int64
 }
 
 func BuildSQL(cfg BatchConfig) (string, error) {

--- a/pkg/backfill/templates/build_test.go
+++ b/pkg/backfill/templates/build_test.go
@@ -18,6 +18,7 @@ func TestBatchStatementBuilder(t *testing.T) {
 				TableName:     "table_name",
 				PrimaryKey:    []string{"id"},
 				BatchSize:     10,
+				Schema:        "public",
 				StateSchema:   "pgroll",
 				TransactionID: 1234,
 			},
@@ -28,6 +29,7 @@ func TestBatchStatementBuilder(t *testing.T) {
 				TableName:     "table_name",
 				PrimaryKey:    []string{"id", "zip"},
 				BatchSize:     10,
+				Schema:        "public",
 				StateSchema:   "pgroll",
 				TransactionID: 1234,
 			},
@@ -39,6 +41,7 @@ func TestBatchStatementBuilder(t *testing.T) {
 				PrimaryKey:    []string{"id"},
 				LastValue:     []string{"1"},
 				BatchSize:     10,
+				Schema:        "public",
 				StateSchema:   "pgroll",
 				TransactionID: 1234,
 			},
@@ -50,6 +53,7 @@ func TestBatchStatementBuilder(t *testing.T) {
 				PrimaryKey:    []string{"id", "zip"},
 				LastValue:     []string{"1", "1234"},
 				BatchSize:     10,
+				Schema:        "public",
 				StateSchema:   "pgroll",
 				TransactionID: 1234,
 			},
@@ -71,7 +75,10 @@ const expectSingleIDColumnNoLastValue = `WITH batch AS
 (
   SELECT "id"
   FROM "table_name"
-  WHERE "pgroll".b_follows_a(xmin::text::bigint, 1234)
+  WHERE (
+    "pgroll".b_follows_a(xmin::text::bigint, 1234) OR
+    "pgroll".b_follows_a(xmin::text::bigint, "pgroll".frozen_xid('public', 'table_name')::text::bigint)
+  )
   ORDER BY "id"
   LIMIT 10
   FOR NO KEY UPDATE
@@ -92,7 +99,10 @@ const multipleIDColumnsNoLastValue = `WITH batch AS
 (
   SELECT "id", "zip"
   FROM "table_name"
-  WHERE "pgroll".b_follows_a(xmin::text::bigint, 1234)
+  WHERE (
+    "pgroll".b_follows_a(xmin::text::bigint, 1234) OR
+    "pgroll".b_follows_a(xmin::text::bigint, "pgroll".frozen_xid('public', 'table_name')::text::bigint)
+  )
   ORDER BY "id", "zip"
   LIMIT 10
   FOR NO KEY UPDATE
@@ -113,7 +123,10 @@ const singleIDColumnWithLastValue = `WITH batch AS
 (
   SELECT "id"
   FROM "table_name"
-  WHERE "pgroll".b_follows_a(xmin::text::bigint, 1234)
+  WHERE (
+    "pgroll".b_follows_a(xmin::text::bigint, 1234) OR
+    "pgroll".b_follows_a(xmin::text::bigint, "pgroll".frozen_xid('public', 'table_name')::text::bigint)
+  )
   AND ("id") > ('1')
   ORDER BY "id"
   LIMIT 10
@@ -135,7 +148,10 @@ const multipleIDColumnsWithLastValue = `WITH batch AS
 (
   SELECT "id", "zip"
   FROM "table_name"
-  WHERE "pgroll".b_follows_a(xmin::text::bigint, 1234)
+  WHERE (
+    "pgroll".b_follows_a(xmin::text::bigint, 1234) OR
+    "pgroll".b_follows_a(xmin::text::bigint, "pgroll".frozen_xid('public', 'table_name')::text::bigint)
+  )
   AND ("id", "zip") > ('1', '1234')
   ORDER BY "id", "zip"
   LIMIT 10

--- a/pkg/backfill/templates/sql.go
+++ b/pkg/backfill/templates/sql.go
@@ -6,7 +6,10 @@ const SQL = `WITH batch AS
 (
   SELECT {{ commaSeparate (quoteIdentifiers .PrimaryKey) }}
   FROM {{ .TableName | qi}}
-  WHERE {{ .StateSchema | qi }}.b_follows_a(xmin::text::bigint, {{ .TransactionID }})
+  WHERE (
+    {{ .StateSchema | qi }}.b_follows_a(xmin::text::bigint, {{ .TransactionID }}) OR
+    {{ .StateSchema | qi }}.b_follows_a(xmin::text::bigint, {{ .StateSchema | qi }}.frozen_xid({{ .Schema | ql }}, {{ .TableName | ql }})::text::bigint)
+  )
   {{ if .LastValue -}}
   AND ({{ commaSeparate (quoteIdentifiers .PrimaryKey) }}) > ({{ commaSeparate (quoteLiterals .LastValue) }})
   {{ end -}}

--- a/pkg/backfill/templates/sql.go
+++ b/pkg/backfill/templates/sql.go
@@ -6,8 +6,9 @@ const SQL = `WITH batch AS
 (
   SELECT {{ commaSeparate (quoteIdentifiers .PrimaryKey) }}
   FROM {{ .TableName | qi}}
+  WHERE {{ .StateSchema | qi }}.b_follows_a(xmin::text::bigint, {{ .TransactionID }})
   {{ if .LastValue -}}
-  WHERE ({{ commaSeparate (quoteIdentifiers .PrimaryKey) }}) > ({{ commaSeparate (quoteLiterals .LastValue) }})
+  AND ({{ commaSeparate (quoteIdentifiers .PrimaryKey) }}) > ({{ commaSeparate (quoteLiterals .LastValue) }})
   {{ end -}}
   ORDER BY {{ commaSeparate (quoteIdentifiers .PrimaryKey) }}
   LIMIT {{ .BatchSize }}

--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -314,6 +314,7 @@ func (m *Roll) performBackfills(ctx context.Context, tables []*schema.Table, cbs
 		backfill.WithBatchSize(m.backfillBatchSize),
 		backfill.WithBatchDelay(m.backfillBatchDelay),
 		backfill.WithCallbacks(cbs...),
+		backfill.WithSchema(m.schema),
 		backfill.WithStateSchema(m.state.Schema()),
 	)
 

--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -313,7 +313,9 @@ func (m *Roll) performBackfills(ctx context.Context, tables []*schema.Table, cbs
 	bf := backfill.New(m.pgConn,
 		backfill.WithBatchSize(m.backfillBatchSize),
 		backfill.WithBatchDelay(m.backfillBatchDelay),
-		backfill.WithCallbacks(cbs...))
+		backfill.WithCallbacks(cbs...),
+		backfill.WithStateSchema(m.state.Schema()),
+	)
 
 	for _, table := range tables {
 		if err := bf.Start(ctx, table); err != nil {

--- a/pkg/state/init.sql
+++ b/pkg/state/init.sql
@@ -361,3 +361,13 @@ DROP EVENT TRIGGER IF EXISTS pg_roll_handle_drop;
 CREATE EVENT TRIGGER pg_roll_handle_drop ON sql_drop
     EXECUTE FUNCTION placeholder.raw_migration ();
 
+-- Determine if a comes before b in a circular sequence
+-- Used for wraparound-aware transaction id comparison in pgroll backfill
+-- operations.
+CREATE OR REPLACE FUNCTION placeholder.b_follows_a (a bigint, b bigint)
+    RETURNS boolean
+    LANGUAGE SQL
+    AS $$
+    SELECT
+        (b - a) & x'FFFFFFFF'::bit(32)::bigint < x'7FFFFFFF'::bit(32)::bigint
+$$;

--- a/pkg/state/init.sql
+++ b/pkg/state/init.sql
@@ -371,3 +371,20 @@ CREATE OR REPLACE FUNCTION placeholder.b_follows_a (a bigint, b bigint)
     SELECT
         (b - a) & x'FFFFFFFF'::bit(32)::bigint < x'7FFFFFFF'::bit(32)::bigint
 $$;
+
+-- Find the xid for a table before which all transaction ids in the table are
+-- frozen
+CREATE OR REPLACE FUNCTION placeholder.frozen_xid (schema_name name, table_name name)
+    RETURNS xid
+    LANGUAGE SQL
+    AS $$
+    SELECT
+        relfrozenxid
+    FROM
+        pg_class
+    WHERE
+        relnamespace::regnamespace::name = schema_name
+        AND relname = table_name
+        AND relkind = 'r'
+$$;
+


### PR DESCRIPTION
Implement one possible solution to limit backfill to touch only rows that existed in the table prior to backfill start and ignore rows inserted or updated after backfill start.

I believe the solution presented here is flawed and should not be merged as is; the PR is open for discussion to see if the technique can be made to work or if we need to take a different approach.

In general, it is fine from a correctness POV if backfill updates a row that was already updated/inserted by a transaction that committed after backfill started; it's not OK from a performance POV however as a backfill running at the same time as a high rate of `INSERT`s into the table will cause the backfill to never terminate (the issue is described in #583).

## Proposed solution

Backfill works be touching rows in batches (batch size is configurable). 'Touch' in this context means to set the row's PK to itself, causing the already-installed backfill trigger to fire for that row.

As of this PR, the per-batch query looks like:

```sql
WITH batch AS
(
  SELECT "id", "zip"
  FROM "table_name"
  WHERE (
    "pgroll".b_follows_a(xmin::text::bigint, 1234) OR
    "pgroll".b_follows_a(xmin::text::bigint, "pgroll".frozen_xid('public', 'table_name')::text::bigint)
  )
  AND ("id", "zip") > ('1', '1234')
  ORDER BY "id", "zip"
  LIMIT 10
  FOR NO KEY UPDATE
),
update AS
(
  UPDATE "table_name"
  SET "id" = "table_name"."id", "zip" = "table_name"."zip"
  FROM batch
  WHERE "table_name"."id" = batch."id" AND "table_name"."zip" = batch."zip"
  RETURNING "table_name"."id", "table_name"."zip"
)
SELECT LAST_VALUE("id") OVER(), LAST_VALUE("zip") OVER()
FROM update
```

The first CTE (`WITH batch AS...`) is the relevant part here. The purpose of this CTE is to select the next batch of rows to be updated (and lock those rows for update).

The relevant part of the first CTE is this bit:

```sql
WHERE (
    "pgroll".b_follows_a(xmin::text::bigint, 1234) OR
    "pgroll".b_follows_a(xmin::text::bigint, "pgroll".frozen_xid('public', 'table_name')::text::bigint)
)
```

This is where we attempt to filter out tuples that were created/updated after the backfill process started. '1234' represents the `xid` of when the backfill process started. The first part:

```sql
    "pgroll".b_follows_a(xmin::text::bigint, 1234)
```

checks to see if the tuple is older than the `xid` when the backfill started. If so the tuple should be part of the batch. `b_follows_a` implements an `xid`-wraparound safe comparison of `xid`s. The transaction id space (0 - 2^32-1) is considered as a circle and anything in the forward half of the circle is considered ahead of `xid`, anything else is behind. See [Postgres Internals book - Chapter 7, Freezing](https://edu.postgrespro.com/postgresql_internals-14_en.pdf) for a description:

<img width="807" alt="image" src="https://github.com/user-attachments/assets/2ac5bf69-63e2-4a45-b83c-c2d4d1f3bcd8" />

Using this calculation alone to determine relative ages between transaction ids will fail for very old rows (older than 2^31 transactions since backfill start), which will appear to be in the future. 

<div align="center">
<img width="243" alt="image" src="https://github.com/user-attachments/assets/23da6f6b-fe18-47f7-942b-5eb16d679c20" />
</div>
Here, the first snowflake transaction at the top of the circle will appear to be in the future relative to T1, but really it's in the past. Postgres solves this problem by 'freezing` old tuples once they are guaranteed visible to all transactions (exactly when Postgres freezes old tuples is configurable, but not relevant here). So we also need a second check to always include a row in the batch if it's frozen:

```sql
    "pgroll".b_follows_a(xmin::text::bigint, "pgroll".frozen_xid('public', 'table_name')::text::bigint)
```

The `frozen_xid` function is defined:

```sql
-- Find the xid for a table before which all transaction ids in the table are
-- frozen
CREATE OR REPLACE FUNCTION pgroll.frozen_xid(schema_name name, table_name name)
RETURNS xid
LANGUAGE SQL
AS $$
  SELECT relfrozenxid
	FROM pg_class
	WHERE relnamespace::regnamespace::name = schema_name
	AND relname = table_name
	AND relkind = 'r'
$$;
```

The test checks if the transaction id that created the tuple comes before the oldest unfrozen tuple in the table  (`pg_class.relfrozenxid`). If so, the tuple is frozen and should be included in the batch even if the visibility check would regard it as in the future.

## Problem

What happens if a tuple was frozen many billions of transactions ago (ie several `xid` wraparounds ago)? the 32 bit `pg_class.relfrozenxid` won't be able to tell us accurately whether the `xid` of this extremely old tuple should be considered frozen or not - `relfrozenxid` doesn't contain `epoch` information about which wraparound cycle it refers to.

The ultimate truth of a whether a tuple is frozen or not is contained in the tuple header - frozen tuples have their `HEAP_XMIN_FROZEN` bits set in `t_infomask`:

```c
static inline bool
HeapTupleHeaderXminFrozen(const HeapTupleHeaderData *tup)
{
	return (tup->t_infomask & HEAP_XMIN_FROZEN) == HEAP_XMIN_FROZEN;
}
```

But the only way to access the tuple header is via the `pageinspect` extension. Prior to Postges `9.4`, frozen tuples had their `xmin` replaced with a special value to indicate that the row was frozen which made easy identification of frozen tuples from SQL possible, but this is no longer the case - the tuple `infomask` is used instead.

## Summary

Without a reliable way to check from SQL whether a tuple is frozen, I don't think this approach is robust. Reliably checking whether a tuple is frozen looks like it requires access to the tuple header, not possible from SQL, only by using extensions.

Using `pageinspect` to determine if a tuple is frozen may be possible, but would introduce a dependency on that extension; currently `pgroll` does not require any extensions. 

Without robust checks for frozen tuples, the backfill process could exclude tuples that should be backfilled potentially resulting in data loss.

## References
* [Postgres Internals book - Chapter 7, Freezing](https://edu.postgrespro.com/postgresql_internals-14_en.pdf)
* [Postgres Wiki article on transaction wraparound and tuple freezing](https://en.wikibooks.org/wiki/PostgreSQL/Wraparound_and_Freeze)
* [Postgres docs on vacuuming and xid wraparound](https://www.postgresql.org/docs/current/routine-vacuuming.html)
* [HOWTO article on xid wraparound](https://gitlab.com/postgres-ai/postgresql-consulting/postgres-howtos/-/blob/main/0044_how_to_monitor_transaction_id_wraparound_risks.md?ref_type=heads)
* [Short thread on Postgres hackers list about a very similar issue](https://www.postgresql.org/message-id/CAA6U2pZx7%3D2YS9u_ZZYSiKR12tbPS81hh37SqEe8t3L_WSvrUw%40mail.gmail.com)
* [SO question and answer, closely related to this issue](https://stackoverflow.com/questions/69316933/how-posgresql-marks-frozen-rows)