### PR TITLE
Support table and column rename operations preceding `create_constraint` operations

### DIFF
--- a/pkg/migrations/op_create_constraint.go
+++ b/pkg/migrations/op_create_constraint.go
@@ -69,7 +69,7 @@ func (o *OpCreateConstraint) Start(ctx context.Context, conn db.DB, latestSchema
 	case OpCreateConstraintTypeUnique:
 		return table, createUniqueIndexConcurrently(ctx, conn, s.Name, o.Name, o.Table, temporaryNames(o.Columns))
 	case OpCreateConstraintTypeCheck:
-		return table, o.addCheckConstraint(ctx, conn)
+		return table, o.addCheckConstraint(ctx, conn, table.Name)
 	case OpCreateConstraintTypeForeignKey:
 		return table, o.addForeignKeyConstraint(ctx, conn)
 	}
@@ -232,9 +232,9 @@ func (o *OpCreateConstraint) Validate(ctx context.Context, s *schema.Schema) err
 	return nil
 }
 
-func (o *OpCreateConstraint) addCheckConstraint(ctx context.Context, conn db.DB) error {
+func (o *OpCreateConstraint) addCheckConstraint(ctx context.Context, conn db.DB, tableName string) error {
 	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s CHECK (%s) NOT VALID",
-		pq.QuoteIdentifier(o.Table),
+		pq.QuoteIdentifier(tableName),
 		pq.QuoteIdentifier(o.Name),
 		rewriteCheckExpression(*o.Check, o.Columns...),
 	))

--- a/pkg/migrations/op_create_constraint.go
+++ b/pkg/migrations/op_create_constraint.go
@@ -37,7 +37,7 @@ func (o *OpCreateConstraint) Start(ctx context.Context, conn db.DB, latestSchema
 			Columns:        table.Columns,
 			SchemaName:     s.Name,
 			LatestSchema:   latestSchema,
-			TableName:      o.Table,
+			TableName:      table.Name,
 			PhysicalColumn: physicalColumnName,
 			SQL:            upSQL,
 		})
@@ -56,7 +56,7 @@ func (o *OpCreateConstraint) Start(ctx context.Context, conn db.DB, latestSchema
 			Columns:        table.Columns,
 			LatestSchema:   latestSchema,
 			SchemaName:     s.Name,
-			TableName:      o.Table,
+			TableName:      table.Name,
 			PhysicalColumn: colName,
 			SQL:            downSQL,
 		})

--- a/pkg/migrations/op_create_constraint.go
+++ b/pkg/migrations/op_create_constraint.go
@@ -134,8 +134,10 @@ func (o *OpCreateConstraint) Complete(ctx context.Context, conn db.DB, tr SQLTra
 }
 
 func (o *OpCreateConstraint) Rollback(ctx context.Context, conn db.DB, tr SQLTransformer, s *schema.Schema) error {
+	table := s.GetTable(o.Table)
+
 	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s %s",
-		pq.QuoteIdentifier(o.Table),
+		pq.QuoteIdentifier(table.Name),
 		dropMultipleColumns(quotedTemporaryNames(o.Columns)),
 	))
 	if err != nil {

--- a/pkg/migrations/op_create_constraint_test.go
+++ b/pkg/migrations/op_create_constraint_test.go
@@ -853,6 +853,119 @@ func TestCreateConstraintInMultiOperationMigrations(t *testing.T) {
 				TableMustBeCleanedUp(t, db, schema, "products", "name")
 			},
 		},
