### PR TITLE
Support parsing multiple SQL statements in `sql2pgroll.Convert`

### DIFF
--- a/pkg/sql2pgroll/convert.go
+++ b/pkg/sql2pgroll/convert.go
@@ -10,52 +10,57 @@ import (
 	"github.com/xataio/pgroll/pkg/migrations"
 )
 
-var ErrStatementCount = fmt.Errorf("expected exactly one statement")
-
 // Convert converts a SQL statement to a slice of pgroll operations.
 func Convert(sql string) (migrations.Operations, error) {
-	ops, err := convert(sql)
-	if err != nil {
-		return nil, err
-	}
-
-	if ops == nil {
-		return makeRawSQLOperation(sql), nil
-	}
-
-	return ops, nil
-}
-
-func convert(sql string) (migrations.Operations, error) {
 	tree, err := pgq.Parse(sql)
 	if err != nil {
 		return nil, fmt.Errorf("parse error: %w", err)
 	}
 
+	var migOps migrations.Operations
 	stmts := tree.GetStmts()
-	if len(stmts) != 1 {
-		return nil, fmt.Errorf("%w: got %d statements", ErrStatementCount, len(stmts))
+	for i, stmt := range stmts {
+		if stmt.GetStmt() == nil {
+			continue
+		}
+		node := stmts[i].GetStmt().GetNode()
+		var ops migrations.Operations
+		var err error
+		switch node := (node).(type) {
+		case *pgq.Node_CreateStmt:
+			ops, err = convertCreateStmt(node.CreateStmt)
+		case *pgq.Node_AlterTableStmt:
+			ops, err = convertAlterTableStmt(node.AlterTableStmt)
+		case *pgq.Node_RenameStmt:
+			ops, err = convertRenameStmt(node.RenameStmt)
+		case *pgq.Node_DropStmt:
+			ops, err = convertDropStatement(node.DropStmt)
+		case *pgq.Node_IndexStmt:
+			ops, err = convertCreateIndexStmt(node.IndexStmt)
+		default:
+			// SQL statement cannot be transformed to pgroll operation
+			// so we will use raw SQL operation
+			ops = makeRawSQLOperation(sql, i)
+		}
+		if err != nil {
+			return nil, err
+		}
+		if ops == nil {
+			ops = makeRawSQLOperation(sql, i)
+		}
+		migOps = append(migOps, ops...)
 	}
-	node := stmts[0].GetStmt().GetNode()
-
-	switch node := (node).(type) {
-	case *pgq.Node_CreateStmt:
-		return convertCreateStmt(node.CreateStmt)
-	case *pgq.Node_AlterTableStmt:
-		return convertAlterTableStmt(node.AlterTableStmt)
-	case *pgq.Node_RenameStmt:
-		return convertRenameStmt(node.RenameStmt)
-	case *pgq.Node_DropStmt:
-		return convertDropStatement(node.DropStmt)
-	case *pgq.Node_IndexStmt:
-		return convertCreateIndexStmt(node.IndexStmt)
-	default:
-		return makeRawSQLOperation(sql), nil
-	}
+	return migOps, nil
 }
 
-func makeRawSQLOperation(sql string) migrations.Operations {
+func makeRawSQLOperation(sql string, idx int) migrations.Operations {
+	stmts, err := pgq.SplitWithParser(sql, true)
+	if err != nil {
+		return migrations.Operations{
+			&migrations.OpRawSQL{Up: sql},
+		}
+	}
 	return migrations.Operations{
-		&migrations.OpRawSQL{Up: sql},
+		&migrations.OpRawSQL{Up: stmts[idx]},
 	}
 }

--- a/pkg/sql2pgroll/convert_test.go
+++ b/pkg/sql2pgroll/convert_test.go
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package sql2pgroll_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/xataio/pgroll/pkg/migrations"
+	"github.com/xataio/pgroll/pkg/sql2pgroll"
+)
+
+func TestConvertToMigration(t *testing.T) {
+	tests := map[string]struct {
+		sql         string
+		expectedOps migrations.Operations
+		expectedErr bool
+	}{
+		"empty SQL statement": {
+			sql: "",
+		},
+		"single SQL statement": {
+			sql: "DROP TYPE t1;",
+			expectedOps: migrations.Operations{
+				&migrations.OpRawSQL{
+					Up: "DROP TYPE t1",
+				},
+			},
+		},
+		"single multiline statement with comments": {
+			sql: `CREATE TABLE t1 (
+id INT, -- my id column
+name TEXT -- my name column
+);
+`,
+			expectedOps: migrations.Operations{
+				&migrations.OpCreateTable{
+					Name: "t1",
+					Columns: []migrations.Column{
+						{
+							Name:     "id",
+							Type:     "int",
+							Nullable: true,
+						},
+						{
+							Name:     "name",
+							Type:     "text",
+							Nullable: true,
+						},
+					},
+				},
+			},
+		},
+		"single function definition multiline with comments": {
+			sql: `CREATE OR REPLACE FUNCTION check_password(uname TEXT, pass TEXT)
+RETURNS BOOLEAN AS $$  -- check password for username
+DECLARE passed BOOLEAN;
+BEGIN
+         SELECT  (pwd = $2) INTO passed
+         FROM    pwds  -- from passwords table
+         WHERE   username = $1; -- select password for username
+         RETURN passed;
+END; $$  LANGUAGE plpgsql
+SECURITY DEFINER`,
+			expectedOps: migrations.Operations{
+				&migrations.OpRawSQL{
+					Up: `CREATE OR REPLACE FUNCTION check_password(uname TEXT, pass TEXT)
+RETURNS BOOLEAN AS $$  -- check password for username
+DECLARE passed BOOLEAN;
+BEGIN
+         SELECT  (pwd = $2) INTO passed
+         FROM    pwds  -- from passwords table
+         WHERE   username = $1; -- select password for username
+         RETURN passed;
+END; $$  LANGUAGE plpgsql
+SECURITY DEFINER`,
+				},
+			},
+		},
+		"multiple SQL raw migration statements": {
+			sql: "DROP TYPE t1; DROP TYPE t2;",
+			expectedOps: migrations.Operations{
+				&migrations.OpRawSQL{
+					Up: "DROP TYPE t1",
+				},
+				&migrations.OpRawSQL{
+					Up: "DROP TYPE t2",
+				},
+			},
+		},
+		"multiple SQL migrations to raw and regular pgroll operations": {
+			sql: "CREATE TABLE t1 (id INT); DROP INDEX idx1; DROP TYPE t1; ALTER TABLE t1 ADD COLUMN name TEXT;",
+			expectedOps: migrations.Operations{
+				&migrations.OpCreateTable{
+					Name: "t1",
+					Columns: []migrations.Column{
+						{
+							Name:     "id",
+							Type:     "int",
+							Nullable: true,
+						},
+					},
+				},
+				&migrations.OpDropIndex{
+					Name: "idx1",
+				},
+				&migrations.OpRawSQL{
+					Up: "DROP TYPE t1",
+				},
+				&migrations.OpAddColumn{
+					Table: "t1",
+					Column: migrations.Column{
+						Name:     "name",
+						Type:     "text",
+						Nullable: true,
+					},
+					Up: sql2pgroll.PlaceHolderSQL,
+				},
+			},
+		},
+		"multiple unknown DDL statements": {
+			sql: "CREATE TYPE t1 AS ENUM ('a', 'b'); CREATE DOMAIN d1 AS TEXT; CREATE SCHEMA s1; CREATE EXTENSION e1;",
+			expectedOps: migrations.Operations{
+				&migrations.OpRawSQL{
+					Up: "CREATE TYPE t1 AS ENUM ('a', 'b')",
+				},
+				&migrations.OpRawSQL{
+					Up: "CREATE DOMAIN d1 AS TEXT",
+				},
+				&migrations.OpRawSQL{
+					Up: "CREATE SCHEMA s1",
+				},
+				&migrations.OpRawSQL{
+					Up: "CREATE EXTENSION e1",
+				},
+			},
+		},
+		"multiple empty SQL statements": {
+			sql: ";;",
+		},
+		"multiple statements with empty SQL statement": {
+			sql: "CREATE TABLE t1 (id INT);; DROP TYPE t1;;",
+			expectedOps: migrations.Operations{
+				&migrations.OpCreateTable{
+					Name: "t1",
+					Columns: []migrations.Column{
+						{
+							Name:     "id",
+							Type:     "int",
+							Nullable: true,
+						},
+					},
+				},
+				&migrations.OpRawSQL{
+					Up: "DROP TYPE t1",
+				},
+			},
+		},
+		"multiple multiline statments with comments": {
+			sql: `DROP TYPE t1; -- drop type t1
+DROP INDEX ixd1; -- drop my index
+`,
+			expectedOps: migrations.Operations{
+				&migrations.OpRawSQL{
+					Up: "DROP TYPE t1",
+				},
+				&migrations.OpDropIndex{
+					Name: "ixd1",
+				},
+			},
+		},
+		"multiple statements with function definition multiline with comments": {
+			sql: `DROP TABLE t1; DROP INDEX idx2; CREATE OR REPLACE FUNCTION check_password(uname TEXT, pass TEXT)
+RETURNS BOOLEAN AS $$  -- check password for username
+DECLARE passed BOOLEAN;
+BEGIN
+         SELECT  (pwd = $2) INTO passed
+         FROM    pwds  -- from passwords table
+         WHERE   username = $1; -- select password for username
+         RETURN passed;
+END; $$  LANGUAGE plpgsql
+SECURITY DEFINER;
+CREATE INDEX idx1 ON t1 (id);
+CREATE TYPE t1;`,
+			expectedOps: migrations.Operations{
+				&migrations.OpDropTable{
+					Name: "t1",
+				},
+				&migrations.OpDropIndex{
+					Name: "idx2",
+				},
+				&migrations.OpRawSQL{
+					Up: `CREATE OR REPLACE FUNCTION check_password(uname TEXT, pass TEXT)
+RETURNS BOOLEAN AS $$  -- check password for username
+DECLARE passed BOOLEAN;
+BEGIN
+         SELECT  (pwd = $2) INTO passed
+         FROM    pwds  -- from passwords table
+         WHERE   username = $1; -- select password for username
+         RETURN passed;
+END; $$  LANGUAGE plpgsql
+SECURITY DEFINER`,
+				},
+				&migrations.OpCreateIndex{
+					Name:    "idx1",
+					Table:   "t1",
+					Columns: []string{"id"},
+					Method:  "btree",
+				},
+				&migrations.OpRawSQL{
+					Up: "CREATE TYPE t1",
+				},
+			},
+		},
+		"syntax error in second statement": {
+			sql:         "DROP INDEX idx1; DROP INDX idx2",
+			expectedErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ops, err := sql2pgroll.Convert(tc.sql)
+			if tc.expectedErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+			assert.Len(t, ops, len(tc.expectedOps))
+			assert.Equal(t, tc.expectedOps, ops)
+		})
+	}
+}

