### PR TITLE
Ignore inferred migrations for `migrate` and `pull` commands

### DIFF
--- a/pkg/roll/unapplied.go
+++ b/pkg/roll/unapplied.go
@@ -17,11 +17,6 @@ import (
 // If the local order of migrations does not match the order of migrations in
 // the schema history, an `ErrMismatchedMigration` error is returned.
 func (m *Roll) UnappliedMigrations(ctx context.Context, dir fs.FS) ([]*migrations.Migration, error) {
-	latestVersion, err := m.State().LatestVersion(ctx, m.Schema())
-	if err != nil {
-		return nil, fmt.Errorf("determining latest version: %w", err)
-	}
-
 	files, err := fs.Glob(dir, "*.json")
 	if err != nil {
 		return nil, fmt.Errorf("reading directory: %w", err)
@@ -34,7 +29,7 @@ func (m *Roll) UnappliedMigrations(ctx context.Context, dir fs.FS) ([]*migration
 
 	// Find the index of the first unapplied migration
 	var idx int
-	if latestVersion != nil {
+	if len(history) > 0 {
 		for _, file := range files {
 			migration, err := openAndReadMigrationFile(dir, file)
 			if err != nil {
@@ -47,7 +42,7 @@ func (m *Roll) UnappliedMigrations(ctx context.Context, dir fs.FS) ([]*migration
 			}
 
 			idx++
-			if migration.Name == *latestVersion {
+			if idx == len(history) {
 				break
 			}
 		}

--- a/pkg/state/history.go
+++ b/pkg/state/history.go
@@ -28,7 +28,7 @@ func (s *State) SchemaHistory(ctx context.Context, schema string) ([]Migration, 
 	rows, err := s.pgConn.QueryContext(ctx,
 		fmt.Sprintf(`SELECT name, migration, created_at
 			FROM %s.migrations
-			WHERE schema=$1 ORDER BY created_at`,
+			WHERE schema=$1 AND migration_type='pgroll' ORDER BY created_at`,
 			pq.QuoteIdentifier(s.schema)), schema)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`SchemaHistory` function returns list of all migrations applied on a schema, including inferred ones. This causes `migrate` command to fail with a migration mismatch error, as described in #664. This PR ignores inferred migrations so that case will be fixed. Also, inferred migrations will not be included in the output of `pull` command as well.

Though, I'm not sure if we should exclude inferred migrations from `pull`. We can also keep them for `pull` while excluding only from `migrate`.