### PR TITLE
Update `DB` interface methods

### DIFF
--- a/pkg/backfill/backfill.go
+++ b/pkg/backfill/backfill.go
@@ -169,7 +169,7 @@ type batcher struct {
 }
 
 func (b *batcher) updateBatch(ctx context.Context, conn db.DB) error {
-	return conn.WithRetryableTransaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	return conn.WithRetryableTransaction(ctx, nil, func(ctx context.Context, tx *sql.Tx) error {
 		// Build the query to update the next batch of rows
 		sql, err := templates.BuildSQL(b.BatchConfig)
 		if err != nil {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -22,6 +22,7 @@ type DB interface {
 	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
 	WithRetryableTransaction(ctx context.Context, f func(context.Context, *sql.Tx) error) error
+	RawConn() *sql.DB
 	Close() error
 }
 
@@ -104,6 +105,11 @@ func (db *RDB) WithRetryableTransaction(ctx context.Context, f func(context.Cont
 
 		return err
 	}
+}
+
+// RawConn returns the underlying *sql.DB.
+func (db *RDB) RawConn() *sql.DB {
+	return db.DB
 }
 
 func (db *RDB) Close() error {

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -123,7 +123,7 @@ func TestWithRetryableTransaction(t *testing.T) {
 
 		// run a transaction that should retry until the lock is released
 		rdb := &db.RDB{DB: conn}
-		err := rdb.WithRetryableTransaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		err := rdb.WithRetryableTransaction(ctx, nil, func(ctx context.Context, tx *sql.Tx) error {
 			return tx.QueryRowContext(ctx, "SELECT 1 FROM test").Err()
 		})
 		require.NoError(t, err)
@@ -149,7 +149,7 @@ func TestWithRetryableTransactionWhenContextCancelled(t *testing.T) {
 		// Cancel the context before the lock times out
 		go time.AfterFunc(500*time.Millisecond, cancel)
 
-		err := rdb.WithRetryableTransaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		err := rdb.WithRetryableTransaction(ctx, nil, func(ctx context.Context, tx *sql.Tx) error {
 			return tx.QueryRowContext(ctx, "SELECT 1 FROM test").Err()
 		})
 		require.Errorf(t, err, "context canceled")

--- a/pkg/db/fake.go
+++ b/pkg/db/fake.go
@@ -19,7 +19,7 @@ func (db *FakeDB) QueryContext(ctx context.Context, query string, args ...interf
 	return nil, nil
 }
 
-func (db *FakeDB) WithRetryableTransaction(ctx context.Context, f func(context.Context, *sql.Tx) error) error {
+func (db *FakeDB) WithRetryableTransaction(ctx context.Context, opts *sql.TxOptions, f func(context.Context, *sql.Tx) error) error {
 	return nil
 }
 

--- a/pkg/db/fake.go
+++ b/pkg/db/fake.go
@@ -23,6 +23,10 @@ func (db *FakeDB) WithRetryableTransaction(ctx context.Context, f func(context.C
 	return nil
 }
 
+func (db *FakeDB) RawConn() *sql.DB {
+	return nil
+}
+
 func (db *FakeDB) Close() error {
 	return nil
 }


### PR DESCRIPTION
Make two changes to the `DB` interface:

* Update the `WithRetryableTransaction` signature to accept a `*sql.TxOptions` parameter. This allows for starting transactions at isolation levels other than the default `READ COMMITTED`.
* Add a `RawConn()` method to retrieve an underlying `*sql.DB` .

Both of these changes are prerequisite steps for addressing #583 