### PR TITLE
Handle errors in `UpdateVirtualSchema`

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -92,15 +92,18 @@ func (m *Migration) Validate(ctx context.Context, s *schema.Schema) error {
 
 // UpdateVirtualSchema updates the in-memory schema representation with the changes
 // made by the migration. No changes are made to the physical database.
-func (m *Migration) UpdateVirtualSchema(ctx context.Context, s *schema.Schema) {
+func (m *Migration) UpdateVirtualSchema(ctx context.Context, s *schema.Schema) error {
 	db := &db.FakeDB{}
 	tr := SQLTransformerFunc(func(sql string) (string, error) { return sql, nil })
 
 	// Run `Start` on each operation using the fake DB. Updates will be made to
 	// the in-memory schema `s` without touching the physical database.
 	for _, op := range m.Operations {
-		op.Start(ctx, db, "", tr, s)
+		if _, err := op.Start(ctx, db, "", tr, s); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // ContainsRawSQLOperation returns true if the migration contains a raw SQL operation

--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -261,7 +261,9 @@ func (m *Roll) Rollback(ctx context.Context) error {
 	}
 
 	// update the in-memory schema with the results of applying the migration
-	migration.UpdateVirtualSchema(ctx, schema)
+	if err := migration.UpdateVirtualSchema(ctx, schema); err != nil {
+		return fmt.Errorf("unable to replay changes to in-memory schema: %w", err)
+	}
 
 	// roll back operations in reverse order
 	for i := len(migration.Operations) - 1; i >= 0; i-- {


### PR DESCRIPTION
Stop swallowing errors in the `UpdateVirtualSchema` method used to replay virtual schema changes prior to migration rollback.