### PR TITLE
Add columns with volatile `DEFAULT`s without an `ACCESS_EXCLUSIVE` table lock

### DIFF
--- a/docs/operations/add_column.mdx
+++ b/docs/operations/add_column.mdx
@@ -39,6 +39,20 @@ Default values are subject to the usual rules for quoting SQL expressions. In pa
 
 **NOTE:** As a special case, the `up` field can be omitted when adding `smallserial`, `serial` and `bigserial` columns.
 
+### Volatile and non-volatile defaults
+
+Postgres handles adding columns with defaults in one of two ways, depending on the [volatility](https://www.postgresql.org/docs/current/xfunc-volatility.html) of the default expression:
+  * For non-volatile defaults, Postgres uses a fast-path optimization to avoid a table rewrite.
+  * For volatile defaults, Postgres must rewrite the table to populate the new column with the default value. This requires a lengthy `ACCESS_EXCLUSIVE` lock on the table.
+
+When adding a new column with a `default`, `pgroll` handles these two cases differently:
+
+For non-volatile defaults, `pgroll` will add the column with the default value directly on migration start.
+
+For volatile defaults, `pgroll` will add the column without the `default` on migration start and use the `up` SQL (which must be set to the same expression as `default`) to populate the column with the 'default' value. The default will be added to the column on migration completion.
+
+By handling defaults in this way, `pgroll` ensures that the lengthy `ACCESS_EXCLUSIVE` lock is avoided when adding columns with volatile defaults.
+
 ## Examples
 
 ### Add multiple columns

--- a/examples/.ledger
+++ b/examples/.ledger
@@ -50,3 +50,4 @@
 50_create_table_with_table_constraint.json
 51_create_table_with_table_foreign_key_constraint.json
 52_create_table_with_exclusion_constraint.json
+53_add_column_with_volatile_default.json

--- a/examples/53_add_column_with_volatile_default.json
+++ b/examples/53_add_column_with_volatile_default.json
@@ -1,0 +1,16 @@
+{
+  "name": "53_add_column_with_volatile_default",
+  "operations": [
+    {
+      "add_column": {
+        "table": "library",
+        "up": "(random() * 1000)::int",
+        "column": {
+          "name": "value",
+          "type": "int",
+          "default": "(random() * 1000)::int"
+        }
+      }
+    }
+  ]
+}

--- a/internal/defaults/fastpath.go
+++ b/internal/defaults/fastpath.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package defaults
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lib/pq"
+	"github.com/xataio/pgroll/pkg/db"
+)
+
+const (
+	cNewTableName  = "_pgroll_temp_fastpath_check"
+	cNewColumnName = "_pgroll_fastpath_check_column"
+)
+
+// UsesFastPath returns true if [defaultExpr] will use the fast-path
+// optimization added in Postgres 11 to avoid taking an `ACCESS_EXCLUSIVE` lock
+// when adding a new column with a `DEFAULT` value.
+//
+// The implementation works by creating a schema-only copy of [tableName],
+// adding a new column with a `DEFAULT` value of [defaultExpr] and checking
+// system catalogs to see if the fast-path optimization was applied.
+func UsesFastPath(ctx context.Context, conn db.DB, tableName, columnType, defaultExpr string) (bool, error) {
+	// Check if we have a real connection or a fake one
+	if _, ok := conn.(*db.FakeDB); ok {
+		return true, nil
+	}
+
+	// Create a schema-only copy of the table
+	_, err := conn.ExecContext(ctx, fmt.Sprintf("CREATE UNLOGGED TABLE %s AS SELECT * FROM %s WHERE false",
+		pq.QuoteIdentifier(cNewTableName),
+		pq.QuoteIdentifier(tableName)))
+	if err != nil {
+		return false, fmt.Errorf("failed to create schema-only copy of table: %w", err)
+	}
+
+	// Ensure that the schema-only copy is removed
+	defer cleanup(ctx, conn)
+
+	// Add a new column with the default value
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s DEFAULT %s",
+		pq.QuoteIdentifier(cNewTableName),
+		pq.QuoteIdentifier(cNewColumnName),
+		columnType,
+		defaultExpr))
+	if err != nil {
+		return false, fmt.Errorf("failed to add column to schema-only copy: %w", err)
+	}
+
+	// Inspect the system catalogs to see if the fast-path optimization was applied
+	rows, err := conn.QueryContext(ctx,
+		"SELECT atthasmissing FROM pg_attribute WHERE attrelid::regclass = $1::regclass AND attname = $2",
+		cNewTableName,
+		cNewColumnName)
+	if err != nil {
+		return false, fmt.Errorf("failed to query pg_attribute: %w", err)
+	}
+	defer rows.Close()
+
+	// Read the `attmissing` column from the result to determine if the fast-path
+	// optimization was applied
+	var hasMissing bool
+	if err := db.ScanFirstValue(rows, &hasMissing); err != nil {
+		return false, fmt.Errorf("failed to read pg_attribute result: %w", err)
+	}
+
+	return hasMissing, nil
+}
+
+func cleanup(ctx context.Context, conn db.DB) {
+	conn.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", pq.QuoteIdentifier(cNewTableName)))
+}

