### PR TITLE
Skip backfill for empty table

### DIFF
--- a/pkg/backfill/backfill.go
+++ b/pkg/backfill/backfill.go
@@ -134,16 +134,6 @@ func getRowCount(ctx context.Context, conn db.DB, tableName string) (int64, erro
 	return total, nil
 }
 
-// IsPossible will return an error if the backfill operation is not supported.
-func IsPossible(table *schema.Table) error {
-	cols := getIdentityColumns(table)
-	if cols == nil {
-		return NotPossibleError{Table: table.Name}
-	}
-
-	return nil
-}
-
 // getIdentityColumn will return a column suitable for use in a backfill operation.
 func getIdentityColumns(table *schema.Table) []string {
 	pks := table.GetPrimaryKey()

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -177,14 +177,6 @@ func (o *OpAddColumn) Validate(ctx context.Context, s *schema.Schema) error {
 		}
 	}
 
-	// Ensure backfill is possible
-	if o.Up != "" {
-		err := backfill.IsPossible(table)
-		if err != nil {
-			return err
-		}
-	}
-
 	if o.Column.Generated != nil && o.Column.Generated.Expression != "" && o.Column.Generated.Identity != nil {
 		return InvalidGeneratedColumnError{Table: o.Table, Column: o.Column.Name}
 	}

--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -168,12 +168,6 @@ func (o *OpAlterColumn) Validate(ctx context.Context, s *schema.Schema) error {
 		return ColumnDoesNotExistError{Table: o.Table, Name: o.Column}
 	}
 
-	// If the operation requires backfills (ie it isn't a rename-only operation),
-	// ensure that the column meets the requirements for backfilling.
-	if err := backfill.IsPossible(table); err != nil {
-		return err
-	}
-
 	ops := o.subOperations()
 
 	// Ensure that at least one sub-operation or rename is present


### PR DESCRIPTION
No need to backfill an empty table. Backfill fails for tables without identity columns, but it shouldn't be necessary for empty tables. This causes meaningless errors like in the example given in the issue description.

Fixes: #636