### PR TITLE
Forbid adding generated columns to existing tables

### DIFF
--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -218,9 +218,8 @@ func addColumn(ctx context.Context, conn db.DB, o OpAddColumn, t *schema.Table, 
 		o.Column.Nullable = true
 	}
 
-	// Generated identity columns are marked not null automatically by PostgreSQL.
-	if o.Column.Generated != nil && o.Column.Generated.Identity != nil && !o.Column.IsNullable() {
-		o.Column.Nullable = true
+	if o.Column.Generated != nil {
+		return fmt.Errorf("adding generated columns to existing tables is not supported")
 	}
 
 	// Don't add a column with a CHECK constraint directly.

--- a/pkg/migrations/op_add_column_test.go
+++ b/pkg/migrations/op_add_column_test.go
@@ -255,102 +255,6 @@ func TestAddColumn(t *testing.T) {
 				}, res)
 			},
 		},
-		// issue: https://github.com/xataio/pgroll/issues/638
-		//{
-		//	name: "add generated identity column and a regular stored column",
-		//	migrations: []migrations.Migration{
-		//		{
-		//			Name: "01_add_table",
-		//			Operations: migrations.Operations{
-		//				&migrations.OpCreateTable{
-		//					Name: "users",
-		//					Columns: []migrations.Column{
-		//						{
-		//							Name: "id",
-		//							Type: "bigint",
-		//							Pk:   true,
-		//							Generated: &migrations.ColumnGenerated{
-		//								Identity: &migrations.ColumnGeneratedIdentity{
-		//									UserSpecifiedValues: "ALWAYS",
-		//								},
-		//							},
-		//						},
-		//						{
-		//							Name: "name",
-		//							Type: "varchar(255)",
-		//						},
-		//					},
-		//				},
-		//			},
-		//		},
-		//		{
-		//			Name: "02_add_column",
-		//			Operations: migrations.Operations{
-		//				&migrations.OpAddColumn{
-		//					Table: "users",
-		//					Column: migrations.Column{
-		//						Name: "generated_upper",
-		//						Type: "varchar(255)",
-		//						Generated: &migrations.ColumnGenerated{
-		//							Expression: "upper(name)",
-		//						},
-		//						Nullable: false,
-		//					},
-		//				},
-		//			},
-		//		},
-		//	},
-		//	afterStart: func(t *testing.T, db *sql.DB, schema string) {
-		//		// old and new views of the table should exist
-		//		ViewMustExist(t, db, schema, "01_add_table", "users")
-		//		ViewMustExist(t, db, schema, "02_add_column", "users")
-
-		//		// inserting via both the old and the new views works
-		//		MustInsert(t, db, schema, "01_add_table", "users", map[string]string{
-		//			"name": "Alice",
-		//		})
-		//		MustInsert(t, db, schema, "02_add_column", "users", map[string]string{
-		//			"name": "Bob",
-		//		})
-
-		//		// selecting from both the old and the new views works
-		//		resOld := MustSelect(t, db, schema, "01_add_table", "users")
-		//		assert.Equal(t, []map[string]any{
-		//			{"id": 1, "name": "Alice"},
-		//			{"id": 2, "name": "Bob"},
-		//		}, resOld)
-		//		resNew := MustSelect(t, db, schema, "02_add_column", "users")
-		//		assert.Equal(t, []map[string]any{
-		//			{"id": 1, "name": "Alice", "generated_upper": "ALICE"},
-		//			{"id": 2, "name": "Bob", "generated_upper": "BOB"},
-		//		}, resNew)
-		//	},
-		//	afterRollback: func(t *testing.T, db *sql.DB, schema string) {
-		//		// The new column has been dropped from the underlying table
-		//		columnName := migrations.TemporaryName("generated_upper")
-		//		ColumnMustNotExist(t, db, schema, "users", columnName)
-
-		//		// The table's column count reflects the drop of the new column
-		//		TableMustHaveColumnCount(t, db, schema, "users", 2)
-		//	},
-		//	afterComplete: func(t *testing.T, db *sql.DB, schema string) {
-		//		// The new view still exists
-		//		ViewMustExist(t, db, schema, "02_add_column", "users")
-
-		//		// Inserting into the new view still works
-		//		MustInsert(t, db, schema, "02_add_column", "users", map[string]string{
-		//			"name": "Carl",
-		//		})
-
-		//		// Selecting from the new view still works
-		//		res := MustSelect(t, db, schema, "02_add_column", "users")
-		//		assert.Equal(t, []map[string]any{
-		//			{"id": 1, "name": "Alice", "generated_upper": "ALICE"},
-		//			{"id": 2, "name": "Bob", "generated_upper": "BOB"},
-		//			{"id": 3, "name": "Carl", "generated_upper": "CARL"},
-		//		}, res)
-		//	},
-		//},
 	})
 }
 
@@ -1521,31 +1425,6 @@ func TestAddColumnValidation(t *testing.T) {
 			},
 			wantStartErr: nil,
 		},
