### PR TITLE
Add support for `no_inherit` on column level constraints and in `create_constraint` operation

### DIFF
--- a/docs/operations/create_constraint.mdx
+++ b/docs/operations/create_constraint.mdx
@@ -17,6 +17,7 @@ Required fields: `name`, `table`, `type`, `up`, `down`.
     "columns": ["column1", "column2"],
     "type": "unique"| "check" | "foreign_key",
     "check": "SQL expression for CHECK constraint",
+    "no_inherit": "true|false",
     "references": {
       "name": "name of foreign key reference",
       "table": "name of referenced table",

--- a/docs/operations/create_table.mdx
+++ b/docs/operations/create_table.mdx
@@ -28,7 +28,8 @@ Each `column` is defined as:
   "default": "default value",
   "check": {
     "name": "name of check constraint",
-    "constraint": "constraint expression"
+    "constraint": "constraint expression",
+    "no_inherit": "true|false"
   },
   "generated": {
     "expression": "expression for stored column",

--- a/internal/jsonschema/testdata/create-constraint-1-invalid-check.txtar
+++ b/internal/jsonschema/testdata/create-constraint-1-invalid-check.txtar
@@ -1,0 +1,28 @@
+This is an invalid 'create_constraint' migration.
+Check constraint must have the option 'check' configured.
+
+-- create_constraint.json --
+{
+  "name": "migration_name",
+  "operations": [
+    {
+      "create_constraint": {
+        "name": "my_invalid_check",
+        "table": "my_table",
+        "type": "check",
+        "columns": [
+          "my_column"
+        ],
+        "up": {
+          "my_column": "my_column"
+        },
+        "down": {
+          "my_column": "my_column"
+        }
+      }
+    }
+  ]
+}
+
+-- valid --
+false

--- a/internal/jsonschema/testdata/create-constraint-2-invalid-no-inherit.txtar
+++ b/internal/jsonschema/testdata/create-constraint-2-invalid-no-inherit.txtar
@@ -1,0 +1,29 @@
+This is an invalid 'create_constraint' migration.
+Only check constraints have no_inherit flag.
+
+-- create_constraint.json --
+{
+  "name": "migration_name",
+  "operations": [
+    {
+      "create_constraint": {
+        "name": "my_invalid_check",
+        "table": "my_table",
+        "type": "foreign_key",
+        "no_inherit": true,
+        "columns": [
+          "my_column"
+        ],
+        "up": {
+          "my_column": "my_column"
+        },
+        "down": {
+          "my_column": "my_column"
+        }
+      }
+    }
+  ]
+}
+
+-- valid --
+false

--- a/pkg/migrations/constraints.go
+++ b/pkg/migrations/constraints.go
@@ -59,7 +59,11 @@ func (w *ConstraintSQLWriter) WriteCheck(check string, noInherit bool) string {
 	if w.Name != "" {
 		constraint = fmt.Sprintf("CONSTRAINT %s ", pq.QuoteIdentifier(w.Name))
 	}
-	constraint += fmt.Sprintf("CHECK (%s)", check)
+	if !strings.HasPrefix(check, "CHECK (") {
+		constraint += fmt.Sprintf("CHECK (%s)", check)
+	} else {
+		constraint += check
+	}
 	if noInherit {
 		constraint += " NO INHERIT"
 	}

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -329,9 +329,8 @@ func (w ColumnSQLWriter) Write(col Column) (string, error) {
 			col.References.MatchType)
 	}
 	if col.Check != nil {
-		sql += fmt.Sprintf(" CONSTRAINT %s CHECK (%s)",
-			pq.QuoteIdentifier(col.Check.Name),
-			col.Check.Constraint)
+		writer := &ConstraintSQLWriter{Name: col.Check.Name}
+		sql += " " + writer.WriteCheck(col.Check.Constraint, col.Check.NoInherit)
 	}
 	return sql, nil
 }

--- a/pkg/migrations/op_common_test.go
+++ b/pkg/migrations/op_common_test.go
@@ -225,14 +225,21 @@ func TriggerMustNotExist(t *testing.T, db *sql.DB, schema, table, trigger string
 
 func CheckConstraintMustNotExist(t *testing.T, db *sql.DB, schema, table, constraint string) {
 	t.Helper()
-	if checkConstraintExists(t, db, schema, table, constraint) {
+	if checkConstraintExists(t, db, schema, table, constraint, false) {
 		t.Fatalf("Expected constraint %q to not exist", constraint)
 	}
 }
 
 func CheckConstraintMustExist(t *testing.T, db *sql.DB, schema, table, constraint string) {
 	t.Helper()
-	if !checkConstraintExists(t, db, schema, table, constraint) {
+	if !checkConstraintExists(t, db, schema, table, constraint, false) {
+		t.Fatalf("Expected constraint %q to exist", constraint)
+	}
+}
+
+func NotInheritableCheckConstraintMustExist(t *testing.T, db *sql.DB, schema, table, constraint string) {
+	t.Helper()
+	if !checkConstraintExists(t, db, schema, table, constraint, true) {
 		t.Fatalf("Expected constraint %q to exist", constraint)
 	}
 }
@@ -369,7 +376,7 @@ func CheckIndexDefinition(t *testing.T, db *sql.DB, schema, table, index, expect
 	}
 }
 
-func checkConstraintExists(t *testing.T, db *sql.DB, schema, table, constraint string) bool {
+func checkConstraintExists(t *testing.T, db *sql.DB, schema, table, constraint string, noInherit bool) bool {
 	t.Helper()
 
 	var exists bool
@@ -380,8 +387,9 @@ func checkConstraintExists(t *testing.T, db *sql.DB, schema, table, constraint s
       WHERE conrelid = $1::regclass
       AND conname = $2
       AND contype = 'c'
+      AND connoinherit = $3
     )`,
-		fmt.Sprintf("%s.%s", schema, table), constraint).Scan(&exists)
+		fmt.Sprintf("%s.%s", schema, table), constraint, noInherit).Scan(&exists)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -234,6 +234,7 @@ func (o *OpCreateTable) updateSchema(s *schema.Schema) *schema.Schema {
 				Name:       c.Name,
 				Columns:    c.Columns,
 				Definition: c.Check,
+				NoInherit:  c.NoInherit,
 			}
 		case ConstraintTypePrimaryKey:
 			primaryKeys = c.Columns

--- a/pkg/migrations/op_create_table_test.go
+++ b/pkg/migrations/op_create_table_test.go
@@ -545,6 +545,7 @@ func TestCreateTable(t *testing.T) {
 									Check: &migrations.CheckConstraint{
 										Name:       "check_name_length",
 										Constraint: "length(name) > 3",
+										NoInherit:  true,
 									},
 								},
 							},
@@ -554,7 +555,7 @@ func TestCreateTable(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The check constraint exists on the new table.
-				CheckConstraintMustExist(t, db, schema, "users", "check_name_length")
+				NotInheritableCheckConstraintMustExist(t, db, schema, "users", "check_name_length")
 
 				// Inserting a row into the table succeeds when the check constraint is satisfied.
 				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
@@ -571,7 +572,7 @@ func TestCreateTable(t *testing.T) {
 			},
 			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The check constraint exists on the new table.
-				CheckConstraintMustExist(t, db, schema, "users", "check_name_length")
+				NotInheritableCheckConstraintMustExist(t, db, schema, "users", "check_name_length")
 
 				// Inserting a row into the table succeeds when the check constraint is satisfied.
 				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{

--- a/pkg/migrations/op_set_check_test.go
+++ b/pkg/migrations/op_set_check_test.go
@@ -47,6 +47,7 @@ func TestSetCheckConstraint(t *testing.T) {
 							Check: &migrations.CheckConstraint{
 								Name:       "check_title_length",
 								Constraint: "length(title) > 3",
+								NoInherit:  true,
 							},
 							Up:   "SELECT CASE WHEN length(title) <= 3 THEN LPAD(title, 4, '-') ELSE title END",
 							Down: "title",
@@ -59,7 +60,7 @@ func TestSetCheckConstraint(t *testing.T) {
 				ColumnMustExist(t, db, schema, "posts", migrations.TemporaryName("title"))
 
 				// A check constraint has been added to the temporary column
-				CheckConstraintMustExist(t, db, schema, "posts", "check_title_length")
+				NotInheritableCheckConstraintMustExist(t, db, schema, "posts", "check_title_length")
 
 				// Inserting a row that meets the check constraint into the old view works.
 				MustInsert(t, db, schema, "01_add_table", "posts", map[string]string{
@@ -103,7 +104,7 @@ func TestSetCheckConstraint(t *testing.T) {
 			},
 			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The check constraint exists on the new table.
-				CheckConstraintMustExist(t, db, schema, "posts", "check_title_length")
+				NotInheritableCheckConstraintMustExist(t, db, schema, "posts", "check_title_length")
 
 				// Inserting a row that meets the check constraint into the new view works.
 				MustInsert(t, db, schema, "02_add_check_constraint", "posts", map[string]string{

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -12,6 +12,9 @@ type CheckConstraint struct {
 
 	// Name of check constraint
 	Name string `json:"name"`
+
+	// Do not propagate constraint to child tables
+	NoInherit bool `json:"no_inherit,omitempty"`
 }
 
 // Column definition
@@ -247,6 +250,9 @@ type OpCreateConstraint struct {
 
 	// Name of the constraint
 	Name string `json:"name"`
+
+	// Do not propagate constraint to child tables
+	NoInherit bool `json:"no_inherit,omitempty"`
 
 	// Reference to the foreign key
 	References *TableForeignKeyReference `json:"references,omitempty"`

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -152,6 +152,9 @@ type CheckConstraint struct {
 
 	// The definition of the check constraint
 	Definition string `json:"definition"`
+
+	// NoInherit indicates that the check constraint should not be inherited
+	NoInherit bool `json:"noInherit"`
 }
 
 // UniqueConstraint represents a unique constraint on a table

--- a/pkg/sql2pgroll/alter_table.go
+++ b/pkg/sql2pgroll/alter_table.go
@@ -226,11 +226,12 @@ func convertAlterTableAddCheckConstraint(stmt *pgq.AlterTableStmt, constraint *p
 	}
 
 	return &migrations.OpCreateConstraint{
-		Type:    migrations.OpCreateConstraintTypeCheck,
-		Name:    constraint.GetConname(),
-		Table:   tableName,
-		Check:   ptr(expr),
-		Columns: []string{PlaceHolderColumnName},
+		Type:      migrations.OpCreateConstraintTypeCheck,
+		Name:      constraint.GetConname(),
+		Table:     tableName,
+		Check:     ptr(expr),
+		NoInherit: constraint.GetIsNoInherit(),
+		Columns:   []string{PlaceHolderColumnName},
 		Up: migrations.MultiColumnUpSQL{
 			PlaceHolderColumnName: PlaceHolderSQL,
 		},
@@ -245,7 +246,7 @@ func convertAlterTableAddCheckConstraint(stmt *pgq.AlterTableStmt, constraint *p
 // information.
 func canConvertCheckConstraint(constraint *pgq.Constraint) bool {
 	switch {
-	case constraint.IsNoInherit, constraint.SkipValidation:
+	case constraint.SkipValidation:
 		return false
 	default:
 		return true

--- a/pkg/sql2pgroll/alter_table_test.go
+++ b/pkg/sql2pgroll/alter_table_test.go
@@ -152,6 +152,10 @@ func TestConvertAlterTableStatements(t *testing.T) {
 			sql:        "ALTER TABLE schema.foo ADD CONSTRAINT bar CHECK (age > 0)",
 			expectedOp: expect.CreateConstraintOp4,
 		},
+		{
+			sql:        "ALTER TABLE foo ADD CONSTRAINT bar CHECK (age > 0) NO INHERIT",
+			expectedOp: expect.CreateConstraintOp5,
+		},
 
 		// Add column
 		{
@@ -320,9 +324,8 @@ func TestUnconvertableAlterTableStatements(t *testing.T) {
 		// Drop constraint with CASCADE
 		"ALTER TABLE foo DROP CONSTRAINT bar CASCADE",
 
-		// NO INHERIT and NOT VALID options on CHECK constraints are not
+		// NOT VALID option on CHECK constraint is not
 		// representable by `OpCreateConstraint`
-		"ALTER TABLE foo ADD CONSTRAINT bar CHECK (age > 0) NO INHERIT",
 		"ALTER TABLE foo ADD CONSTRAINT bar CHECK (age > 0) NOT VALID",
 
 		// ADD COLUMN cases not yet covered

--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -442,6 +442,7 @@ func convertInlineCheckConstraint(tableName, columnName string, constraint *pgq.
 	return &migrations.CheckConstraint{
 		Name:       name,
 		Constraint: expr,
+		NoInherit:  constraint.GetIsNoInherit(),
 	}, nil
 }
 

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -66,6 +66,10 @@ func TestConvertCreateTableStatements(t *testing.T) {
 			expectedOp: expect.CreateTableOp10,
 		},
 		{
+			sql:        "CREATE TABLE foo(a int CHECK (a > 0) NO INHERIT)",
+			expectedOp: expect.CreateTableOp37,
+		},
+		{
 			sql:        "CREATE TABLE foo(a int CONSTRAINT my_check CHECK (a > 0))",
 			expectedOp: expect.CreateTableOp18,
 		},
@@ -323,9 +327,6 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 		// Primary key constraint options are not supported
 		"CREATE TABLE foo(a int PRIMARY KEY USING INDEX TABLESPACE bar)",
 		"CREATE TABLE foo(a int PRIMARY KEY WITH (fillfactor=70))",
-
-		// CHECK constraint NO INHERIT option is not supported
-		"CREATE TABLE foo(a int CHECK (a > 0) NO INHERIT)",
 
 		// Options on UNIQUE constraints are not supported
 		"CREATE TABLE foo(a int UNIQUE NULLS NOT DISTINCT)",

--- a/pkg/sql2pgroll/expect/create_constraint.go
+++ b/pkg/sql2pgroll/expect/create_constraint.go
@@ -58,3 +58,18 @@ var CreateConstraintOp4 = &migrations.OpCreateConstraint{
 		sql2pgroll.PlaceHolderColumnName: sql2pgroll.PlaceHolderSQL,
 	},
 }
+
+var CreateConstraintOp5 = &migrations.OpCreateConstraint{
+	Type:      migrations.OpCreateConstraintTypeCheck,
+	Name:      "bar",
+	Table:     "foo",
+	Check:     ptr("age > 0"),
+	NoInherit: true,
+	Columns:   []string{sql2pgroll.PlaceHolderColumnName},
+	Up: map[string]string{
+		sql2pgroll.PlaceHolderColumnName: sql2pgroll.PlaceHolderSQL,
+	},
+	Down: map[string]string{
+		sql2pgroll.PlaceHolderColumnName: sql2pgroll.PlaceHolderSQL,
+	},
+}

--- a/pkg/sql2pgroll/expect/create_table.go
+++ b/pkg/sql2pgroll/expect/create_table.go
@@ -736,3 +736,19 @@ var CreateTableOp36 = &migrations.OpCreateTable{
 		},
 	},
 }
+
+var CreateTableOp37 = &migrations.OpCreateTable{
+	Name: "foo",
+	Columns: []migrations.Column{
+		{
+			Name:     "a",
+			Type:     "int",
+			Nullable: true,
+			Check: &migrations.CheckConstraint{
+				Name:       "foo_a_check",
+				Constraint: "a > 0",
+				NoInherit:  true,
+			},
+		},
+	},
+}

--- a/pkg/state/init.sql
+++ b/pkg/state/init.sql
@@ -216,10 +216,10 @@ BEGIN
                                 WHERE
                                     indrelid = t.oid::regclass GROUP BY pi.indexrelid, pi.indisunique, pi.indpred, am.amname) AS ix_details), 'checkConstraints', (
                         SELECT
-                            COALESCE(json_object_agg(cc_details.conname, json_build_object('name', cc_details.conname, 'columns', cc_details.columns, 'definition', cc_details.definition)), '{}'::json)
+                            COALESCE(json_object_agg(cc_details.conname, json_build_object('name', cc_details.conname, 'columns', cc_details.columns, 'definition', cc_details.definition, 'noInherit', cc_details.connoinherit)), '{}'::json)
                         FROM (
                             SELECT
-                                cc_constraint.conname, array_agg(cc_attr.attname ORDER BY cc_constraint.conkey::int[]) AS columns, pg_get_constraintdef(cc_constraint.oid) AS definition FROM pg_constraint AS cc_constraint
+                                cc_constraint.conname, array_agg(cc_attr.attname ORDER BY cc_constraint.conkey::int[]) AS columns, pg_get_constraintdef(cc_constraint.oid) AS definition, cc_constraint.connoinherit FROM pg_constraint AS cc_constraint
                             INNER JOIN pg_attribute cc_attr ON cc_attr.attrelid = cc_constraint.conrelid
                                 AND cc_attr.attnum = ANY (cc_constraint.conkey)
                             WHERE

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -792,6 +792,40 @@ func TestReadSchema(t *testing.T) {
 									Name:       "age_check",
 									Columns:    []string{"age"},
 									Definition: "CHECK ((age > 18))",
+									NoInherit:  false,
+								},
+							},
+							UniqueConstraints:  map[string]*schema.UniqueConstraint{},
+							ExcludeConstraints: map[string]*schema.ExcludeConstraint{},
+						},
+					},
+				},
+			},
+			{
+				name:       "check constraint with no inherit",
+				createStmt: "CREATE TABLE public.table1 (age INTEGER, CONSTRAINT age_check CHECK (age > 18) NO INHERIT);",
+				wantSchema: &schema.Schema{
+					Name: "public",
+					Tables: map[string]*schema.Table{
+						"table1": {
+							Name: "table1",
+							Columns: map[string]*schema.Column{
+								"age": {
+									Name:         "age",
+									Type:         "integer",
+									Nullable:     true,
+									PostgresType: "base",
+								},
+							},
+							PrimaryKey:  []string{},
+							Indexes:     map[string]*schema.Index{},
+							ForeignKeys: map[string]*schema.ForeignKey{},
+							CheckConstraints: map[string]*schema.CheckConstraint{
+								"age_check": {
+									Name:       "age_check",
+									Columns:    []string{"age"},
+									Definition: "CHECK ((age > 18)) NO INHERIT",
+									NoInherit:  true,
 								},
 							},
 							UniqueConstraints:  map[string]*schema.UniqueConstraint{},

--- a/schema.json
+++ b/schema.json
@@ -16,6 +16,11 @@
         "name": {
           "description": "Name of check constraint",
           "type": "string"
+        },
+        "no_inherit": {
+          "description": "Do not propagate constraint to child tables",
+          "type": "boolean",
+          "default": false
         }
       },
       "required": ["constraint", "name"],
@@ -794,6 +799,11 @@
           "description": "Check constraint expression",
           "type": "string"
         },
+        "no_inherit": {
+          "description": "Do not propagate constraint to child tables",
+          "type": "boolean",
+          "default": false
+        },
         "references": {
           "description": "Reference to the foreign key",
           "$ref": "#/$defs/TableForeignKeyReference"
@@ -820,9 +830,32 @@
             "properties": {
               "check": {
                 "const": ""
+              },
+              "no_inherit": {
+                "const": false
               }
             },
             "required": ["columns", "references"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "check"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "check": {
+                "type": "string"
+              },
+              "references": {
+                "const": {}
+              }
+            },
+            "required": ["check"]
           }
         }
       ],


### PR DESCRIPTION
This PR adds a new option `no_inherit` to inline and table level check constraints in `create_constraint`. It also makes sure that the check is duplicated correctly during migration. Also, I added the new attribute `noInherit` to the output of `analyze`/`read_schema`.