### PR TITLE
Add support for `alter_table` change type operations in multi-operation migrations

### DIFF
--- a/pkg/migrations/op_change_type_test.go
+++ b/pkg/migrations/op_change_type_test.go
@@ -652,6 +652,110 @@ func TestChangeColumnType(t *testing.T) {
 	})
 }
 
+func TestChangeTypeInMultiOperationMigrations(t *testing.T) {
+	t.Parallel()
+
+	ExecuteTests(t, TestCases{
+		{
+			name: "rename table, change type",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_create_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "items",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "int",
+									Pk:   true,
+								},
+								{
+									Name:     "name",
+									Type:     "varchar(3)",
+									Nullable: true,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_multi_operation",
+					Operations: migrations.Operations{
+						&migrations.OpRenameTable{
+							From: "items",
+							To:   "products",
+						},
+						&migrations.OpAlterColumn{
+							Table:  "products",
+							Column: "name",
+							Type:   ptr("text"),
+							Up:     "name",
+							Down:   "CASE WHEN LENGTH(name) > 3 THEN 'xxx' ELSE name END",
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
+				// The new column has the expected type
+				// The table hasn't been physically renamed yet, so we need to use the old name
+				ColumnMustHaveType(t, db, schema, "items", migrations.TemporaryName("name"), "text")
+
+				// Can insert a row into the new schema
+				MustInsert(t, db, schema, "02_multi_operation", "products", map[string]string{
+					"id":   "1",
+					"name": "apple",
+				})
+
+				// Can insert a row into the old schema
+				MustInsert(t, db, schema, "01_create_table", "items", map[string]string{
+					"id":   "2",
+					"name": "abc",
+				})
+
+				// The new view has the expected rows
+				rows := MustSelect(t, db, schema, "02_multi_operation", "products")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "name": "apple"},
+					{"id": 2, "name": "abc"},
+				}, rows)
+
+				// The old view has the expected rows
+				rows = MustSelect(t, db, schema, "01_create_table", "items")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "name": "xxx"},
+					{"id": 2, "name": "abc"},
+				}, rows)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
+				// The table has been cleaned up
+				TableMustBeCleanedUp(t, db, schema, "items", "name")
+			},
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+				// The new column has the expected type
+				ColumnMustHaveType(t, db, schema, "products", "name", "text")
+
+				// Can insert a row into the new schema
+				MustInsert(t, db, schema, "02_multi_operation", "products", map[string]string{
+					"id":   "3",
+					"name": "carrot",
+				})
+
+				// The new view has the expected rows
+				rows := MustSelect(t, db, schema, "02_multi_operation", "products")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "name": "xxx"},
+					{"id": 2, "name": "abc"},
+					{"id": 3, "name": "carrot"},
+				}, rows)
+
+				// The table has been cleaned up
+				TableMustBeCleanedUp(t, db, schema, "products", "name")
+			},
+		},
+	})
+}
+
 func TestChangeColumnTypeValidation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Ensure that multi-operation migrations combining `alter_column` operations that change column type work in combination with other operations.

Add testcases for:

* rename table, change column type
* rename table, rename column, change column type

Previously these migrations would fail as the `alter_column` operation was unaware of the renames made by the preceding operation.

Part of #239 