--- a/pkg/sql2pgroll/convert_test.go
+++ b/pkg/sql2pgroll/convert_test.go
@@ -18,7 +18,9 @@ func TestConvertToMigration(t *testing.T) {
 		expectedErr bool
 	}{
 		"empty SQL statement": {
-			sql: "",
+			sql:         "",
+			expectedOps: nil,
+			expectedErr: false,
 		},
 		"single SQL statement": {
 			sql: "DROP TYPE t1;",
@@ -27,6 +29,7 @@ func TestConvertToMigration(t *testing.T) {
 					Up: "DROP TYPE t1",
 				},
 			},
+			expectedErr: false,
 		},
 		"single multiline statement with comments": {
 			sql: `CREATE TABLE t1 (
@@ -51,6 +54,7 @@ name TEXT -- my name column
 					},
 				},
 			},
+			expectedErr: false,
 		},
 		"single function definition multiline with comments": {
 			sql: `CREATE OR REPLACE FUNCTION check_password(uname TEXT, pass TEXT)
@@ -88,6 +92,7 @@ SECURITY DEFINER`,
 					Up: "DROP TYPE t2",
 				},
 			},
+			expectedErr: false,
 		},
 		"multiple SQL migrations to raw and regular pgroll operations": {
 			sql: "CREATE TABLE t1 (id INT); DROP INDEX idx1; DROP TYPE t1; ALTER TABLE t1 ADD COLUMN name TEXT;",
@@ -118,6 +123,7 @@ SECURITY DEFINER`,
 					Up: sql2pgroll.PlaceHolderSQL,
 				},
 			},
