### PR TITLE
Support table and column rename operations preceding `drop_multicolumn_constraint` operations

### DIFF
--- a/pkg/migrations/op_drop_multicolumn_constraint.go
+++ b/pkg/migrations/op_drop_multicolumn_constraint.go
@@ -60,7 +60,9 @@ func (o *OpDropMultiColumnConstraint) Start(ctx context.Context, conn db.DB, lat
 
 		// Add the new column to the internal schema representation. This is done
 		// here, before creation of the down trigger, so that the trigger can declare
-		// a variable for the new column.
+		// a variable for the new column. Save the old column name for use as the
+		// physical column name in the down trigger first.
+		oldPhysicalColumn := table.GetColumn(columnName).Name
 		table.AddColumn(columnName, &schema.Column{
 			Name: TemporaryName(columnName),
 		})
@@ -73,7 +75,7 @@ func (o *OpDropMultiColumnConstraint) Start(ctx context.Context, conn db.DB, lat
 			SchemaName:     s.Name,
 			LatestSchema:   latestSchema,
 			TableName:      table.Name,
-			PhysicalColumn: columnName,
+			PhysicalColumn: oldPhysicalColumn,
 			SQL:            o.Down[columnName],
 		})
 		if err != nil {

--- a/pkg/migrations/op_drop_multicolumn_constraint.go
+++ b/pkg/migrations/op_drop_multicolumn_constraint.go
@@ -125,7 +125,7 @@ func (o *OpDropMultiColumnConstraint) Rollback(ctx context.Context, conn db.DB, 
 	for _, columnName := range table.GetConstraintColumns(o.Name) {
 		// Drop the new column
 		_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s DROP COLUMN IF EXISTS %s",
-			pq.QuoteIdentifier(o.Table),
+			pq.QuoteIdentifier(table.Name),
 			pq.QuoteIdentifier(TemporaryName(columnName)),
 		))
 		if err != nil {

--- a/pkg/migrations/op_drop_multicolumn_constraint.go
+++ b/pkg/migrations/op_drop_multicolumn_constraint.go
@@ -45,7 +45,7 @@ func (o *OpDropMultiColumnConstraint) Start(ctx context.Context, conn db.DB, lat
 			Columns:        table.Columns,
 			SchemaName:     s.Name,
 			LatestSchema:   latestSchema,
-			TableName:      o.Table,
+			TableName:      table.Name,
 			PhysicalColumn: TemporaryName(columnName),
 			SQL:            o.upSQL(columnName),
 		})
@@ -67,7 +67,7 @@ func (o *OpDropMultiColumnConstraint) Start(ctx context.Context, conn db.DB, lat
 			Columns:        table.Columns,
 			SchemaName:     s.Name,
 			LatestSchema:   latestSchema,
-			TableName:      o.Table,
+			TableName:      table.Name,
 			PhysicalColumn: columnName,
 			SQL:            o.Down[columnName],
 		})

--- a/pkg/migrations/op_rename_column.go
+++ b/pkg/migrations/op_rename_column.go
@@ -24,6 +24,10 @@ func (o *OpRenameColumn) Start(ctx context.Context, conn db.DB, latestSchema str
 	}
 	table.RenameColumn(o.From, o.To)
 
+	// Update the name of the column in any constraints that reference the
+	// renamed column.
+	table.RenameConstraintColumns(o.From, o.To)
+
 	return nil, nil
 }
 
@@ -43,6 +47,10 @@ func (o *OpRenameColumn) Complete(ctx context.Context, conn db.DB, tr SQLTransfo
 	// has really been renamed.
 	column := table.GetColumn(o.To)
 	column.Name = o.To
+
+	// Update the name of the column in any constraints that reference the
+	// renamed column.
+	table.RenameConstraintColumns(o.From, o.To)
 
 	return err
 }
@@ -86,6 +94,7 @@ func (o *OpRenameColumn) Validate(ctx context.Context, s *schema.Schema) error {
 	// Update the in-memory schema to reflect the column rename so that it is
 	// visible to subsequent operations' validation steps.
 	table.RenameColumn(o.From, o.To)
+	table.RenameConstraintColumns(o.From, o.To)
 
 	return nil
 }

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -277,6 +277,28 @@ func (t *Table) GetConstraintColumns(name string) []string {
 	return slices.Compact(columns)
 }
 
+// RenameConstraintColumns renames all occurrences of a column name in any
+// constraint on the table from `from` to `to`.
+func (t *Table) RenameConstraintColumns(from, to string) {
+	updateColumns := func(columns []string) {
+		for i, c := range columns {
+			if c == from {
+				columns[i] = to
+			}
+		}
+	}
+
+	for _, cc := range t.CheckConstraints {
+		updateColumns(cc.Columns)
+	}
+	for _, uc := range t.UniqueConstraints {
+		updateColumns(uc.Columns)
+	}
+	for _, fk := range t.ForeignKeys {
+		updateColumns(fk.Columns)
+	}
+}
+
 // GetPrimaryKey returns the columns that make up the primary key
 func (t *Table) GetPrimaryKey() (columns []*Column) {
 	for _, name := range t.PrimaryKey {


### PR DESCRIPTION
Ensure that `drop_multicolumn_constraint` operations can be preceded by rename table and rename column operations as in the following example:

```json
{
  "name": "24_drop_constraint",
  "operations": [
    {
      "rename_table": {
        "from": "items",
        "to": "products"
      }
    },
    {
      "rename_column": {
        "table": "products",
        "from": "name",
        "to": "item_name"
      }
    },
    {
      "drop_multicolumn_constraint": {
        "table": "products",
        "name": "name_length",
        "up": {
          "item_name": "item_name"
        },
        "down": {
          "item_name": "SELECT CASE WHEN length(item_name) <= 3 THEN LPAD(item_name, 4, '-') ELSE item_name END"
        }
      }
    }
  ]
}
```

Part of #239.