--- a/internal/defaults/fastpath_test.go
+++ b/internal/defaults/fastpath_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package defaults_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xataio/pgroll/pkg/db"
+	"github.com/xataio/pgroll/pkg/roll"
+
+	"github.com/xataio/pgroll/internal/defaults"
+	"github.com/xataio/pgroll/internal/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.SharedTestMain(m)
+}
+
+func TestFastPathDefaults(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		Name             string
+		ColumnType       string
+		Default          string
+		ExpectedFastPath bool
+	}{
+		{
+			Name:             "constant integer",
+			ColumnType:       "int",
+			Default:          "10",
+			ExpectedFastPath: true,
+		},
+		{
+			Name:             "constant boolean",
+			ColumnType:       "bool",
+			Default:          "true",
+			ExpectedFastPath: true,
+		},
+		{
+			Name:             "simple arithmetic",
+			ColumnType:       "int",
+			Default:          "1 + 2 + 3",
+			ExpectedFastPath: true,
+		},
+		{
+			Name:             "random() function",
+			ColumnType:       "double precision",
+			Default:          "random()",
+			ExpectedFastPath: false,
+		},
+		{
+			Name:             "random() function with typecast",
+			ColumnType:       "integer",
+			Default:          "(random()*1000)::integer",
+			ExpectedFastPath: false,
+		},
+		{
+			Name:             "timeofday() function",
+			ColumnType:       "text",
+			Default:          "timeofday()",
+			ExpectedFastPath: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			testutils.WithMigratorAndConnectionToContainer(t, func(mig *roll.Roll, conn *sql.DB) {
+				ctx := context.Background()
+				rdb := &db.RDB{DB: conn}
+
+				createTestTable(t, conn)
+
+				fp, err := defaults.UsesFastPath(ctx, rdb, "test_table", tc.ColumnType, tc.Default)
+				require.NoError(t, err)
+
+				require.Equal(t, tc.ExpectedFastPath, fp)
+			})
+		})
+	}
+}
+
+func createTestTable(t *testing.T, conn *sql.DB) {
+	t.Helper()
+
+	_, err := conn.Exec(`
+    CREATE TABLE test_table (
+      id SERIAL PRIMARY KEY,
+      name TEXT NOT NULL
+    )
+  `)
+	require.NoError(t, err)
+}

--- a/pkg/migrations/column.go
+++ b/pkg/migrations/column.go
@@ -17,6 +17,11 @@ func (c *Column) IsPrimaryKey() bool {
 	return c.Pk
 }
 
+// HasDefault returns true if the column has a default value
+func (c *Column) HasDefault() bool {
+	return c.Default != nil
+}
+
 // HasImplicitDefault returns true if the column has an implicit default value
 func (c *Column) HasImplicitDefault() bool {
 	switch c.Type {

--- a/pkg/migrations/errors.go
+++ b/pkg/migrations/errors.go
@@ -289,3 +289,11 @@ type InvalidGeneratedColumnError struct {
 func (e InvalidGeneratedColumnError) Error() string {
 	return fmt.Sprintf("column %q on table %q is invalid: only one of generated.expression and generated.identity may be set", e.Column, e.Table)
 }
+
+type UpSQLMustBeColumnDefaultError struct {
+	Column string
+}
+
+func (e UpSQLMustBeColumnDefaultError) Error() string {
+	return fmt.Sprintf(`volatile default expression for column %q; "up" must be equal to "default"`, e.Column)
+}


### PR DESCRIPTION
Ensure that adding a new column (with an `add_column` operation) does not take an `ACCESS_EXCLUSIVE` lock on the table even when the column has a volatile `DEFAULT` expression.

Adding a column with a `DEFAULT` expression in Postgres can have one of two different locking behaviours depending on the expression used as the `DEFAULT`:

* For non-volatile `DEFAULT` expressions, the column addition can use the fast-path optimization to add the column default; this is a catalog-only operation and so holds a lock only for a very short time.
* For volatile `DEFAULT` expressions, the fast-path optimization cannot be used; the change requires a full table rewrite - this means holding an `ACCESS_EXCLUSIVE` lock on the table until the rewrite is complete.

This PR makes `add_column` operations aware of this distinction and able to add columns with volatile defaults without taking an `ACCESS_EXCLUSIVE` lock on the table. 

When adding a column with a `DEFAULT`:

* create a temporary schema-only copy of the table.
* add the column to this temporary table
* read the [pg_attribute.atthasmissing](https://www.postgresql.org/docs/current/catalog-pg-attribute.html) system catalog field to determine whether the fast-path optimization was used to add the column `DEFAULT`.
* drop the temporary table

Now the operation knows whether the column can be added using the fast-path `DEFAULT` optimization. In the case where the column can use the optimization, the column can be added with a `DEFAULT` directly. In the case where the fast-path optimization can't be used:

* Add the column without a `DEFAULT` value
* Create an `up` trigger to backfill the column using the column `DEFAULT` expression
* Add the `DEFAULT` to the column on migration completion

This avoids the `ACCESS_EXCLUSIVE` lock; effectively replacing the table rewrite that would have caused it with a backfill operation instead.

If the column to be added has a volatile `DEFAULT` and a  `NOT NULL` constraint, the column must be added with a `NOT NULL ... NOT VALID` constraint to allow the column to be added without a `DEFAULT`; the constraint is validated and upgraded on migration completion.

For a non-volatile `DEFAULT`s, the operation must set `up` to the same expression as is set in `default`. The operation will fail and roll back if they differ.

## References

Volatile vs non-volatile functions:
* https://www.postgresql.org/docs/current/xfunc-volatility.html

The fast-path optimization for non-volatile column `DEFAULT` expressions is explained here:

* https://brandur.org/postgres-default
* https://www.enterprisedb.com/blog/adding-new-table-columns-default-values-postgresql-11

Fixes https://github.com/xataio/pgroll/issues/643