### PR TITLE
Re-read schema in between operations during migration completion

### DIFF
--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -145,17 +145,7 @@ func (o *OpAddColumn) Complete(ctx context.Context, conn db.DB, tr SQLTransforme
 		}
 	}
 
-	// Add the column to the in-memory schema so that Complete steps in subsequent
-	// operations can see the new column.
-	table := s.GetTable(o.Table)
-	if table == nil {
-		return TableDoesNotExistError{Name: o.Table}
-	}
-	table.AddColumn(o.Column.Name, &schema.Column{
-		Name: o.Column.Name,
-	})
-
-	return err
+	return nil
 }
 
 func (o *OpAddColumn) Rollback(ctx context.Context, conn db.DB, tr SQLTransformer, s *schema.Schema) error {

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -60,9 +60,7 @@ func (o *OpCreateTable) Start(ctx context.Context, conn db.DB, latestSchema stri
 }
 
 func (o *OpCreateTable) Complete(ctx context.Context, conn db.DB, tr SQLTransformer, s *schema.Schema) error {
-	// Update the in-memory schema representation with the new table
-	o.updateSchema(s)
-
+	// No-op
 	return nil
 }
 

--- a/pkg/migrations/op_rename_column.go
+++ b/pkg/migrations/op_rename_column.go
@@ -38,20 +38,6 @@ func (o *OpRenameColumn) Complete(ctx context.Context, conn db.DB, tr SQLTransfo
 		pq.QuoteIdentifier(o.From),
 		pq.QuoteIdentifier(o.To)))
 
-	// Update the in-memory schema to reflect the column rename so that it is
-	// visible to subsequent operations' Complete steps.
-	table := s.GetTable(o.Table)
-	table.RenameColumn(o.From, o.To)
-
-	// Update the physical name of the column in the virtual schema now that it
-	// has really been renamed.
-	column := table.GetColumn(o.To)
-	column.Name = o.To
-
-	// Update the name of the column in any constraints that reference the
-	// renamed column.
-	table.RenameConstraintColumns(o.From, o.To)
-
 	return err
 }
 

--- a/pkg/migrations/op_rename_table.go
+++ b/pkg/migrations/op_rename_table.go
@@ -23,15 +23,6 @@ func (o *OpRenameTable) Complete(ctx context.Context, conn db.DB, tr SQLTransfor
 		pq.QuoteIdentifier(o.From),
 		pq.QuoteIdentifier(o.To)))
 
-	// Rename the table in the virtual schema so that the `Complete` methods
-	// of subsequent operations in the same migration can find it.
-	s.RenameTable(o.From, o.To)
-
-	// Update the physical name of the table in the virtual schema now that it
-	// has really been renamed.
-	table := s.GetTable(o.To)
-	table.Name = o.To
-
 	return err
 }
 

--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -194,6 +194,11 @@ func (m *Roll) Complete(ctx context.Context) error {
 			return fmt.Errorf("unable to execute complete operation: %w", err)
 		}
 
+		currentSchema, err = m.state.ReadSchema(ctx, m.schema)
+		if err != nil {
+			return fmt.Errorf("unable to read schema: %w", err)
+		}
+
 		if _, ok := op.(migrations.RequiresSchemaRefreshOperation); ok {
 			if _, ok := op.(*migrations.OpRawSQL); !ok || !m.noVersionSchemaForRawSQL {
 				refreshViews = true


### PR DESCRIPTION
Re-read the schema in between operations when completing a migration. This gives each operation `Complete` method the most up-to-date picture of the schema when invoked.

Stop doing the same thing manually by updating the virtual schema in the few operation `Complete` methods that were doing so.

Part of https://github.com/xataio/pgroll/issues/643