+			expectedErr: false,
 		},
 		"multiple unknown DDL statements": {
 			sql: "CREATE TYPE t1 AS ENUM ('a', 'b'); CREATE DOMAIN d1 AS TEXT; CREATE SCHEMA s1; CREATE EXTENSION e1;",
@@ -135,6 +141,7 @@ SECURITY DEFINER`,
 					Up: "CREATE EXTENSION e1",
 				},
 			},
+			expectedErr: false,
 		},
 		"multiple empty SQL statements": {
 			sql: ";;",
@@ -156,6 +163,7 @@ SECURITY DEFINER`,
 					Up: "DROP TYPE t1",
 				},
 			},
+			expectedErr: false,
 		},
 		"multiple multiline statments with comments": {
 			sql: `DROP TYPE t1; -- drop type t1
@@ -169,6 +177,7 @@ DROP INDEX ixd1; -- drop my index
 					Name: "ixd1",
 				},
 			},
+			expectedErr: false,
 		},
 		"multiple statements with function definition multiline with comments": {
 			sql: `DROP TABLE t1; DROP INDEX idx2; CREATE OR REPLACE FUNCTION check_password(uname TEXT, pass TEXT)
@@ -212,9 +221,11 @@ SECURITY DEFINER`,
 					Up: "CREATE TYPE t1",
 				},
 			},
+			expectedErr: false,
 		},
 		"syntax error in second statement": {
 			sql:         "DROP INDEX idx1; DROP INDX idx2",
+			expectedOps: nil,
 			expectedErr: true,
 		},
 	}


### PR DESCRIPTION
This PR introduces support for translating multiple SQL statements to pgroll operations in `sql2pgroll.Convert`.

This PR required by the upcoming improvements to support reading complete SQL migration
files produced by ORMs.