-		//{
-		//	name: "generated column is either stored or identity",
-		//	migrations: []migrations.Migration{
-		//		addTableMigrationNoPKNullable,
-		//		{
-		//			Name: "02_add_column",
-		//			Operations: migrations.Operations{
-		//				&migrations.OpAddColumn{
-		//					Table: "users",
-		//					Column: migrations.Column{
-		//						Name: "name_upper",
-		//						Type: "text",
-		//						Generated: &migrations.ColumnGenerated{
-		//							Expression: "upper(name)",
-		//							Identity: &migrations.ColumnGeneratedIdentity{
-		//								SequenceOptions: "start 2",
-		//							},
-		//						},
-		//					},
-		//				},
-		//			},
-		//		},
-		//	},
-		//	wantStartErr: migrations.InvalidGeneratedColumnError{Table: "users", Column: "name_upper"},
-		//},
 	})
 }
 

--- a/pkg/migrations/op_add_column_test.go
+++ b/pkg/migrations/op_add_column_test.go
@@ -255,101 +255,102 @@ func TestAddColumn(t *testing.T) {
 				}, res)
 			},
 		},
-		{
-			name: "add generated identity column and a regular stored column",
-			migrations: []migrations.Migration{
-				{
-					Name: "01_add_table",
-					Operations: migrations.Operations{
-						&migrations.OpCreateTable{
-							Name: "users",
-							Columns: []migrations.Column{
-								{
-									Name: "id",
-									Type: "bigint",
-									Pk:   true,
-									Generated: &migrations.ColumnGenerated{
-										Identity: &migrations.ColumnGeneratedIdentity{
-											UserSpecifiedValues: "ALWAYS",
-										},
-									},
-								},
-								{
-									Name: "name",
-									Type: "varchar(255)",
-								},
-							},
-						},
-					},
-				},
-				{
-					Name: "02_add_column",
-					Operations: migrations.Operations{
-						&migrations.OpAddColumn{
-							Table: "users",
-							Column: migrations.Column{
-								Name: "generated_upper",
-								Type: "varchar(255)",
-								Generated: &migrations.ColumnGenerated{
-									Expression: "upper(name)",
-								},
-								Nullable: false,
-							},
-						},
-					},
-				},
-			},
-			afterStart: func(t *testing.T, db *sql.DB, schema string) {
-				// old and new views of the table should exist
-				ViewMustExist(t, db, schema, "01_add_table", "users")
-				ViewMustExist(t, db, schema, "02_add_column", "users")
+		// issue: https://github.com/xataio/pgroll/issues/638
+		//{
+		//	name: "add generated identity column and a regular stored column",
+		//	migrations: []migrations.Migration{
+		//		{
+		//			Name: "01_add_table",
+		//			Operations: migrations.Operations{
+		//				&migrations.OpCreateTable{
+		//					Name: "users",
+		//					Columns: []migrations.Column{
+		//						{
+		//							Name: "id",
+		//							Type: "bigint",
+		//							Pk:   true,
+		//							Generated: &migrations.ColumnGenerated{
+		//								Identity: &migrations.ColumnGeneratedIdentity{
+		//									UserSpecifiedValues: "ALWAYS",
+		//								},
+		//							},
+		//						},
+		//						{
+		//							Name: "name",
+		//							Type: "varchar(255)",
+		//						},
+		//					},
+		//				},
+		//			},
+		//		},
+		//		{
+		//			Name: "02_add_column",
+		//			Operations: migrations.Operations{
+		//				&migrations.OpAddColumn{
+		//					Table: "users",
+		//					Column: migrations.Column{
+		//						Name: "generated_upper",
+		//						Type: "varchar(255)",
+		//						Generated: &migrations.ColumnGenerated{
+		//							Expression: "upper(name)",
+		//						},
+		//						Nullable: false,
+		//					},
+		//				},
+		//			},
+		//		},
+		//	},
+		//	afterStart: func(t *testing.T, db *sql.DB, schema string) {
+		//		// old and new views of the table should exist
+		//		ViewMustExist(t, db, schema, "01_add_table", "users")
+		//		ViewMustExist(t, db, schema, "02_add_column", "users")
 
-				// inserting via both the old and the new views works
-				MustInsert(t, db, schema, "01_add_table", "users", map[string]string{
-					"name": "Alice",
-				})
-				MustInsert(t, db, schema, "02_add_column", "users", map[string]string{
-					"name": "Bob",
-				})
+		//		// inserting via both the old and the new views works
+		//		MustInsert(t, db, schema, "01_add_table", "users", map[string]string{
+		//			"name": "Alice",
+		//		})
+		//		MustInsert(t, db, schema, "02_add_column", "users", map[string]string{
+		//			"name": "Bob",
+		//		})
 
-				// selecting from both the old and the new views works
-				resOld := MustSelect(t, db, schema, "01_add_table", "users")
-				assert.Equal(t, []map[string]any{
-					{"id": 1, "name": "Alice"},
-					{"id": 2, "name": "Bob"},
-				}, resOld)
-				resNew := MustSelect(t, db, schema, "02_add_column", "users")
-				assert.Equal(t, []map[string]any{
-					{"id": 1, "name": "Alice", "generated_upper": "ALICE"},
-					{"id": 2, "name": "Bob", "generated_upper": "BOB"},
-				}, resNew)
-			},
-			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
-				// The new column has been dropped from the underlying table
-				columnName := migrations.TemporaryName("generated_upper")
-				ColumnMustNotExist(t, db, schema, "users", columnName)
+		//		// selecting from both the old and the new views works
+		//		resOld := MustSelect(t, db, schema, "01_add_table", "users")
+		//		assert.Equal(t, []map[string]any{
+		//			{"id": 1, "name": "Alice"},
+		//			{"id": 2, "name": "Bob"},
+		//		}, resOld)
+		//		resNew := MustSelect(t, db, schema, "02_add_column", "users")
+		//		assert.Equal(t, []map[string]any{
+		//			{"id": 1, "name": "Alice", "generated_upper": "ALICE"},
+		//			{"id": 2, "name": "Bob", "generated_upper": "BOB"},
+		//		}, resNew)
+		//	},
+		//	afterRollback: func(t *testing.T, db *sql.DB, schema string) {
+		//		// The new column has been dropped from the underlying table
+		//		columnName := migrations.TemporaryName("generated_upper")
+		//		ColumnMustNotExist(t, db, schema, "users", columnName)
 
-				// The table's column count reflects the drop of the new column
-				TableMustHaveColumnCount(t, db, schema, "users", 2)
-			},
-			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
-				// The new view still exists
-				ViewMustExist(t, db, schema, "02_add_column", "users")
+		//		// The table's column count reflects the drop of the new column
+		//		TableMustHaveColumnCount(t, db, schema, "users", 2)
+		//	},
+		//	afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+		//		// The new view still exists
+		//		ViewMustExist(t, db, schema, "02_add_column", "users")
 
