### PR TITLE
Add support for `NOT VALID` in constraint writer

### DIFF
--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -336,6 +336,7 @@ type ConstraintSQLWriter struct {
 	Columns           []string
 	InitiallyDeferred bool
 	Deferrable        bool
+	SkipValidation    bool
 
 	// unique, exclude, primary key constraints support the following options
 	IncludeColumns    []string
@@ -367,6 +368,7 @@ func (w *ConstraintSQLWriter) WriteCheck(check string, noInherit bool) string {
 	if noInherit {
 		constraint += " NO INHERIT"
 	}
+	constraint += w.addNotValid()
 	return constraint
 }
 
@@ -406,6 +408,7 @@ func (w *ConstraintSQLWriter) WriteForeignKey(referencedTable string, referenced
 		onUpdateAction,
 	)
 	constraint += w.addDeferrable()
+	constraint += w.addNotValid()
 	return constraint
 }
 
@@ -453,4 +456,11 @@ func (w *ConstraintSQLWriter) addDeferrable() string {
 		deferrable += " INITIALLY IMMEDIATE"
 	}
 	return deferrable
+}
+
+func (w *ConstraintSQLWriter) addNotValid() string {
+	if w.SkipValidation {
+		return " NOT VALID"
+	}
+	return ""
 }


### PR DESCRIPTION
This PR adds support for creating not validated constraints in `ALTER TABLE` statements.
I am adding unit tests in a follow-up PR, when `ConstraintSQLWriter` is moved into a separate file.
Either way, it is not used anywhere yet to avoid conflicts with other FK related
changes in future PRs.

Extracted from https://github.com/xataio/pgroll/pull/628