+		{
+			name: "rename table, rename column, create constraint",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_create_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "items",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "int",
+									Pk:   true,
+								},
+								{
+									Name:     "name",
+									Type:     "varchar(255)",
+									Nullable: true,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_multi_operation",
+					Operations: migrations.Operations{
+						&migrations.OpRenameTable{
+							From: "items",
+							To:   "products",
+						},
+						&migrations.OpRenameColumn{
+							Table: "products",
+							From:  "name",
+							To:    "item_name",
+						},
+						&migrations.OpCreateConstraint{
+							Table:   "products",
+							Type:    migrations.OpCreateConstraintTypeCheck,
+							Name:    "check_item_name",
+							Check:   ptr("length(item_name) > 3"),
+							Columns: []string{"item_name"},
+							Up: map[string]string{
+								"item_name": "CASE WHEN length(item_name) <= 3 THEN item_name || '-xxx' ELSE item_name END",
+							},
+							Down: map[string]string{
+								"item_name": "item_name",
+							},
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
+				// Can insert a row into the new schema that meets the constraint
+				MustInsert(t, db, schema, "02_multi_operation", "products", map[string]string{
+					"id":        "1",
+					"item_name": "apple",
+				})
+
+				// Can't insert a row into the new schema that violates the constraint
+				MustNotInsert(t, db, schema, "02_multi_operation", "products", map[string]string{
+					"id":        "2",
+					"item_name": "abc",
+				}, testutils.CheckViolationErrorCode)
+
+				// Can insert a row into the old schema that violates the constraint
+				MustInsert(t, db, schema, "01_create_table", "items", map[string]string{
+					"id":   "2",
+					"name": "abc",
+				})
+
+				// The new view has the expected rows
+				rows := MustSelect(t, db, schema, "02_multi_operation", "products")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "item_name": "apple"},
+					{"id": 2, "item_name": "abc-xxx"},
+				}, rows)
+
+				// The old view has the expected rows
+				rows = MustSelect(t, db, schema, "01_create_table", "items")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "name": "apple"},
+					{"id": 2, "name": "abc"},
+				}, rows)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
+				// The table has been cleaned up
+				TableMustBeCleanedUp(t, db, schema, "items", "name")
+			},
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+				// Can insert a row into the new schema that meets the constraint
+				MustInsert(t, db, schema, "02_multi_operation", "products", map[string]string{
+					"id":        "3",
+					"item_name": "banana",
+				})
+
+				// Can't insert a row into the new schema that violates the constraint
+				MustNotInsert(t, db, schema, "02_multi_operation", "products", map[string]string{
+					"id":        "3",
+					"item_name": "abc",
+				}, testutils.CheckViolationErrorCode)
+
+				// The new view has the expected rows
+				rows := MustSelect(t, db, schema, "02_multi_operation", "products")
+				assert.Equal(t, []map[string]any{
+					{"id": 1, "item_name": "apple"},
+					{"id": 2, "item_name": "abc-xxx"},
+					{"id": 3, "item_name": "banana"},
+				}, rows)
+
+				// The table has been cleaned up
+				TableMustBeCleanedUp(t, db, schema, "products", "name")
+			},
+		},
 	})
 }
 


### PR DESCRIPTION
Add support for allowing the table and column on which a `create_constraint` operation acts to be renamed by preceding operations in the same migration. For example, ensure that a migration like this works as expected:

```json
{
  "name": "16_multiple_ops",
  "operations": [
    {
      "rename_table": {
        "from": "items",
        "to": "products"
      }
    },
    {
      "rename_column": {
        "table": "products",
        "from": "name",
        "to": "item_name"
      }
    },
    {
      "create_constraint": {
        "table": "products",
        "type": "check",
        "name": "check_item_name",
        "columns": [ "item_name" ],
        "check": "length(item_name) > 3",
        "up": {
          "item_name": "item_name || '-from-up'"
        },
        "down": {
          "item_name": "item_name || '-from-down'"
        }
      }
    }
  ]
}
```

Here, a three operation migration first renames the `items` table to `products`, renames the `name` field to `item_name` then adds a `CHECK` constraint to the `item_name` field on the `products` table.

This PR covers the case of adding `CHECK` constraints only; further (smaller) PRs may be needed for the other constraint types supported by `create_constraint`.

Part of #239 