### PR TITLE
Expose foreign key constraint options in inline FK definition and in `create_constraint`

### DIFF
--- a/docs/operations/create_constraint.mdx
+++ b/docs/operations/create_constraint.mdx
@@ -22,6 +22,9 @@ Required fields: `name`, `table`, `type`, `up`, `down`.
       "table": "name of referenced table",
       "columns": "[names of referenced columns]",
       "on_delete": "ON DELETE behaviour, can be CASCADE, SET NULL, RESTRICT, or NO ACTION. Default is NO ACTION",
+      "on_delete_set_columns": ["list of FKs to set", "in on delete operation on SET NULL or SET DEFAULT"],
+      "on_update": "ON UPDATE behaviour, can be CASCADE, SET NULL, RESTRICT, or NO ACTION. Default is NO ACTION",
+      "match_type": "match type, can be SIMPLE or FULL. Default is SIMPLE"
     },
     "up": {
       "column1": "up SQL expressions for each column covered by the constraint",

--- a/docs/operations/create_table.mdx
+++ b/docs/operations/create_table.mdx
@@ -42,6 +42,8 @@ Each `column` is defined as:
     "table": "name of referenced table",
     "column": "name of referenced column",
     "on_delete": "ON DELETE behaviour, can be CASCADE, SET NULL, SET DEFAULT, RESTRICT, or NO ACTION. Default is NO ACTION",
+    "on_update": "ON UPDATE behaviour, can be CASCADE, SET NULL, RESTRICT, or NO ACTION. Default is NO ACTION",
+    "match_type": "match type, can be SIMPLE or FULL. Default is SIMPLE"
   }
 },
 ```

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -314,16 +314,14 @@ func (w ColumnSQLWriter) Write(col Column) (string, error) {
 	}
 
 	if col.References != nil {
-		onDelete := string(ForeignKeyActionNOACTION)
-		if col.References.OnDelete != "" {
-			onDelete = strings.ToUpper(string(col.References.OnDelete))
-		}
-
-		sql += fmt.Sprintf(" CONSTRAINT %s REFERENCES %s(%s) ON DELETE %s",
-			pq.QuoteIdentifier(col.References.Name),
-			pq.QuoteIdentifier(col.References.Table),
-			pq.QuoteIdentifier(col.References.Column),
-			onDelete)
+		writer := &ConstraintSQLWriter{Name: col.References.Name}
+		sql += " " + writer.WriteForeignKey(
+			col.References.Table,
+			[]string{col.References.Column},
+			col.References.OnDelete,
+			col.References.OnUpdate,
+			nil,
+			col.References.MatchType)
 	}
 	if col.Check != nil {
 		sql += fmt.Sprintf(" CONSTRAINT %s CHECK (%s)",

--- a/pkg/migrations/op_add_column_test.go
+++ b/pkg/migrations/op_add_column_test.go
@@ -636,7 +636,14 @@ func TestAddForeignKeyColumn(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The foreign key constraint exists on the new table.
-				ValidatedForeignKeyMustExist(t, db, schema, "orders", "fk_users_id", withOnDeleteCascade())
+				ValidatedForeignKeyMustExistWithReferentialAction(
+					t,
+					db,
+					schema,
+					"orders",
+					"fk_users_id",
+					migrations.ForeignKeyActionCASCADE,
+					migrations.ForeignKeyActionNOACTION)
 
 				// Inserting a row into the referenced table succeeds.
 				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
@@ -669,7 +676,14 @@ func TestAddForeignKeyColumn(t *testing.T) {
 			},
 			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The foreign key constraint still exists on the new table
-				ValidatedForeignKeyMustExist(t, db, schema, "orders", "fk_users_id", withOnDeleteCascade())
+				ValidatedForeignKeyMustExistWithReferentialAction(
+					t,
+					db,
+					schema,
+					"orders",
+					"fk_users_id",
+					migrations.ForeignKeyActionCASCADE,
+					migrations.ForeignKeyActionNOACTION)
 
 				// Inserting a row into the referenced table succeeds.
 				MustInsert(t, db, schema, "02_add_column", "users", map[string]string{

--- a/pkg/migrations/op_change_type_test.go
+++ b/pkg/migrations/op_change_type_test.go
@@ -207,13 +207,27 @@ func TestChangeColumnType(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// A temporary FK constraint has been created on the temporary column
-				ValidatedForeignKeyMustExist(t, db, schema, "employees", migrations.DuplicationName("fk_employee_department"), withOnDeleteCascade())
+				ValidatedForeignKeyMustExistWithReferentialAction(
+					t,
+					db,
+					schema,
+					"employees",
+					migrations.DuplicationName("fk_employee_department"),
+					migrations.ForeignKeyActionCASCADE,
+					migrations.ForeignKeyActionNOACTION)
 			},
 			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
 			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The foreign key constraint still exists on the column
-				ValidatedForeignKeyMustExist(t, db, schema, "employees", "fk_employee_department", withOnDeleteCascade())
+				ValidatedForeignKeyMustExistWithReferentialAction(
+					t,
+					db,
+					schema,
+					"employees",
+					"fk_employee_department",
+					migrations.ForeignKeyActionCASCADE,
+					migrations.ForeignKeyActionNOACTION)
 			},
 		},
 		{

--- a/pkg/migrations/op_create_constraint_test.go
+++ b/pkg/migrations/op_create_constraint_test.go
@@ -496,6 +496,149 @@ func TestCreateConstraint(t *testing.T) {
 			},
 		},
 		{
+			name: "create foreign key constraint on multiple columns with on delete",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_tables",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name: "zip",
+									Type: "integer",
+									Pk:   true,
+								},
+								{
+									Name:     "name",
+									Type:     "varchar(255)",
+									Nullable: false,
+								},
+								{
+									Name:     "email",
+									Type:     "varchar(255)",
+									Nullable: false,
+								},
+							},
+						},
+						&migrations.OpCreateTable{
+							Name: "reports",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name:     "users_id",
+									Type:     "integer",
+									Nullable: true,
+								},
+								{
+									Name:     "users_zip",
+									Type:     "integer",
+									Nullable: true,
+								},
+								{
+									Name:     "description",
+									Type:     "varchar(255)",
+									Nullable: false,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_create_constraint",
+					Operations: migrations.Operations{
+						&migrations.OpCreateConstraint{
+							Name:    "fk_users",
+							Table:   "reports",
+							Type:    "foreign_key",
+							Columns: []string{"users_id", "users_zip"},
+							References: &migrations.TableForeignKeyReference{
+								Table:    "users",
+								Columns:  []string{"id", "zip"},
+								OnDelete: migrations.ForeignKeyActionSETNULL,
+							},
+							Up: map[string]string{
+								"users_id":  "1",
+								"users_zip": "12345",
+							},
+							Down: map[string]string{
+								"users_id":  "users_id",
+								"users_zip": "users_zip",
+							},
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
+				// The new (temporary) column should exist on the underlying table.
+				ColumnMustExist(t, db, schema, "reports", migrations.TemporaryName("users_id"))
+				// The new (temporary) column should exist on the underlying table.
+				ColumnMustExist(t, db, schema, "reports", migrations.TemporaryName("users_zip"))
+				// A temporary FK constraint has been created on the temporary column
+				NotValidatedForeignKeyMustExistWithReferentialAction(t, db, schema, "reports", "fk_users", migrations.ForeignKeyActionSETNULL, migrations.ForeignKeyActionNOACTION)
+
+				// Insert values to refer to.
+				MustInsert(t, db, schema, "01_add_tables", "users", map[string]string{
+					"name":  "alice",
+					"email": "alice@example.com",
+					"zip":   "12345",
+				})
+
+				// Inserting values into the old schema that the violate the fk constraint must succeed.
+				MustInsert(t, db, schema, "01_add_tables", "reports", map[string]string{
+					"description": "random report",
+				})
+
+				// Inserting values into the new schema that meet the FK constraint should succeed.
+				MustInsert(t, db, schema, "02_create_constraint", "reports", map[string]string{
+					"description": "alice report",
+					"users_id":    "1",
+					"users_zip":   "12345",
+				})
+				// Inserting data into the new `reports` view with an invalid user reference fails.
+				MustNotInsert(t, db, schema, "02_create_constraint", "reports", map[string]string{
+					"description": "no one report",
+					"users_id":    "100",
+					"users_zip":   "100",
+				}, testutils.FKViolationErrorCode)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
+				// The check constraint must not exists on the table.
+				CheckConstraintMustNotExist(t, db, schema, "reports", "fk_users")
+				// Functions, triggers and temporary columns are dropped.
+				TableMustBeCleanedUp(t, db, schema, "reports", "users_id")
+				TableMustBeCleanedUp(t, db, schema, "reports", "users_zip")
+			},
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+				ValidatedForeignKeyMustExistWithReferentialAction(t, db, schema, "reports", "fk_users", migrations.ForeignKeyActionSETNULL, migrations.ForeignKeyActionNOACTION)
+				// Functions, triggers and temporary columns are dropped.
+				TableMustBeCleanedUp(t, db, schema, "reports", "users_id")
+				TableMustBeCleanedUp(t, db, schema, "reports", "users_zip")
+
+				// Inserting values into the new schema that the violate the check constraint must fail.
+				MustNotInsert(t, db, schema, "02_create_constraint", "reports", map[string]string{
+					"description": "no one report",
+					"users_id":    "100",
+					"users_zip":   "100",
+				}, testutils.FKViolationErrorCode)
+
+				rows := MustSelect(t, db, schema, "02_create_constraint", "reports")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "description": "random report", "users_id": 1, "users_zip": 12345},
+					{"id": 2, "description": "alice report", "users_id": 1, "users_zip": 12345},
+				}, rows)
+			},
+		},
+		{
 			name: "create unique constraint on a unique column and another column",
 			migrations: []migrations.Migration{
 				{

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -404,6 +404,7 @@ func (w *ConstraintSQLWriter) WriteForeignKey(referencedTable string, referenced
 	if w.Name != "" {
 		constraint = fmt.Sprintf("CONSTRAINT %s ", pq.QuoteIdentifier(w.Name))
 	}
+	// in case of in line foreign key constraint, columns are already included in the column definition
 	if len(w.Columns) != 0 {
 		constraint += fmt.Sprintf("FOREIGN KEY (%s) ", strings.Join(quoteColumnNames(w.Columns), ", "))
 	}

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -404,8 +404,10 @@ func (w *ConstraintSQLWriter) WriteForeignKey(referencedTable string, referenced
 	if w.Name != "" {
 		constraint = fmt.Sprintf("CONSTRAINT %s ", pq.QuoteIdentifier(w.Name))
 	}
-	constraint += fmt.Sprintf("FOREIGN KEY (%s) REFERENCES %s (%s) MATCH %s ON DELETE %s ON UPDATE %s",
-		strings.Join(quoteColumnNames(w.Columns), ", "),
+	if len(w.Columns) != 0 {
+		constraint += fmt.Sprintf("FOREIGN KEY (%s) ", strings.Join(quoteColumnNames(w.Columns), ", "))
+	}
+	constraint += fmt.Sprintf("REFERENCES %s (%s) MATCH %s ON DELETE %s ON UPDATE %s",
 		pq.QuoteIdentifier(referencedTable),
 		strings.Join(quoteColumnNames(referencedColumns), ", "),
 		matchTypeStr,

--- a/pkg/migrations/op_create_table_test.go
+++ b/pkg/migrations/op_create_table_test.go
@@ -323,7 +323,14 @@ func TestCreateTable(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The foreign key constraint exists on the new table.
-				ValidatedForeignKeyMustExist(t, db, schema, "orders", "fk_users_id", withOnDeleteCascade())
+				ValidatedForeignKeyMustExistWithReferentialAction(
+					t,
+					db,
+					schema,
+					"orders",
+					"fk_users_id",
+					migrations.ForeignKeyActionCASCADE,
+					migrations.ForeignKeyActionNOACTION)
 
 				// Inserting a row into the referenced table succeeds.
 				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
@@ -355,7 +362,14 @@ func TestCreateTable(t *testing.T) {
 				// The table has been dropped, so the foreign key constraint is gone.
 			},
 			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
-				ValidatedForeignKeyMustExist(t, db, schema, "orders", "fk_users_id", withOnDeleteCascade())
+				ValidatedForeignKeyMustExistWithReferentialAction(
+					t,
+					db,
+					schema,
+					"orders",
+					"fk_users_id",
+					migrations.ForeignKeyActionCASCADE,
+					migrations.ForeignKeyActionNOACTION)
 
 				// Inserting a row into the referenced table succeeds.
 				MustInsert(t, db, schema, "02_create_table_with_fk", "users", map[string]string{
@@ -382,6 +396,133 @@ func TestCreateTable(t *testing.T) {
 				// The row in the referencing table has been deleted by the ON DELETE CASCADE.
 				rows := MustSelect(t, db, schema, "02_create_table_with_fk", "orders")
 				assert.Empty(t, rows)
+			},
+		},
+		{
+			name: "create table with foreign key with default ON UPDATE and ON UPDATE CASADE",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_create_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name:   "name",
+									Type:   "varchar(255)",
+									Unique: true,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_create_table_with_fk",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "orders",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name: "user_id",
+									Type: "integer",
+									References: &migrations.ForeignKeyReference{
+										Column:   "id",
+										Name:     "fk_users_id",
+										Table:    "users",
+										OnDelete: migrations.ForeignKeyActionCASCADE,
+										OnUpdate: migrations.ForeignKeyActionCASCADE,
+									},
+								},
+								{
+									Name: "quantity",
+									Type: "integer",
+								},
+							},
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
+				// The foreign key constraint exists on the new table.
+				ValidatedForeignKeyMustExistWithReferentialAction(
+					t,
+					db,
+					schema,
+					"orders",
+					"fk_users_id",
+					migrations.ForeignKeyActionCASCADE,
+					migrations.ForeignKeyActionCASCADE)
+
+				// Inserting a row into the referenced table succeeds.
+				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
+					"name": "alice",
+				})
+
+				// Inserting a row into the referencing table succeeds as the referenced row exists.
+				MustInsert(t, db, schema, "02_create_table_with_fk", "orders", map[string]string{
+					"user_id":  "1",
+					"quantity": "100",
+				})
+
+				// Inserting a row into the referencing table fails as the referenced row does not exist.
+				MustNotInsert(t, db, schema, "02_create_table_with_fk", "orders", map[string]string{
+					"user_id":  "2",
+					"quantity": "200",
+				}, testutils.FKViolationErrorCode)
+
+				// Deleting a row in the referenced table succeeds and cascades.
+				MustDelete(t, db, schema, "02_create_table_with_fk", "users", map[string]string{
+					"name": "alice",
+				})
+				rows := MustSelect(t, db, schema, "02_create_table_with_fk", "users")
+				assert.Equal(t, []map[string]any{}, rows)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
+				// The table has been dropped, so the foreign key constraint is gone.
+			},
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+				ValidatedForeignKeyMustExistWithReferentialAction(
+					t,
+					db,
+					schema,
+					"orders",
+					"fk_users_id",
+					migrations.ForeignKeyActionCASCADE,
+					migrations.ForeignKeyActionCASCADE)
+
+				// Inserting a row into the referenced table succeeds.
+				MustInsert(t, db, schema, "02_create_table_with_fk", "users", map[string]string{
+					"name": "bob",
+				})
+
+				// Inserting a row into the referencing table succeeds as the referenced row exists.
+				MustInsert(t, db, schema, "02_create_table_with_fk", "orders", map[string]string{
+					"user_id":  "2",
+					"quantity": "200",
+				})
+
+				// Inserting a row into the referencing table fails as the referenced row does not exist.
+				MustNotInsert(t, db, schema, "02_create_table_with_fk", "orders", map[string]string{
+					"user_id":  "3",
+					"quantity": "300",
+				}, testutils.FKViolationErrorCode)
+
+				// Deleting a row in the referenced table succeeds and cascades.
+				MustDelete(t, db, schema, "02_create_table_with_fk", "users", map[string]string{
+					"name": "bob",
+				})
+				rows := MustSelect(t, db, schema, "02_create_table_with_fk", "users")
+				assert.Equal(t, []map[string]any{}, rows)
 			},
 		},
 		{

--- a/pkg/migrations/op_set_check_test.go
+++ b/pkg/migrations/op_set_check_test.go
@@ -274,13 +274,27 @@ func TestSetCheckConstraint(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// A temporary FK constraint has been created on the temporary column
-				ValidatedForeignKeyMustExist(t, db, schema, "employees", migrations.DuplicationName("fk_employee_department"), withOnDeleteCascade())
+				ValidatedForeignKeyMustExistWithReferentialAction(
+					t,
+					db,
+					schema,
+					"employees",
+					migrations.DuplicationName("fk_employee_department"),
+					migrations.ForeignKeyActionCASCADE,
+					migrations.ForeignKeyActionNOACTION)
 			},
 			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
 			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The foreign key constraint still exists on the column
-				ValidatedForeignKeyMustExist(t, db, schema, "employees", "fk_employee_department", withOnDeleteCascade())
+				ValidatedForeignKeyMustExistWithReferentialAction(
+					t,
+					db,
+					schema,
+					"employees",
+					"fk_employee_department",
+					migrations.ForeignKeyActionCASCADE,
+					migrations.ForeignKeyActionNOACTION)
 			},
 		},
 		{

--- a/pkg/migrations/op_set_fk_test.go
+++ b/pkg/migrations/op_set_fk_test.go
@@ -751,13 +751,27 @@ func TestSetForeignKey(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// A temporary FK constraint has been created on the temporary column
-				ValidatedForeignKeyMustExist(t, db, schema, "posts", migrations.DuplicationName("fk_users_id_1"), withOnDeleteCascade())
+				ValidatedForeignKeyMustExistWithReferentialAction(
+					t,
+					db,
+					schema,
+					"posts",
+					migrations.DuplicationName("fk_users_id_1"),
+					migrations.ForeignKeyActionCASCADE,
+					migrations.ForeignKeyActionNOACTION)
 			},
 			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
 			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The foreign key constraint still exists on the column
-				ValidatedForeignKeyMustExist(t, db, schema, "posts", "fk_users_id_1", withOnDeleteCascade())
+				ValidatedForeignKeyMustExistWithReferentialAction(
+					t,
+					db,
+					schema,
+					"posts",
+					"fk_users_id_1",
+					migrations.ForeignKeyActionCASCADE,
+					migrations.ForeignKeyActionNOACTION)
 			},
 		},
 		{

--- a/pkg/migrations/op_set_notnull_test.go
+++ b/pkg/migrations/op_set_notnull_test.go
@@ -277,13 +277,27 @@ func TestSetNotNull(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// A temporary FK constraint has been created on the temporary column
-				ValidatedForeignKeyMustExist(t, db, schema, "employees", migrations.DuplicationName("fk_employee_department"), withOnDeleteCascade())
+				ValidatedForeignKeyMustExistWithReferentialAction(
+					t,
+					db,
+					schema,
+					"employees",
+					migrations.DuplicationName("fk_employee_department"),
+					migrations.ForeignKeyActionCASCADE,
+					migrations.ForeignKeyActionNOACTION)
 			},
 			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
 			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The foreign key constraint still exists on the column
-				ValidatedForeignKeyMustExist(t, db, schema, "employees", "fk_employee_department", withOnDeleteCascade())
+				ValidatedForeignKeyMustExistWithReferentialAction(
+					t,
+					db,
+					schema,
+					"employees",
+					"fk_employee_department",
+					migrations.ForeignKeyActionCASCADE,
+					migrations.ForeignKeyActionNOACTION)
 			},
 		},
 		{

--- a/pkg/migrations/op_set_unique_test.go
+++ b/pkg/migrations/op_set_unique_test.go
@@ -312,13 +312,27 @@ func TestSetColumnUnique(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// A temporary FK constraint has been created on the temporary column
-				ValidatedForeignKeyMustExist(t, db, schema, "employees", migrations.DuplicationName("fk_employee_department"), withOnDeleteSetNull())
+				ValidatedForeignKeyMustExistWithReferentialAction(
+					t,
+					db,
+					schema,
+					"employees",
+					migrations.DuplicationName("fk_employee_department"),
+					migrations.ForeignKeyActionSETNULL,
+					migrations.ForeignKeyActionNOACTION)
 			},
 			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 			},
 			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The foreign key constraint still exists on the column
-				ValidatedForeignKeyMustExist(t, db, schema, "employees", "fk_employee_department", withOnDeleteSetNull())
+				ValidatedForeignKeyMustExistWithReferentialAction(
+					t,
+					db,
+					schema,
+					"employees",
+					"fk_employee_department",
+					migrations.ForeignKeyActionSETNULL,
+					migrations.ForeignKeyActionNOACTION)
 			},
 		},
 		{


### PR DESCRIPTION
Now more foreign key options are supported:
* `match_type` in column definitions and in `create_constraint`
* `on_update` in column definitions and in `create_constraint`
* `on_delete_set_columns` in `create_constraint`
* `on_update` in inline FK definitions in a column's `references`
* `match_type` in inline FK definction in a column's `references`

Extracted from https://github.com/xataio/pgroll/pull/628. The only remaining part of that PR is adding support in `sql2pgroll`. :tada: 
