### PR TITLE
Use `sql2pgroll.Convert` in `convert` command to translate SQL statements from migration file and stdin

### DIFF
--- a/cli-definition.json
+++ b/cli-definition.json
@@ -26,7 +26,8 @@
       "example": "",
       "flags": [
         {
-          "name": "migration-name",
+          "name": "name",
+          "shorthand": "n",
           "description": "Name of the migration",
           "default": "{current_timestamp}"
         }

--- a/cli-definition.json
+++ b/cli-definition.json
@@ -21,10 +21,16 @@
     },
     {
       "name": "convert",
-      "short": "Convert SQL statements to pgroll operations from SQL",
+      "short": "Convert SQL statements to a pgroll migration from SQL",
       "use": "convert <path to file with migrations>",
       "example": "",
-      "flags": [],
+      "flags": [
+        {
+          "name": "migration-name",
+          "description": "Name of the migration",
+          "default": "{current_timestamp}"
+        }
+      ],
       "subcommands": [],
       "args": [
         "migration-file"

--- a/cli-definition.json
+++ b/cli-definition.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "convert",
-      "short": "Convert SQL statements to a pgroll migration from SQL",
+      "short": "Convert SQL statements to a pgroll migration",
       "use": "convert <path to file with migrations>",
       "example": "",
       "flags": [

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -32,7 +32,7 @@ func convertCmd() *cobra.Command {
 			}
 			defer reader.Close()
 
-			if migrationName == "" {
+			if migrationName == "{current_timestamp}" {
 				migrationName = time.Now().Format("20060102150405")
 			}
 			migration, err := sqlStatementsToMigration(reader, migrationName)
@@ -48,7 +48,7 @@ func convertCmd() *cobra.Command {
 		},
 	}
 
-	convertCmd.Flags().StringVar(&migrationName, "migration-name", "{current_timestamp}", "Name of the migration")
+	convertCmd.Flags().StringVarP(&migrationName, "name", "n", "{current_timestamp}", "Name of the migration")
 
 	return convertCmd
 }

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -21,7 +21,7 @@ func convertCmd() *cobra.Command {
 	convertCmd := &cobra.Command{
 		Use:       "convert <path to file with migrations>",
 		Short:     "Convert SQL statements to a pgroll migration",
-		Long:      "Convert SQL statements to pgroll migrations from SQL. The command can read SQL statements from stdin or a file",
+		Long:      "Convert SQL statements to a pgroll migration. The command can read SQL statements from stdin or a file",
 		Args:      cobra.MaximumNArgs(1),
 		ValidArgs: []string{"migration-file"},
 		Hidden:    true,

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -3,17 +3,25 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/xataio/pgroll/pkg/migrations"
+	"github.com/xataio/pgroll/pkg/sql2pgroll"
 )
 
 func convertCmd() *cobra.Command {
+	var migrationName string
+
 	convertCmd := &cobra.Command{
 		Use:       "convert <path to file with migrations>",
-		Short:     "Convert SQL statements to pgroll operations from SQL",
+		Short:     "Convert SQL statements to a pgroll migration from SQL",
+		Long:      "Convert SQL statements to pgroll migrations from SQL. The command can read SQL statements from stdin or a file",
 		Args:      cobra.MaximumNArgs(1),
 		ValidArgs: []string{"migration-file"},
 		Hidden:    true,
@@ -24,10 +32,23 @@ func convertCmd() *cobra.Command {
 			}
 			defer reader.Close()
 
-			_, err = scanSQLStatements(reader)
-			return err
+			if migrationName == "" {
+				migrationName = time.Now().Format("20060102150405")
+			}
+			migration, err := sqlStatementsToMigration(reader, migrationName)
+			if err != nil {
+				return err
+			}
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(migration); err != nil {
+				return fmt.Errorf("encode migration: %w", err)
+			}
+			return nil
 		},
 	}
+
+	convertCmd.Flags().StringVar(&migrationName, "migration-name", "{current_timestamp}", "Name of the migration")
 
 	return convertCmd
 }
@@ -39,6 +60,18 @@ func openSQLReader(args []string) (io.ReadCloser, error) {
 	return os.Open(args[0])
 }
 
-func scanSQLStatements(reader io.Reader) ([]string, error) {
-	panic("not implemented")
+func sqlStatementsToMigration(reader io.Reader, name string) (migrations.Migration, error) {
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, reader)
+	if err != nil {
+		return migrations.Migration{}, err
+	}
+	ops, err := sql2pgroll.Convert(buf.String())
+	if err != nil {
+		return migrations.Migration{}, err
+	}
+	return migrations.Migration{
+		Name:       name,
+		Operations: ops,
+	}, nil
 }

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -20,7 +20,7 @@ func convertCmd() *cobra.Command {
 
 	convertCmd := &cobra.Command{
 		Use:       "convert <path to file with migrations>",
-		Short:     "Convert SQL statements to a pgroll migration from SQL",
+		Short:     "Convert SQL statements to a pgroll migration",
 		Long:      "Convert SQL statements to pgroll migrations from SQL. The command can read SQL statements from stdin or a file",
 		Args:      cobra.MaximumNArgs(1),
 		ValidArgs: []string{"migration-file"},


### PR DESCRIPTION
This PR adds the implementation to the subcommand `convert`. From now on,
`pgroll convert` can translate several SQL migrations into a single migration file.

It has one flag called `migration-name` so users can specify a name for their migration.
If they don't, `pgroll` sets the name to the current timestamp.


```sh
$ pgroll convert --help
Convert SQL statements to pgroll migrations. The command can read SQL statements from stdin or a file

Usage:
  pgroll convert <path to file with migrations> [flags]
  Flags:
  -h, --help          help for convert
  -n, --name string   Name of the migration (default "{current_timestamp}")
```

The command expects input either from an SQL migration file or stdin.

```sh
$ echo "CREATE TABLE t1(); alter table t1 add column name text; create type t1 as enum ('1','2','3')" | pgroll convert
{
  "name": "20250220125242",
  "operations": [
    {
      "create_table": {
        "columns": null,
        "name": "t1"
      }
    },
    {
      "add_column": {
        "column": {
          "name": "name",
          "nullable": true,
          "type": "text"
        },
        "table": "t1",
        "up": "TODO: Implement SQL data migration"
      }
    },
    {
      "sql": {
        "up": "create type t1 as enum ('1','2','3')"
      }
    }
  ]
}
```

I am adding more detailed documentation when we expose the command publicly.