### PR TITLE
Make backfill batch selection exclude rows inserted or updated after backfill start

### DIFF
--- a/pkg/backfill/backfill.go
+++ b/pkg/backfill/backfill.go
@@ -53,9 +53,10 @@ func (bf *Backfill) Start(ctx context.Context, table *schema.Table) error {
 	// Create a batcher for the table.
 	b := batcher{
 		BatchConfig: templates.BatchConfig{
-			TableName:  table.Name,
-			PrimaryKey: identityColumns,
-			BatchSize:  bf.batchSize,
+			TableName:           table.Name,
+			PrimaryKey:          identityColumns,
+			BatchSize:           bf.batchSize,
+			NeedsBackfillColumn: "_pgroll_needs_backfill",
 		},
 	}
 

--- a/pkg/backfill/templates/build.go
+++ b/pkg/backfill/templates/build.go
@@ -11,10 +11,11 @@ import (
 )
 
 type BatchConfig struct {
-	TableName  string
-	PrimaryKey []string
-	LastValue  []string
-	BatchSize  int
+	TableName           string
+	PrimaryKey          []string
+	LastValue           []string
+	BatchSize           int
+	NeedsBackfillColumn string
 }
 
 func BuildSQL(cfg BatchConfig) (string, error) {

--- a/pkg/backfill/templates/build_test.go
+++ b/pkg/backfill/templates/build_test.go
@@ -15,35 +15,39 @@ func TestBatchStatementBuilder(t *testing.T) {
 	}{
 		"single identity column no last value": {
 			config: BatchConfig{
-				TableName:  "table_name",
-				PrimaryKey: []string{"id"},
-				BatchSize:  10,
+				TableName:           "table_name",
+				PrimaryKey:          []string{"id"},
+				NeedsBackfillColumn: "_pgroll_needs_backfill",
+				BatchSize:           10,
 			},
 			expected: expectSingleIDColumnNoLastValue,
 		},
 		"multiple identity columns no last value": {
 			config: BatchConfig{
-				TableName:  "table_name",
-				PrimaryKey: []string{"id", "zip"},
-				BatchSize:  10,
+				TableName:           "table_name",
+				PrimaryKey:          []string{"id", "zip"},
+				NeedsBackfillColumn: "_pgroll_needs_backfill",
+				BatchSize:           10,
 			},
 			expected: multipleIDColumnsNoLastValue,
 		},
 		"single identity column with last value": {
 			config: BatchConfig{
-				TableName:  "table_name",
-				PrimaryKey: []string{"id"},
-				LastValue:  []string{"1"},
-				BatchSize:  10,
+				TableName:           "table_name",
+				PrimaryKey:          []string{"id"},
+				NeedsBackfillColumn: "_pgroll_needs_backfill",
+				LastValue:           []string{"1"},
+				BatchSize:           10,
 			},
 			expected: singleIDColumnWithLastValue,
 		},
 		"multiple identity columns with last value": {
 			config: BatchConfig{
-				TableName:  "table_name",
-				PrimaryKey: []string{"id", "zip"},
-				LastValue:  []string{"1", "1234"},
-				BatchSize:  10,
+				TableName:           "table_name",
+				PrimaryKey:          []string{"id", "zip"},
+				NeedsBackfillColumn: "_pgroll_needs_backfill",
+				LastValue:           []string{"1", "1234"},
+				BatchSize:           10,
 			},
 			expected: multipleIDColumnsWithLastValue,
 		},
@@ -63,6 +67,7 @@ const expectSingleIDColumnNoLastValue = `WITH batch AS
 (
   SELECT "id"
   FROM "table_name"
+  WHERE "_pgroll_needs_backfill" = true
   ORDER BY "id"
   LIMIT 10
   FOR NO KEY UPDATE
@@ -83,6 +88,7 @@ const multipleIDColumnsNoLastValue = `WITH batch AS
 (
   SELECT "id", "zip"
   FROM "table_name"
+  WHERE "_pgroll_needs_backfill" = true
   ORDER BY "id", "zip"
   LIMIT 10
   FOR NO KEY UPDATE
@@ -103,7 +109,8 @@ const singleIDColumnWithLastValue = `WITH batch AS
 (
   SELECT "id"
   FROM "table_name"
-  WHERE ("id") > ('1')
+  WHERE "_pgroll_needs_backfill" = true
+  AND ("id") > ('1')
   ORDER BY "id"
   LIMIT 10
   FOR NO KEY UPDATE
@@ -124,7 +131,8 @@ const multipleIDColumnsWithLastValue = `WITH batch AS
 (
   SELECT "id", "zip"
   FROM "table_name"
-  WHERE ("id", "zip") > ('1', '1234')
+  WHERE "_pgroll_needs_backfill" = true
+  AND ("id", "zip") > ('1', '1234')
   ORDER BY "id", "zip"
   LIMIT 10
   FOR NO KEY UPDATE

--- a/pkg/backfill/templates/sql.go
+++ b/pkg/backfill/templates/sql.go
@@ -6,8 +6,9 @@ const SQL = `WITH batch AS
 (
   SELECT {{ commaSeparate (quoteIdentifiers .PrimaryKey) }}
   FROM {{ .TableName | qi}}
+  WHERE {{ .NeedsBackfillColumn | qi }} = true
   {{ if .LastValue -}}
-  WHERE ({{ commaSeparate (quoteIdentifiers .PrimaryKey) }}) > ({{ commaSeparate (quoteLiterals .LastValue) }})
+  AND ({{ commaSeparate (quoteIdentifiers .PrimaryKey) }}) > ({{ commaSeparate (quoteLiterals .LastValue) }})
   {{ end -}}
   ORDER BY {{ commaSeparate (quoteIdentifiers .PrimaryKey) }}
   LIMIT {{ .BatchSize }}

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -94,6 +94,14 @@ func (o *OpAddColumn) Complete(ctx context.Context, conn db.DB, tr SQLTransforme
 		return err
 	}
 
+	// Remove the needs backfill column
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s DROP COLUMN IF EXISTS %s",
+		pq.QuoteIdentifier(o.Table),
+		pq.QuoteIdentifier(CNeedsBackfillColumn)))
+	if err != nil {
+		return err
+	}
+
 	if !o.Column.IsNullable() && o.Column.Default == nil {
 		_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s VALIDATE CONSTRAINT %s",
 			pq.QuoteIdentifier(o.Table),
@@ -169,6 +177,15 @@ func (o *OpAddColumn) Rollback(ctx context.Context, conn db.DB, tr SQLTransforme
 
 	_, err = conn.ExecContext(ctx, fmt.Sprintf("DROP FUNCTION IF EXISTS %s CASCADE",
 		pq.QuoteIdentifier(TriggerFunctionName(o.Table, o.Column.Name))))
+	if err != nil {
+		return err
+	}
+
+	// Remove the needs backfill column
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s DROP COLUMN IF EXISTS %s",
+		pq.QuoteIdentifier(table.Name),
+		pq.QuoteIdentifier(CNeedsBackfillColumn)))
+
 	return err
 }
 

--- a/pkg/migrations/op_add_column_test.go
+++ b/pkg/migrations/op_add_column_test.go
@@ -1127,9 +1127,9 @@ func TestAddColumnWithUpSql(t *testing.T) {
 				// after rollback + restart + complete, all 'description' values are the backfilled ones.
 				res := MustSelect(t, db, schema, "02_add_column", "products")
 				assert.Equal(t, []map[string]any{
+					{"id": "c", "name": "cherries", "description": "CHERRIES"},
 					{"id": "a", "name": "apple", "description": "APPLE"},
 					{"id": "b", "name": "banana", "description": "BANANA"},
-					{"id": "c", "name": "cherries", "description": "CHERRIES"},
 				}, res)
 
 				// The trigger function has been dropped.

--- a/pkg/migrations/op_common_test.go
+++ b/pkg/migrations/op_common_test.go
@@ -882,12 +882,16 @@ func MustSelect(t *testing.T, db *sql.DB, schema, version, table string) []map[s
 // - The down functions for the columns no longer exist.
 // - The up triggers for the columns no longer exist.
 // - The down triggers for the columns no longer exist.
+// - The _pgroll_needs_backfill column should not exist on the table.
 func TableMustBeCleanedUp(t *testing.T, db *sql.DB, schema, table string, columns ...string) {
 	t.Helper()
 
 	for _, column := range columns {
 		// The temporary column should not exist on the underlying table.
 		ColumnMustNotExist(t, db, schema, table, migrations.TemporaryName(column))
+
+		// The _pgroll_needs_backfill column should not exist on the table.
+		ColumnMustNotExist(t, db, schema, table, migrations.CNeedsBackfillColumn)
 
 		// The up function for the column no longer exists.
 		FunctionMustNotExist(t, db, schema, migrations.TriggerFunctionName(table, column))

--- a/pkg/migrations/op_drop_column.go
+++ b/pkg/migrations/op_drop_column.go
@@ -53,19 +53,43 @@ func (o *OpDropColumn) Complete(ctx context.Context, conn db.DB, tr SQLTransform
 
 	_, err = conn.ExecContext(ctx, fmt.Sprintf("DROP FUNCTION IF EXISTS %s CASCADE",
 		pq.QuoteIdentifier(TriggerFunctionName(o.Table, o.Column))))
+	if err != nil {
+		return err
+	}
 
-	return err
+	// Remove the needs backfill column
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s DROP COLUMN IF EXISTS %s",
+		pq.QuoteIdentifier(o.Table),
+		pq.QuoteIdentifier(CNeedsBackfillColumn)))
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (o *OpDropColumn) Rollback(ctx context.Context, conn db.DB, tr SQLTransformer, s *schema.Schema) error {
+	table := s.GetTable(o.Table)
+
 	_, err := conn.ExecContext(ctx, fmt.Sprintf("DROP FUNCTION IF EXISTS %s CASCADE",
 		pq.QuoteIdentifier(TriggerFunctionName(o.Table, o.Column))))
+	if err != nil {
+		return err
+	}
+
+	// Remove the needs backfill column
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s DROP COLUMN IF EXISTS %s",
+		pq.QuoteIdentifier(table.Name),
+		pq.QuoteIdentifier(CNeedsBackfillColumn)))
+	if err != nil {
+		return err
+	}
 
 	// Mark the column as no longer deleted so thats it's visible to preceding
 	// rollback operations in the same migration
 	s.GetTable(o.Table).UnRemoveColumn(o.Column)
 
-	return err
+	return nil
 }
 
 func (o *OpDropColumn) Validate(ctx context.Context, s *schema.Schema) error {

--- a/pkg/migrations/op_drop_constraint.go
+++ b/pkg/migrations/op_drop_constraint.go
@@ -95,6 +95,14 @@ func (o *OpDropConstraint) Complete(ctx context.Context, conn db.DB, tr SQLTrans
 		return err
 	}
 
+	// Remove the needs backfill column
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s DROP COLUMN IF EXISTS %s",
+		pq.QuoteIdentifier(table.Name),
+		pq.QuoteIdentifier(CNeedsBackfillColumn)))
+	if err != nil {
+		return err
+	}
+
 	// Drop the old column
 	_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s DROP COLUMN IF EXISTS %s",
 		pq.QuoteIdentifier(o.Table),
@@ -137,6 +145,14 @@ func (o *OpDropConstraint) Rollback(ctx context.Context, conn db.DB, tr SQLTrans
 	_, err = conn.ExecContext(ctx, fmt.Sprintf("DROP FUNCTION IF EXISTS %s CASCADE",
 		pq.QuoteIdentifier(TriggerFunctionName(o.Table, TemporaryName(columnName))),
 	))
+	if err != nil {
+		return err
+	}
+
+	// Remove the needs backfill column
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s DROP COLUMN IF EXISTS %s",
+		pq.QuoteIdentifier(table.Name),
+		pq.QuoteIdentifier(CNeedsBackfillColumn)))
 
 	return err
 }

--- a/pkg/migrations/op_drop_multicolumn_constraint.go
+++ b/pkg/migrations/op_drop_multicolumn_constraint.go
@@ -108,6 +108,14 @@ func (o *OpDropMultiColumnConstraint) Complete(ctx context.Context, conn db.DB, 
 			return err
 		}
 
+		// Remove the needs backfill column
+		_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s DROP COLUMN IF EXISTS %s",
+			pq.QuoteIdentifier(o.Table),
+			pq.QuoteIdentifier(CNeedsBackfillColumn)))
+		if err != nil {
+			return err
+		}
+
 		// Drop the old column
 		_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s DROP COLUMN IF EXISTS %s",
 			pq.QuoteIdentifier(o.Table),
@@ -151,6 +159,14 @@ func (o *OpDropMultiColumnConstraint) Rollback(ctx context.Context, conn db.DB, 
 		_, err = conn.ExecContext(ctx, fmt.Sprintf("DROP FUNCTION IF EXISTS %s CASCADE",
 			pq.QuoteIdentifier(TriggerFunctionName(o.Table, TemporaryName(columnName))),
 		))
+		if err != nil {
+			return err
+		}
+
+		// Remove the needs backfill column
+		_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s DROP COLUMN IF EXISTS %s",
+			pq.QuoteIdentifier(table.Name),
+			pq.QuoteIdentifier(CNeedsBackfillColumn)))
 		if err != nil {
 			return err
 		}

--- a/pkg/migrations/templates/function.go
+++ b/pkg/migrations/templates/function.go
@@ -21,6 +21,7 @@ const Function = `CREATE OR REPLACE FUNCTION {{ .Name | qi }}()
 
       IF search_path {{- if eq .Direction "up" }} != {{- else }} = {{- end }} {{ .LatestSchema | ql }} THEN
         NEW.{{ .PhysicalColumn | qi  }} = {{ .SQL }};
+        NEW.{{ .NeedsBackfillColumn | qi }} = false;
       END IF;
 
       RETURN NEW;

--- a/pkg/migrations/trigger.go
+++ b/pkg/migrations/trigger.go
@@ -26,14 +26,15 @@ const (
 const CNeedsBackfillColumn = "_pgroll_needs_backfill"
 
 type triggerConfig struct {
-	Name           string
-	Direction      TriggerDirection
-	Columns        map[string]*schema.Column
-	SchemaName     string
-	TableName      string
-	PhysicalColumn string
-	LatestSchema   string
-	SQL            string
+	Name                string
+	Direction           TriggerDirection
+	Columns             map[string]*schema.Column
+	SchemaName          string
+	TableName           string
+	PhysicalColumn      string
+	LatestSchema        string
+	SQL                 string
+	NeedsBackfillColumn string
 }
 
 func createTrigger(ctx context.Context, conn db.DB, tr SQLTransformer, cfg triggerConfig) error {
@@ -47,6 +48,7 @@ func createTrigger(ctx context.Context, conn db.DB, tr SQLTransformer, cfg trigg
 	}
 
 	cfg.SQL = expr
+	cfg.NeedsBackfillColumn = CNeedsBackfillColumn
 
 	funcSQL, err := buildFunction(cfg)
 	if err != nil {

--- a/pkg/migrations/trigger_test.go
+++ b/pkg/migrations/trigger_test.go
@@ -26,11 +26,12 @@ func TestBuildFunction(t *testing.T) {
 					"product":  {Name: "product", Type: "text"},
 					"review":   {Name: "review", Type: "text"},
 				},
-				SchemaName:     "public",
-				LatestSchema:   "public_01_migration_name",
-				TableName:      "reviews",
-				PhysicalColumn: "_pgroll_new_review",
-				SQL:            "product || 'is good'",
+				SchemaName:          "public",
+				LatestSchema:        "public_01_migration_name",
+				TableName:           "reviews",
+				PhysicalColumn:      "_pgroll_new_review",
+				NeedsBackfillColumn: CNeedsBackfillColumn,
+				SQL:                 "product || 'is good'",
 			},
 			expected: `CREATE OR REPLACE FUNCTION "triggerName"()
     RETURNS TRIGGER
@@ -50,6 +51,7 @@ func TestBuildFunction(t *testing.T) {
 
       IF search_path != 'public_01_migration_name' THEN
         NEW."_pgroll_new_review" = product || 'is good';
+        NEW."_pgroll_needs_backfill" = false;
       END IF;
 
       RETURN NEW;
@@ -67,11 +69,12 @@ func TestBuildFunction(t *testing.T) {
 					"product":  {Name: "product", Type: "text"},
 					"review":   {Name: "review", Type: "text"},
 				},
-				SchemaName:     "public",
-				LatestSchema:   "public_01_migration_name",
-				TableName:      "reviews",
-				PhysicalColumn: "review",
-				SQL:            `NEW."_pgroll_new_review"`,
+				SchemaName:          "public",
+				LatestSchema:        "public_01_migration_name",
+				TableName:           "reviews",
+				PhysicalColumn:      "review",
+				NeedsBackfillColumn: CNeedsBackfillColumn,
+				SQL:                 `NEW."_pgroll_new_review"`,
 			},
 			expected: `CREATE OR REPLACE FUNCTION "triggerName"()
     RETURNS TRIGGER
@@ -91,6 +94,7 @@ func TestBuildFunction(t *testing.T) {
 
       IF search_path = 'public_01_migration_name' THEN
         NEW."review" = NEW."_pgroll_new_review";
+        NEW."_pgroll_needs_backfill" = false;
       END IF;
 
       RETURN NEW;
@@ -109,11 +113,12 @@ func TestBuildFunction(t *testing.T) {
 					"review":   {Name: "review", Type: "text"},
 					"rating":   {Name: "_pgroll_new_rating", Type: "integer"},
 				},
-				SchemaName:     "public",
-				LatestSchema:   "public_01_migration_name",
-				TableName:      "reviews",
-				PhysicalColumn: "rating",
-				SQL:            `CAST(rating as text)`,
+				SchemaName:          "public",
+				LatestSchema:        "public_01_migration_name",
+				TableName:           "reviews",
+				PhysicalColumn:      "rating",
+				NeedsBackfillColumn: CNeedsBackfillColumn,
+				SQL:                 `CAST(rating as text)`,
 			},
 			expected: `CREATE OR REPLACE FUNCTION "triggerName"()
     RETURNS TRIGGER
@@ -134,6 +139,7 @@ func TestBuildFunction(t *testing.T) {
 
       IF search_path = 'public_01_migration_name' THEN
         NEW."rating" = CAST(rating as text);
+        NEW."_pgroll_needs_backfill" = false;
       END IF;
 
       RETURN NEW;


### PR DESCRIPTION
Backfill only rows present at backfill start. This is third approach to solving https://github.com/xataio/pgroll/issues/583. The previous two are:
* https://github.com/xataio/pgroll/pull/634
* https://github.com/xataio/pgroll/pull/648

This is the most direct approach to solving the problem. At the same time as the up/down triggers are created to perform a backfill, a `_pgroll_needs_backfill` column is also created on the table to be backfilled. The column has a `DEFAULT` of `true`; the constant default ensures that this extra column can be added quickly without a lengthy `ACCESS_EXCLUSIVE` lock. The column is removed when the the operation is rolled back or completed.

The up/down triggers are modified to set `_pgroll_needs_backfill` to false whenever they update a row.

The backfill itself is updated to select only rows having `_pgroll_needs_backfill` set to `true` - this ensures that only rows created before the triggers were installed are updated by the backfill. The backfill process still needs to *read* every row in the table, including those inserted/updated after backfill start, but only those rows created before backfill start will be updated.

The main disadvantage of this approach is that backfill now requires an extra column to be created on the target table.