### PR TITLE
Support table and column rename operations preceding `create_constraint` `FOREIGN KEY` operations

### DIFF
--- a/pkg/migrations/op_create_constraint.go
+++ b/pkg/migrations/op_create_constraint.go
@@ -86,7 +86,7 @@ func (o *OpCreateConstraint) Start(ctx context.Context, conn db.DB, latestSchema
 	case OpCreateConstraintTypeCheck:
 		return table, o.addCheckConstraint(ctx, conn, table.Name)
 	case OpCreateConstraintTypeForeignKey:
-		return table, o.addForeignKeyConstraint(ctx, conn)
+		return table, o.addForeignKeyConstraint(ctx, conn, table)
 	}
 
 	return table, nil
@@ -274,8 +274,8 @@ func (o *OpCreateConstraint) addCheckConstraint(ctx context.Context, conn db.DB,
 	return err
 }
 
-func (o *OpCreateConstraint) addForeignKeyConstraint(ctx context.Context, conn db.DB) error {
-	sql := fmt.Sprintf("ALTER TABLE %s ADD ", pq.QuoteIdentifier(o.Table))
+func (o *OpCreateConstraint) addForeignKeyConstraint(ctx context.Context, conn db.DB, table *schema.Table) error {
+	sql := fmt.Sprintf("ALTER TABLE %s ADD ", pq.QuoteIdentifier(table.Name))
 
 	writer := &ConstraintSQLWriter{
 		Name:           o.Name,


### PR DESCRIPTION
Ensure that `create_constraint` `FOREIGN KEY` operations can be preceded by rename table and rename column operations as in the following example:

```json
{
  "name": "22_multiple_ops",
  "operations": [
    {
      "rename_table": {
        "from": "items",
        "to": "products"
      }
    },
    {
      "rename_column": {
        "table": "products",
        "from": "owner",
        "to": "owner_id"
      }
    },
    {
      "create_constraint": {
        "table": "products",
        "type": "foreign_key",
        "name": "fk_items_users",
        "columns": ["owner_id"],
        "references": {
          "table": "users",
          "columns": ["id"]
        },
        "up": {
          "owner_id": "owner_id"
        },
        "down": {
          "owner_id": "owner_id"
        }
      }
    }
  ]
}
```

Follow up to #674 and #676. 

Part of #239.