-				// Inserting into the new view still works
-				MustInsert(t, db, schema, "02_add_column", "users", map[string]string{
-					"name": "Carl",
-				})
+		//		// Inserting into the new view still works
+		//		MustInsert(t, db, schema, "02_add_column", "users", map[string]string{
+		//			"name": "Carl",
+		//		})
 
-				// Selecting from the new view still works
-				res := MustSelect(t, db, schema, "02_add_column", "users")
-				assert.Equal(t, []map[string]any{
-					{"id": 1, "name": "Alice", "generated_upper": "ALICE"},
-					{"id": 2, "name": "Bob", "generated_upper": "BOB"},
-					{"id": 3, "name": "Carl", "generated_upper": "CARL"},
-				}, res)
-			},
-		},
+		//		// Selecting from the new view still works
+		//		res := MustSelect(t, db, schema, "02_add_column", "users")
+		//		assert.Equal(t, []map[string]any{
+		//			{"id": 1, "name": "Alice", "generated_upper": "ALICE"},
+		//			{"id": 2, "name": "Bob", "generated_upper": "BOB"},
+		//			{"id": 3, "name": "Carl", "generated_upper": "CARL"},
+		//		}, res)
+		//	},
+		//},
 	})
 }
 
@@ -1520,31 +1521,31 @@ func TestAddColumnValidation(t *testing.T) {
 			},
 			wantStartErr: nil,
 		},
-		{
-			name: "generated column is either stored or identity",
-			migrations: []migrations.Migration{
-				addTableMigrationNoPKNullable,
-				{
-					Name: "02_add_column",
-					Operations: migrations.Operations{
-						&migrations.OpAddColumn{
-							Table: "users",
-							Column: migrations.Column{
-								Name: "name_upper",
-								Type: "text",
-								Generated: &migrations.ColumnGenerated{
-									Expression: "upper(name)",
-									Identity: &migrations.ColumnGeneratedIdentity{
-										SequenceOptions: "start 2",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantStartErr: migrations.InvalidGeneratedColumnError{Table: "users", Column: "name_upper"},
-		},
+		//{
+		//	name: "generated column is either stored or identity",
+		//	migrations: []migrations.Migration{
+		//		addTableMigrationNoPKNullable,
+		//		{
+		//			Name: "02_add_column",
+		//			Operations: migrations.Operations{
+		//				&migrations.OpAddColumn{
+		//					Table: "users",
+		//					Column: migrations.Column{
+		//						Name: "name_upper",
+		//						Type: "text",
+		//						Generated: &migrations.ColumnGenerated{
+		//							Expression: "upper(name)",
+		//							Identity: &migrations.ColumnGeneratedIdentity{
+		//								SequenceOptions: "start 2",
+		//							},
+		//						},
+		//					},
+		//				},
+		//			},
+		//		},
+		//	},
+		//	wantStartErr: migrations.InvalidGeneratedColumnError{Table: "users", Column: "name_upper"},
+		//},
 	})
 }
 


### PR DESCRIPTION
This is a temporary limitation we have to introduce to make sure
people are not adding generated columns to their existing tables.
Right now, with the current approach if someone adds a new generated
column to their big table, PostgreSQL has to write the new stored
value or generate the new identity for every row, leading to possible downtime.
