### PR TITLE
Improve `create_index` operation with extra index element settings

### DIFF
--- a/docs/operations/create_index.mdx
+++ b/docs/operations/create_index.mdx
@@ -17,10 +17,10 @@ description: A create index operation creates a new index on a set of columns.
         "nulls": "FIRST | LAST",
         "opclass": {
           "name": "operator_class_name",
-          "params": {
-             "param1": "val",
-             "param2": "val"
-          }
+          "params": [
+             "param1=val",
+             "param2=val"
+          ]
         }
       }
     ]

--- a/docs/operations/create_index.mdx
+++ b/docs/operations/create_index.mdx
@@ -10,7 +10,20 @@ description: A create index operation creates a new index on a set of columns.
   "create_index": {
     "table": "name of table on which to define the index",
     "name": "index name",
-    "columns": [ "names of columns on which to define the index" ]
+    "columns": [
+      "column_name": {
+        "collate": "collation name",
+        "sort": "ASC | DESC",
+        "nulls": "FIRST | LAST",
+        "opclass": {
+          "name": "operator_class_name",
+          "params": {
+             "param1": "val",
+             "param2": "val"
+          }
+        }
+      }
+    ]
     "predicate": "conditional expression for defining a partial index",
     "storage_parameters": "comma-separated list of storage parameters",
     "unique": true | false,
@@ -51,3 +64,9 @@ Set storage parameters and index method:
 Create a unique index:
 
 <ExampleSnippet example="42_create_unique_index.json" language="json" />
+
+### Create an index with custom operator class
+
+Create an index with a custom operator class:
+
+<ExampleSnippet example="54_create_index_with_opclass.json" language="json" />

--- a/examples/.ledger
+++ b/examples/.ledger
@@ -51,3 +51,4 @@
 51_create_table_with_table_foreign_key_constraint.json
 52_create_table_with_exclusion_constraint.json
 53_add_column_with_volatile_default.json
+54_create_index_with_opclass.json

--- a/examples/10_create_index.json
+++ b/examples/10_create_index.json
@@ -5,9 +5,9 @@
       "create_index": {
         "name": "idx_fruits_name",
         "table": "fruits",
-        "columns": [
-          "name"
-        ]
+        "columns": {
+          "name": {}
+        }
       }
     }
   ]

--- a/examples/37_create_partial_index.json
+++ b/examples/37_create_partial_index.json
@@ -5,9 +5,9 @@
       "create_index": {
         "name": "idx_fruits_id_gt_10",
         "table": "fruits",
-        "columns": [
-          "id"
-        ],
+        "columns": {
+          "id": {}
+        },
         "predicate": "id > 10"
       }
     }

--- a/examples/38_create_hash_index_with_fillfactor.json
+++ b/examples/38_create_hash_index_with_fillfactor.json
@@ -5,9 +5,9 @@
       "create_index": {
         "name": "idx_fruits_name",
         "table": "fruits",
-        "columns": [
-          "name"
-        ],
+        "columns": {
+          "name": {}
+        },
         "method": "hash",
         "storage_parameters": "fillfactor = 70"
       }

--- a/examples/42_create_unique_index.json
+++ b/examples/42_create_unique_index.json
@@ -5,9 +5,9 @@
       "create_index": {
         "name": "idx_fruits_unique_name",
         "table": "fruits",
-        "columns": [
-          "name"
-        ],
+        "columns": {
+          "name": {}
+        },
         "unique": true
       }
     }

--- a/examples/54_create_index_with_opclass.json
+++ b/examples/54_create_index_with_opclass.json
@@ -1,0 +1,18 @@
+{
+  "name": "54_create_index_with_opclass",
+  "operations": [
+    {
+      "create_index": {
+        "name": "idx_fruits_custom_opclass",
+        "table": "fruits",
+        "columns": {
+          "id": {
+            "opclass": {
+              "name": "int8_ops"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.35.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.35.0
-	github.com/xataio/pg_query_go/v6 v6.0.0-20250124115938-4fa82ad6d036
+	github.com/xataio/pg_query_go/v6 v6.0.0-20250226124908-814e464c6798
 	golang.org/x/tools v0.30.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.35.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.35.0
-	github.com/xataio/pg_query_go/v6 v6.0.0-20250226124908-814e464c6798
+	github.com/xataio/pg_query_go/v6 v6.0.0-20250226155420-277802e03678
 	golang.org/x/tools v0.30.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -223,6 +223,8 @@ github.com/tklauser/numcpus v0.8.0 h1:Mx4Wwe/FjZLeQsK/6kt2EOepwwSl7SmJrK5bV/dXYg
 github.com/tklauser/numcpus v0.8.0/go.mod h1:ZJZlAY+dmR4eut8epnzf0u/VwodKmryxR8txiloSqBE=
 github.com/xataio/pg_query_go/v6 v6.0.0-20250124115938-4fa82ad6d036 h1:QMjBW1XIFUDzyUs/zlYmUo8lNO+hQ4VVt0msFv2AYpw=
 github.com/xataio/pg_query_go/v6 v6.0.0-20250124115938-4fa82ad6d036/go.mod h1:GK6bpfAhPtZb7wG/IccqvnH+cz3cmvvRTkC+MosESGo=
+github.com/xataio/pg_query_go/v6 v6.0.0-20250226124908-814e464c6798 h1:rfb51gWpD24si3My5eiSJBGFKl+uzxN+He53bZCMsOw=
+github.com/xataio/pg_query_go/v6 v6.0.0-20250226124908-814e464c6798/go.mod h1:GK6bpfAhPtZb7wG/IccqvnH+cz3cmvvRTkC+MosESGo=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=

--- a/go.sum
+++ b/go.sum
@@ -225,6 +225,8 @@ github.com/xataio/pg_query_go/v6 v6.0.0-20250124115938-4fa82ad6d036 h1:QMjBW1XIF
 github.com/xataio/pg_query_go/v6 v6.0.0-20250124115938-4fa82ad6d036/go.mod h1:GK6bpfAhPtZb7wG/IccqvnH+cz3cmvvRTkC+MosESGo=
 github.com/xataio/pg_query_go/v6 v6.0.0-20250226124908-814e464c6798 h1:rfb51gWpD24si3My5eiSJBGFKl+uzxN+He53bZCMsOw=
 github.com/xataio/pg_query_go/v6 v6.0.0-20250226124908-814e464c6798/go.mod h1:GK6bpfAhPtZb7wG/IccqvnH+cz3cmvvRTkC+MosESGo=
+github.com/xataio/pg_query_go/v6 v6.0.0-20250226155420-277802e03678 h1:jNslWEyKOXeYi7wZfkcSfsR/slEemAU5rVKBvkNnSsg=
+github.com/xataio/pg_query_go/v6 v6.0.0-20250226155420-277802e03678/go.mod h1:GK6bpfAhPtZb7wG/IccqvnH+cz3cmvvRTkC+MosESGo=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=

--- a/pkg/migrations/op_common_test.go
+++ b/pkg/migrations/op_common_test.go
@@ -373,7 +373,7 @@ func indexDescendingExists(t *testing.T, db *sql.DB, schema, table, index string
     FROM pg_index
     WHERE indrelid = $1::regclass
     AND indexrelid = $2::regclass`,
-		fmt.Sprintf("%s.%s", schema, table), index).Scan(&flags)
+		fmt.Sprintf("%s.%s", schema, table), fmt.Sprintf("%s.%s", schema, index)).Scan(&flags)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/migrations/op_common_test.go
+++ b/pkg/migrations/op_common_test.go
@@ -309,6 +309,13 @@ func IndexMustExist(t *testing.T, db *sql.DB, schema, table, index string) {
 	}
 }
 
+func IndexDescendingMustExist(t *testing.T, db *sql.DB, table, index string, columnIdx int) {
+	t.Helper()
+	if !indexDescendingExists(t, db, table, index, columnIdx) {
+		t.Fatalf("Expected index %q to exist", index)
+	}
+}
+
 func IndexMustNotExist(t *testing.T, db *sql.DB, schema, table, index string) {
 	t.Helper()
 	if indexExists(t, db, schema, table, index) {
@@ -355,6 +362,25 @@ func indexExists(t *testing.T, db *sql.DB, schema, table, index string) bool {
 	}
 
 	return exists
+}
+
+func indexDescendingExists(t *testing.T, db *sql.DB, table, index string, columnIdx int) bool {
+	t.Helper()
+
+	var flags []uint8
+	err := db.QueryRow(`
+    SELECT indoption
+    FROM pg_index
+    WHERE indrelid = $1::regclass
+    AND indexrelid = $2::regclass`,
+		table, index).Scan(&flags)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check if index is descending using the 1st bit of the flags
+	indoptionDesc := uint8(1)
+	return flags[columnIdx]&indoptionDesc == 1
 }
 
 func CheckIndexDefinition(t *testing.T, db *sql.DB, schema, table, index, expectedDefinition string) {

--- a/pkg/migrations/op_common_test.go
+++ b/pkg/migrations/op_common_test.go
@@ -309,9 +309,9 @@ func IndexMustExist(t *testing.T, db *sql.DB, schema, table, index string) {
 	}
 }
 
-func IndexDescendingMustExist(t *testing.T, db *sql.DB, table, index string, columnIdx int) {
+func IndexDescendingMustExist(t *testing.T, db *sql.DB, schema, table, index string, columnIdx int) {
 	t.Helper()
-	if !indexDescendingExists(t, db, table, index, columnIdx) {
+	if !indexDescendingExists(t, db, schema, table, index, columnIdx) {
 		t.Fatalf("Expected index %q to exist", index)
 	}
 }
@@ -364,7 +364,7 @@ func indexExists(t *testing.T, db *sql.DB, schema, table, index string) bool {
 	return exists
 }
 
-func indexDescendingExists(t *testing.T, db *sql.DB, table, index string, columnIdx int) bool {
+func indexDescendingExists(t *testing.T, db *sql.DB, schema, table, index string, columnIdx int) bool {
 	t.Helper()
 
 	var flags []uint8
@@ -373,7 +373,7 @@ func indexDescendingExists(t *testing.T, db *sql.DB, table, index string, column
     FROM pg_index
     WHERE indrelid = $1::regclass
     AND indexrelid = $2::regclass`,
-		table, index).Scan(&flags)
+		fmt.Sprintf("%s.%s", schema, table), index).Scan(&flags)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/migrations/op_create_index.go
+++ b/pkg/migrations/op_create_index.go
@@ -100,12 +100,7 @@ func (o *OpCreateIndex) Validate(ctx context.Context, s *schema.Schema) error {
 		return TableDoesNotExistError{Name: o.Table}
 	}
 
-	if len(o.Columns) == 0 {
-		return FieldRequiredError{Name: "columns"}
-	}
-
-	cols := map[string]IndexField(o.Columns)
-	for column := range cols {
+	for column := range map[string]IndexField(o.Columns) {
 		if table.GetColumn(column) == nil {
 			return ColumnDoesNotExistError{Table: o.Table, Name: column}
 		}

--- a/pkg/migrations/op_create_index_test.go
+++ b/pkg/migrations/op_create_index_test.go
@@ -201,7 +201,7 @@ func TestCreateIndex(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The index has been created on the underlying table.
-				IndexDescendingMustExist(t, db, "users", "idx_users_name", 0)
+				IndexDescendingMustExist(t, db, schema, "users", "idx_users_name", 0)
 			},
 			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// The index has been dropped from the the underlying table.

--- a/pkg/migrations/op_create_index_test.go
+++ b/pkg/migrations/op_create_index_test.go
@@ -45,7 +45,7 @@ func TestCreateIndex(t *testing.T) {
 						&migrations.OpCreateIndex{
 							Name:    "idx_users_name",
 							Table:   "users",
-							Columns: []string{"name"},
+							Columns: map[string]migrations.IndexElemSettings{"name": {}},
 						},
 					},
 				},
@@ -91,7 +91,7 @@ func TestCreateIndex(t *testing.T) {
 						&migrations.OpCreateIndex{
 							Name:    "idx_USERS_name",
 							Table:   "users",
-							Columns: []string{"name"},
+							Columns: map[string]migrations.IndexElemSettings{"name": {}},
 						},
 					},
 				},
@@ -142,7 +142,7 @@ func TestCreateIndex(t *testing.T) {
 						&migrations.OpCreateIndex{
 							Name:      "idx_users_name_after_2019",
 							Table:     "users",
-							Columns:   []string{"registered_at_year"},
+							Columns:   map[string]migrations.IndexElemSettings{"registered_at_year": {}},
 							Predicate: "registered_at_year > 2019",
 						},
 					},
@@ -156,6 +156,52 @@ func TestCreateIndex(t *testing.T) {
 			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// The index has been dropped from the the underlying table.
 				IndexMustNotExist(t, db, schema, "users", "idx_users_name_after_2019")
+			},
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+				// Complete is a no-op.
+			},
+		},
+		{
+			name: "create index with descending order",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "serial",
+									Pk:   true,
+								},
+								{
+									Name:     "name",
+									Type:     "varchar(255)",
+									Nullable: false,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_create_index",
+					Operations: migrations.Operations{
+						&migrations.OpCreateIndex{
+							Name:    "idx_users_name",
+							Table:   "users",
+							Columns: map[string]migrations.IndexElemSettings{"name": {Sort: migrations.IndexElemSettingsSortDESC}},
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
+				// The index has been created on the underlying table.
+				IndexMustExist(t, db, schema, "users", "idx_users_name")
+			},
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
+				// The index has been dropped from the the underlying table.
+				IndexMustNotExist(t, db, schema, "users", "idx_users_name")
 			},
 			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// Complete is a no-op.
@@ -195,7 +241,7 @@ func TestCreateIndex(t *testing.T) {
 						&migrations.OpCreateIndex{
 							Name:    invalidName,
 							Table:   "users",
-							Columns: []string{"registered_at_year"},
+							Columns: map[string]migrations.IndexElemSettings{"registered_at_year": {}},
 						},
 					},
 				},
@@ -234,7 +280,7 @@ func TestCreateIndex(t *testing.T) {
 						&migrations.OpCreateIndex{
 							Name:              "idx_users_name_hash",
 							Table:             "users",
-							Columns:           []string{"name"},
+							Columns:           map[string]migrations.IndexElemSettings{"name": {}},
 							Method:            migrations.OpCreateIndexMethodHash,
 							StorageParameters: "fillfactor = 70",
 						},
@@ -295,7 +341,7 @@ func TestCreateIndexOnMultipleColumns(t *testing.T) {
 					&migrations.OpCreateIndex{
 						Name:    "idx_users_name_email",
 						Table:   "users",
-						Columns: []string{"name", "email"},
+						Columns: map[string]migrations.IndexElemSettings{"name": {}, "email": {}},
 					},
 				},
 			},
@@ -350,7 +396,7 @@ func TestCreateIndexInMultiOperationMigrations(t *testing.T) {
 						},
 						&migrations.OpCreateIndex{
 							Table:   "products",
-							Columns: []string{"name"},
+							Columns: map[string]migrations.IndexElemSettings{"name": {}},
 							Name:    "idx_products_name",
 						},
 					},
@@ -406,7 +452,7 @@ func TestCreateIndexInMultiOperationMigrations(t *testing.T) {
 						},
 						&migrations.OpCreateIndex{
 							Table:   "products",
-							Columns: []string{"item_name"},
+							Columns: map[string]migrations.IndexElemSettings{"item_name": {}},
 							Name:    "idx_products_item_name",
 						},
 					},
@@ -449,7 +495,7 @@ func TestCreateIndexInMultiOperationMigrations(t *testing.T) {
 						&migrations.OpCreateIndex{
 							Name:    "idx_users_name",
 							Table:   "users",
-							Columns: []string{"name"},
+							Columns: map[string]migrations.IndexElemSettings{"name": {}},
 						},
 					},
 				},
@@ -505,7 +551,7 @@ func TestCreateIndexInMultiOperationMigrations(t *testing.T) {
 						&migrations.OpCreateIndex{
 							Name:    "idx_users_age",
 							Table:   "users",
-							Columns: []string{"age"},
+							Columns: map[string]migrations.IndexElemSettings{"age": {}},
 						},
 					},
 				},

--- a/pkg/migrations/op_create_index_test.go
+++ b/pkg/migrations/op_create_index_test.go
@@ -45,7 +45,7 @@ func TestCreateIndex(t *testing.T) {
 						&migrations.OpCreateIndex{
 							Name:    "idx_users_name",
 							Table:   "users",
-							Columns: map[string]migrations.IndexElemSettings{"name": {}},
+							Columns: map[string]migrations.IndexField{"name": {}},
 						},
 					},
 				},
@@ -91,7 +91,7 @@ func TestCreateIndex(t *testing.T) {
 						&migrations.OpCreateIndex{
 							Name:    "idx_USERS_name",
 							Table:   "users",
-							Columns: map[string]migrations.IndexElemSettings{"name": {}},
+							Columns: map[string]migrations.IndexField{"name": {}},
 						},
 					},
 				},
@@ -142,7 +142,7 @@ func TestCreateIndex(t *testing.T) {
 						&migrations.OpCreateIndex{
 							Name:      "idx_users_name_after_2019",
 							Table:     "users",
-							Columns:   map[string]migrations.IndexElemSettings{"registered_at_year": {}},
+							Columns:   map[string]migrations.IndexField{"registered_at_year": {}},
 							Predicate: "registered_at_year > 2019",
 						},
 					},
@@ -188,16 +188,20 @@ func TestCreateIndex(t *testing.T) {
 					Name: "02_create_index",
 					Operations: migrations.Operations{
 						&migrations.OpCreateIndex{
-							Name:    "idx_users_name",
-							Table:   "users",
-							Columns: map[string]migrations.IndexElemSettings{"name": {Sort: migrations.IndexElemSettingsSortDESC}},
+							Name:  "idx_users_name",
+							Table: "users",
+							Columns: map[string]migrations.IndexField{
+								"name": {
+									Sort: migrations.IndexFieldSortDESC,
+								},
+							},
 						},
 					},
 				},
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The index has been created on the underlying table.
-				IndexMustExist(t, db, schema, "users", "idx_users_name")
+				IndexDescendingMustExist(t, db, "users", "idx_users_name", 0)
 			},
 			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
 				// The index has been dropped from the the underlying table.
@@ -241,7 +245,7 @@ func TestCreateIndex(t *testing.T) {
 						&migrations.OpCreateIndex{
 							Name:    invalidName,
 							Table:   "users",
-							Columns: map[string]migrations.IndexElemSettings{"registered_at_year": {}},
+							Columns: map[string]migrations.IndexField{"registered_at_year": {}},
 						},
 					},
 				},
@@ -280,7 +284,7 @@ func TestCreateIndex(t *testing.T) {
 						&migrations.OpCreateIndex{
 							Name:              "idx_users_name_hash",
 							Table:             "users",
-							Columns:           map[string]migrations.IndexElemSettings{"name": {}},
+							Columns:           map[string]migrations.IndexField{"name": {}},
 							Method:            migrations.OpCreateIndexMethodHash,
 							StorageParameters: "fillfactor = 70",
 						},
@@ -341,7 +345,7 @@ func TestCreateIndexOnMultipleColumns(t *testing.T) {
 					&migrations.OpCreateIndex{
 						Name:    "idx_users_name_email",
 						Table:   "users",
-						Columns: map[string]migrations.IndexElemSettings{"name": {}, "email": {}},
+						Columns: map[string]migrations.IndexField{"name": {}, "email": {}},
 					},
 				},
 			},
@@ -396,7 +400,7 @@ func TestCreateIndexInMultiOperationMigrations(t *testing.T) {
 						},
 						&migrations.OpCreateIndex{
 							Table:   "products",
-							Columns: map[string]migrations.IndexElemSettings{"name": {}},
+							Columns: map[string]migrations.IndexField{"name": {}},
 							Name:    "idx_products_name",
 						},
 					},
@@ -452,7 +456,7 @@ func TestCreateIndexInMultiOperationMigrations(t *testing.T) {
 						},
 						&migrations.OpCreateIndex{
 							Table:   "products",
-							Columns: map[string]migrations.IndexElemSettings{"item_name": {}},
+							Columns: map[string]migrations.IndexField{"item_name": {}},
 							Name:    "idx_products_item_name",
 						},
 					},
@@ -495,7 +499,7 @@ func TestCreateIndexInMultiOperationMigrations(t *testing.T) {
 						&migrations.OpCreateIndex{
 							Name:    "idx_users_name",
 							Table:   "users",
-							Columns: map[string]migrations.IndexElemSettings{"name": {}},
+							Columns: map[string]migrations.IndexField{"name": {}},
 						},
 					},
 				},
@@ -551,7 +555,7 @@ func TestCreateIndexInMultiOperationMigrations(t *testing.T) {
 						&migrations.OpCreateIndex{
 							Name:    "idx_users_age",
 							Table:   "users",
-							Columns: map[string]migrations.IndexElemSettings{"age": {}},
+							Columns: map[string]migrations.IndexField{"age": {}},
 						},
 					},
 				},

--- a/pkg/migrations/op_drop_index_test.go
+++ b/pkg/migrations/op_drop_index_test.go
@@ -42,7 +42,7 @@ func TestDropIndex(t *testing.T) {
 						&migrations.OpCreateIndex{
 							Name:    "idx_users_name",
 							Table:   "users",
-							Columns: map[string]migrations.IndexElemSettings{"name": {}},
+							Columns: map[string]migrations.IndexField{"name": {}},
 						},
 					},
 				},
@@ -96,7 +96,7 @@ func TestDropIndex(t *testing.T) {
 						&migrations.OpCreateIndex{
 							Name:    "idx_USERS_name",
 							Table:   "users",
-							Columns: map[string]migrations.IndexElemSettings{"name": {}},
+							Columns: map[string]migrations.IndexField{"name": {}},
 						},
 					},
 				},

--- a/pkg/migrations/op_drop_index_test.go
+++ b/pkg/migrations/op_drop_index_test.go
@@ -42,7 +42,7 @@ func TestDropIndex(t *testing.T) {
 						&migrations.OpCreateIndex{
 							Name:    "idx_users_name",
 							Table:   "users",
-							Columns: []string{"name"},
+							Columns: map[string]migrations.IndexElemSettings{"name": {}},
 						},
 					},
 				},
@@ -96,7 +96,7 @@ func TestDropIndex(t *testing.T) {
 						&migrations.OpCreateIndex{
 							Name:    "idx_USERS_name",
 							Table:   "users",
-							Columns: []string{"name"},
+							Columns: map[string]migrations.IndexElemSettings{"name": {}},
 						},
 					},
 				},

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -181,6 +181,40 @@ type ForeignKeyReference struct {
 	Table string `json:"table"`
 }
 
+type IndexElemSettings struct {
+	// Collate corresponds to the JSON schema field "collate".
+	Collate string `json:"collate,omitempty"`
+
+	// Nulls corresponds to the JSON schema field "nulls".
+	Nulls *IndexElemSettingsNulls `json:"nulls,omitempty"`
+
+	// Opclass corresponds to the JSON schema field "opclass".
+	Opclass *IndexElemSettingsOpclass `json:"opclass,omitempty"`
+
+	// Sort corresponds to the JSON schema field "sort".
+	Sort IndexElemSettingsSort `json:"sort,omitempty"`
+}
+
+type IndexElemSettingsNulls string
+
+const IndexElemSettingsNullsFIRST IndexElemSettingsNulls = "FIRST"
+const IndexElemSettingsNullsLAST IndexElemSettingsNulls = "LAST"
+
+type IndexElemSettingsOpclass struct {
+	// Name corresponds to the JSON schema field "name".
+	Name string `json:"name,omitempty"`
+
+	// Params corresponds to the JSON schema field "params".
+	Params IndexElemSettingsOpclassParams `json:"params,omitempty"`
+}
+
+type IndexElemSettingsOpclassParams map[string]interface{}
+
+type IndexElemSettingsSort string
+
+const IndexElemSettingsSortASC IndexElemSettingsSort = "ASC"
+const IndexElemSettingsSortDESC IndexElemSettingsSort = "DESC"
+
 // Map of column names to down SQL expressions
 type MultiColumnDownSQL map[string]string
 
@@ -275,8 +309,11 @@ const OpCreateConstraintTypeUnique OpCreateConstraintType = "unique"
 
 // Create index operation
 type OpCreateIndex struct {
-	// Names of columns on which to define the index
-	Columns []string `json:"columns"`
+	// Names and settings of columns on which to define the index
+	Columns OpCreateIndexColumns `json:"columns,omitempty"`
+
+	// Advanced columns configuration
+	Elements []string `json:"elements,omitempty"`
 
 	// Index method to use for the index: btree, hash, gist, spgist, gin, brin
 	Method OpCreateIndexMethod `json:"method,omitempty"`
@@ -296,6 +333,9 @@ type OpCreateIndex struct {
 	// Indicates if the index is unique
 	Unique bool `json:"unique,omitempty"`
 }
+
+// Names and settings of columns on which to define the index
+type OpCreateIndexColumns map[string]IndexElemSettings
 
 type OpCreateIndexMethod string
 

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -181,6 +181,7 @@ type ForeignKeyReference struct {
 	Table string `json:"table"`
 }
 
+// Index field and its settings
 type IndexField struct {
 	// Collation for the index element
 	Collate string `json:"collate,omitempty"`
@@ -310,9 +311,6 @@ const OpCreateConstraintTypeUnique OpCreateConstraintType = "unique"
 type OpCreateIndex struct {
 	// Names and settings of columns on which to define the index
 	Columns OpCreateIndexColumns `json:"columns"`
-
-	// Advanced columns configuration
-	Elements []string `json:"elements,omitempty"`
 
 	// Index method to use for the index: btree, hash, gist, spgist, gin, brin
 	Method OpCreateIndexMethod `json:"method,omitempty"`

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -181,39 +181,38 @@ type ForeignKeyReference struct {
 	Table string `json:"table"`
 }
 
-type IndexElemSettings struct {
-	// Collate corresponds to the JSON schema field "collate".
+type IndexField struct {
+	// Collation for the index element
 	Collate string `json:"collate,omitempty"`
 
-	// Nulls corresponds to the JSON schema field "nulls".
-	Nulls *IndexElemSettingsNulls `json:"nulls,omitempty"`
+	// Nulls ordering, default is first if ascending, last if descending
+	Nulls *IndexFieldNulls `json:"nulls,omitempty"`
 
-	// Opclass corresponds to the JSON schema field "opclass".
-	Opclass *IndexElemSettingsOpclass `json:"opclass,omitempty"`
+	// Operator class settings
+	Opclass *IndexFieldOpclass `json:"opclass,omitempty"`
 
-	// Sort corresponds to the JSON schema field "sort".
-	Sort IndexElemSettingsSort `json:"sort,omitempty"`
+	// Sort order, default is ascending (ASC)
+	Sort IndexFieldSort `json:"sort,omitempty"`
 }
 
-type IndexElemSettingsNulls string
+type IndexFieldNulls string
 
-const IndexElemSettingsNullsFIRST IndexElemSettingsNulls = "FIRST"
-const IndexElemSettingsNullsLAST IndexElemSettingsNulls = "LAST"
+const IndexFieldNullsFIRST IndexFieldNulls = "FIRST"
+const IndexFieldNullsLAST IndexFieldNulls = "LAST"
 
-type IndexElemSettingsOpclass struct {
-	// Name corresponds to the JSON schema field "name".
+// Operator class settings
+type IndexFieldOpclass struct {
+	// Name of the operator class
 	Name string `json:"name,omitempty"`
 
-	// Params corresponds to the JSON schema field "params".
-	Params IndexElemSettingsOpclassParams `json:"params,omitempty"`
+	// Operator class parameters
+	Params []string `json:"params,omitempty"`
 }
 
-type IndexElemSettingsOpclassParams map[string]interface{}
+type IndexFieldSort string
 
-type IndexElemSettingsSort string
-
-const IndexElemSettingsSortASC IndexElemSettingsSort = "ASC"
-const IndexElemSettingsSortDESC IndexElemSettingsSort = "DESC"
+const IndexFieldSortASC IndexFieldSort = "ASC"
+const IndexFieldSortDESC IndexFieldSort = "DESC"
 
 // Map of column names to down SQL expressions
 type MultiColumnDownSQL map[string]string
@@ -335,7 +334,7 @@ type OpCreateIndex struct {
 }
 
 // Names and settings of columns on which to define the index
-type OpCreateIndexColumns map[string]IndexElemSettings
+type OpCreateIndexColumns map[string]IndexField
 
 type OpCreateIndexMethod string
 

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -309,7 +309,7 @@ const OpCreateConstraintTypeUnique OpCreateConstraintType = "unique"
 // Create index operation
 type OpCreateIndex struct {
 	// Names and settings of columns on which to define the index
-	Columns OpCreateIndexColumns `json:"columns,omitempty"`
+	Columns OpCreateIndexColumns `json:"columns"`
 
 	// Advanced columns configuration
 	Elements []string `json:"elements,omitempty"`

--- a/pkg/sql2pgroll/convert_test.go
+++ b/pkg/sql2pgroll/convert_test.go
@@ -214,7 +214,7 @@ SECURITY DEFINER`,
 				&migrations.OpCreateIndex{
 					Name:    "idx1",
 					Table:   "t1",
-					Columns: map[string]migrations.IndexElemSettings{"id": {}},
+					Columns: map[string]migrations.IndexField{"id": {}},
 					Method:  "btree",
 				},
 				&migrations.OpRawSQL{

--- a/pkg/sql2pgroll/convert_test.go
+++ b/pkg/sql2pgroll/convert_test.go
@@ -214,7 +214,7 @@ SECURITY DEFINER`,
 				&migrations.OpCreateIndex{
 					Name:    "idx1",
 					Table:   "t1",
-					Columns: []string{"id"},
+					Columns: map[string]migrations.IndexElemSettings{"id": {}},
 					Method:  "btree",
 				},
 				&migrations.OpRawSQL{

--- a/pkg/sql2pgroll/create_index_test.go
+++ b/pkg/sql2pgroll/create_index_test.go
@@ -26,7 +26,7 @@ func TestConvertCreateIndexStatements(t *testing.T) {
 		},
 		{
 			sql:        "CREATE INDEX idx_name ON foo (bar ASC)",
-			expectedOp: expect.CreateIndexOp1,
+			expectedOp: expect.CreateIndexOp12,
 		},
 		{
 			sql:        "CREATE INDEX idx_name ON foo USING btree (bar)",
@@ -112,6 +112,34 @@ func TestConvertCreateIndexStatements(t *testing.T) {
 			sql:        "CREATE INDEX idx_name ON foo (bar) WITH (fillfactor = 70, deduplicate_items = true)",
 			expectedOp: expect.CreateIndexOpWithStorageParam("fillfactor=70, deduplicate_items=true"),
 		},
+		{
+			sql:        "CREATE INDEX idx_name ON foo (bar COLLATE en_us)",
+			expectedOp: expect.CreateIndexOp6,
+		},
+		{
+			sql:        "CREATE INDEX idx_name ON foo (bar DESC)",
+			expectedOp: expect.CreateIndexOp7,
+		},
+		{
+			sql:        "CREATE INDEX idx_name ON foo (bar NULLS FIRST)",
+			expectedOp: expect.CreateIndexOp8,
+		},
+		{
+			sql:        "CREATE INDEX idx_name ON foo (bar NULLS LAST)",
+			expectedOp: expect.CreateIndexOp9,
+		},
+		{
+			sql:        "CREATE INDEX idx_name ON foo (bar opclass (test = test))",
+			expectedOp: expect.CreateIndexOp10,
+		},
+		{
+			sql:        "CREATE INDEX idx_name ON foo (bar opclass1, baz opclass2)",
+			expectedOp: expect.CreateIndexOp11,
+		},
+		{
+			sql:        "CREATE INDEX idx_name ON foo (bar opclass1, baz opclass2)",
+			expectedOp: expect.CreateIndexOp11,
+		},
 	}
 
 	for _, tc := range tests {
@@ -132,18 +160,8 @@ func TestUnconvertableCreateIndexStatements(t *testing.T) {
 	tests := []string{
 		// Tablespaces are not supported
 		"CREATE INDEX idx_name ON foo (bar) TABLESPACE baz",
-		// Index collations are not supported
-		"CREATE INDEX idx_name ON foo (bar COLLATE en_US)",
-		// Index ordering other than the default ASC is not supported
-		"CREATE INDEX idx_name ON foo (bar DESC)",
-		// Index nulls ordering is not supported
-		"CREATE INDEX idx_name ON foo (bar NULLS FIRST)",
-		"CREATE INDEX idx_name ON foo (bar NULLS LAST)",
 		// Included columns are not supported
 		"CREATE INDEX idx_name ON foo (bar) INCLUDE (baz)",
-		// opclasses with or without options are not supported
-		"CREATE INDEX idx_name ON foo (bar opclass (test = test))",
-		"CREATE INDEX idx_name ON foo (bar opclass)",
 		// Indexes created with ONLY are not supported
 		"CREATE INDEX idx_name ON ONLY foo (bar)",
 		// Indexes with NULLS NOT DISTINCT are not supported

--- a/pkg/sql2pgroll/expect/create_index.go
+++ b/pkg/sql2pgroll/expect/create_index.go
@@ -9,7 +9,7 @@ import (
 var CreateIndexOp1 = &migrations.OpCreateIndex{
 	Name:    "idx_name",
 	Table:   "foo",
-	Columns: []string{"bar"},
+	Columns: map[string]migrations.IndexElemSettings{"bar": {}},
 	Method:  migrations.OpCreateIndexMethodBtree,
 }
 
@@ -21,7 +21,7 @@ func CreateIndexOp1WithMethod(method string) *migrations.OpCreateIndex {
 	return &migrations.OpCreateIndex{
 		Name:    "idx_name",
 		Table:   "foo",
-		Columns: []string{"bar"},
+		Columns: map[string]migrations.IndexElemSettings{"bar": {}},
 		Method:  parsed,
 	}
 }
@@ -29,21 +29,21 @@ func CreateIndexOp1WithMethod(method string) *migrations.OpCreateIndex {
 var CreateIndexOp2 = &migrations.OpCreateIndex{
 	Name:    "idx_name",
 	Table:   "schema.foo",
-	Columns: []string{"bar"},
+	Columns: map[string]migrations.IndexElemSettings{"bar": {}},
 	Method:  migrations.OpCreateIndexMethodBtree,
 }
 
 var CreateIndexOp3 = &migrations.OpCreateIndex{
 	Name:    "idx_name",
 	Table:   "foo",
-	Columns: []string{"bar", "baz"},
+	Columns: map[string]migrations.IndexElemSettings{"bar": {}, "baz": {}},
 	Method:  migrations.OpCreateIndexMethodBtree,
 }
 
 var CreateIndexOp4 = &migrations.OpCreateIndex{
 	Name:    "idx_name",
 	Table:   "foo",
-	Columns: []string{"bar"},
+	Columns: map[string]migrations.IndexElemSettings{"bar": {}},
 	Method:  migrations.OpCreateIndexMethodBtree,
 	Unique:  true,
 }
@@ -51,16 +51,78 @@ var CreateIndexOp4 = &migrations.OpCreateIndex{
 var CreateIndexOp5 = &migrations.OpCreateIndex{
 	Name:      "idx_name",
 	Table:     "foo",
-	Columns:   []string{"bar"},
+	Columns:   map[string]migrations.IndexElemSettings{"bar": {}},
 	Method:    migrations.OpCreateIndexMethodBtree,
 	Predicate: "foo > 0",
+}
+
+var CreateIndexOp6 = &migrations.OpCreateIndex{
+	Name:    "idx_name",
+	Table:   "foo",
+	Method:  migrations.OpCreateIndexMethodBtree,
+	Columns: map[string]migrations.IndexElemSettings{"bar": {Collate: "en_us"}},
+}
+
+var CreateIndexOp7 = &migrations.OpCreateIndex{
+	Name:    "idx_name",
+	Table:   "foo",
+	Method:  migrations.OpCreateIndexMethodBtree,
+	Columns: map[string]migrations.IndexElemSettings{"bar": {Sort: migrations.IndexElemSettingsSortDESC}},
+}
+
+var CreateIndexOp8 = &migrations.OpCreateIndex{
+	Name:    "idx_name",
+	Table:   "foo",
+	Method:  migrations.OpCreateIndexMethodBtree,
+	Columns: map[string]migrations.IndexElemSettings{"bar": {Nulls: ptr(migrations.IndexElemSettingsNullsFIRST)}},
+}
+
+var CreateIndexOp9 = &migrations.OpCreateIndex{
+	Name:    "idx_name",
+	Table:   "foo",
+	Method:  migrations.OpCreateIndexMethodBtree,
+	Columns: map[string]migrations.IndexElemSettings{"bar": {Nulls: ptr(migrations.IndexElemSettingsNullsLAST)}},
+}
+
+var CreateIndexOp10 = &migrations.OpCreateIndex{
+	Name:    "idx_name",
+	Table:   "foo",
+	Method:  migrations.OpCreateIndexMethodBtree,
+	Columns: map[string]migrations.IndexElemSettings{"bar": {Opclass: ptr(migrations.IndexElemSettingsOpclass{Name: "opclass", Params: map[string]any{"test": "test"}})}},
+}
+
+var CreateIndexOp11 = &migrations.OpCreateIndex{
+	Name:   "idx_name",
+	Table:  "foo",
+	Method: migrations.OpCreateIndexMethodBtree,
+	Columns: map[string]migrations.IndexElemSettings{
+		"bar": {
+			Opclass: ptr(migrations.IndexElemSettingsOpclass{
+				Name:   "opclass1",
+				Params: map[string]any{},
+			}),
+		},
+		"baz": {
+			Opclass: ptr(migrations.IndexElemSettingsOpclass{
+				Name:   "opclass2",
+				Params: map[string]any{},
+			}),
+		},
+	},
+}
+
+var CreateIndexOp12 = &migrations.OpCreateIndex{
+	Name:    "idx_name",
+	Table:   "foo",
+	Columns: map[string]migrations.IndexElemSettings{"bar": {Sort: migrations.IndexElemSettingsSortASC}},
+	Method:  migrations.OpCreateIndexMethodBtree,
 }
 
 func CreateIndexOpWithStorageParam(param string) *migrations.OpCreateIndex {
 	return &migrations.OpCreateIndex{
 		Name:              "idx_name",
 		Table:             "foo",
-		Columns:           []string{"bar"},
+		Columns:           map[string]migrations.IndexElemSettings{"bar": {}},
 		Method:            migrations.OpCreateIndexMethodBtree,
 		StorageParameters: param,
 	}

--- a/pkg/sql2pgroll/expect/create_index.go
+++ b/pkg/sql2pgroll/expect/create_index.go
@@ -9,7 +9,7 @@ import (
 var CreateIndexOp1 = &migrations.OpCreateIndex{
 	Name:    "idx_name",
 	Table:   "foo",
-	Columns: map[string]migrations.IndexElemSettings{"bar": {}},
+	Columns: map[string]migrations.IndexField{"bar": {}},
 	Method:  migrations.OpCreateIndexMethodBtree,
 }
 
@@ -21,7 +21,7 @@ func CreateIndexOp1WithMethod(method string) *migrations.OpCreateIndex {
 	return &migrations.OpCreateIndex{
 		Name:    "idx_name",
 		Table:   "foo",
-		Columns: map[string]migrations.IndexElemSettings{"bar": {}},
+		Columns: map[string]migrations.IndexField{"bar": {}},
 		Method:  parsed,
 	}
 }
@@ -29,21 +29,21 @@ func CreateIndexOp1WithMethod(method string) *migrations.OpCreateIndex {
 var CreateIndexOp2 = &migrations.OpCreateIndex{
 	Name:    "idx_name",
 	Table:   "schema.foo",
-	Columns: map[string]migrations.IndexElemSettings{"bar": {}},
+	Columns: map[string]migrations.IndexField{"bar": {}},
 	Method:  migrations.OpCreateIndexMethodBtree,
 }
 
 var CreateIndexOp3 = &migrations.OpCreateIndex{
 	Name:    "idx_name",
 	Table:   "foo",
-	Columns: map[string]migrations.IndexElemSettings{"bar": {}, "baz": {}},
+	Columns: map[string]migrations.IndexField{"bar": {}, "baz": {}},
 	Method:  migrations.OpCreateIndexMethodBtree,
 }
 
 var CreateIndexOp4 = &migrations.OpCreateIndex{
 	Name:    "idx_name",
 	Table:   "foo",
-	Columns: map[string]migrations.IndexElemSettings{"bar": {}},
+	Columns: map[string]migrations.IndexField{"bar": {}},
 	Method:  migrations.OpCreateIndexMethodBtree,
 	Unique:  true,
 }
@@ -51,78 +51,105 @@ var CreateIndexOp4 = &migrations.OpCreateIndex{
 var CreateIndexOp5 = &migrations.OpCreateIndex{
 	Name:      "idx_name",
 	Table:     "foo",
-	Columns:   map[string]migrations.IndexElemSettings{"bar": {}},
+	Columns:   map[string]migrations.IndexField{"bar": {}},
 	Method:    migrations.OpCreateIndexMethodBtree,
 	Predicate: "foo > 0",
 }
 
 var CreateIndexOp6 = &migrations.OpCreateIndex{
-	Name:    "idx_name",
-	Table:   "foo",
-	Method:  migrations.OpCreateIndexMethodBtree,
-	Columns: map[string]migrations.IndexElemSettings{"bar": {Collate: "en_us"}},
+	Name:   "idx_name",
+	Table:  "foo",
+	Method: migrations.OpCreateIndexMethodBtree,
+	Columns: map[string]migrations.IndexField{
+		"bar": {
+			Collate: "en_us",
+		},
+	},
 }
 
 var CreateIndexOp7 = &migrations.OpCreateIndex{
-	Name:    "idx_name",
-	Table:   "foo",
-	Method:  migrations.OpCreateIndexMethodBtree,
-	Columns: map[string]migrations.IndexElemSettings{"bar": {Sort: migrations.IndexElemSettingsSortDESC}},
+	Name:   "idx_name",
+	Table:  "foo",
+	Method: migrations.OpCreateIndexMethodBtree,
+	Columns: map[string]migrations.IndexField{
+		"bar": {
+			Sort: migrations.IndexFieldSortDESC,
+		},
+	},
 }
 
 var CreateIndexOp8 = &migrations.OpCreateIndex{
-	Name:    "idx_name",
-	Table:   "foo",
-	Method:  migrations.OpCreateIndexMethodBtree,
-	Columns: map[string]migrations.IndexElemSettings{"bar": {Nulls: ptr(migrations.IndexElemSettingsNullsFIRST)}},
+	Name:   "idx_name",
+	Table:  "foo",
+	Method: migrations.OpCreateIndexMethodBtree,
+	Columns: map[string]migrations.IndexField{
+		"bar": {
+			Nulls: ptr(migrations.IndexFieldNullsFIRST),
+		},
+	},
 }
 
 var CreateIndexOp9 = &migrations.OpCreateIndex{
-	Name:    "idx_name",
-	Table:   "foo",
-	Method:  migrations.OpCreateIndexMethodBtree,
-	Columns: map[string]migrations.IndexElemSettings{"bar": {Nulls: ptr(migrations.IndexElemSettingsNullsLAST)}},
+	Name:   "idx_name",
+	Table:  "foo",
+	Method: migrations.OpCreateIndexMethodBtree,
+	Columns: map[string]migrations.IndexField{
+		"bar": {
+			Nulls: ptr(migrations.IndexFieldNullsLAST),
+		},
+	},
 }
 
 var CreateIndexOp10 = &migrations.OpCreateIndex{
-	Name:    "idx_name",
-	Table:   "foo",
-	Method:  migrations.OpCreateIndexMethodBtree,
-	Columns: map[string]migrations.IndexElemSettings{"bar": {Opclass: ptr(migrations.IndexElemSettingsOpclass{Name: "opclass", Params: map[string]any{"test": "test"}})}},
+	Name:   "idx_name",
+	Table:  "foo",
+	Method: migrations.OpCreateIndexMethodBtree,
+	Columns: map[string]migrations.IndexField{
+		"bar": {
+			Opclass: ptr(migrations.IndexFieldOpclass{
+				Name:   "opclass",
+				Params: []string{"test=test"},
+			}),
+		},
+	},
 }
 
 var CreateIndexOp11 = &migrations.OpCreateIndex{
 	Name:   "idx_name",
 	Table:  "foo",
 	Method: migrations.OpCreateIndexMethodBtree,
-	Columns: map[string]migrations.IndexElemSettings{
+	Columns: map[string]migrations.IndexField{
 		"bar": {
-			Opclass: ptr(migrations.IndexElemSettingsOpclass{
+			Opclass: ptr(migrations.IndexFieldOpclass{
 				Name:   "opclass1",
-				Params: map[string]any{},
+				Params: []string{},
 			}),
 		},
 		"baz": {
-			Opclass: ptr(migrations.IndexElemSettingsOpclass{
+			Opclass: ptr(migrations.IndexFieldOpclass{
 				Name:   "opclass2",
-				Params: map[string]any{},
+				Params: []string{},
 			}),
 		},
 	},
 }
 
 var CreateIndexOp12 = &migrations.OpCreateIndex{
-	Name:    "idx_name",
-	Table:   "foo",
-	Columns: map[string]migrations.IndexElemSettings{"bar": {Sort: migrations.IndexElemSettingsSortASC}},
-	Method:  migrations.OpCreateIndexMethodBtree,
+	Name:  "idx_name",
+	Table: "foo",
+	Columns: map[string]migrations.IndexField{
+		"bar": {
+			Sort: migrations.IndexFieldSortASC,
+		},
+	},
+	Method: migrations.OpCreateIndexMethodBtree,
 }
 
 func CreateIndexOpWithStorageParam(param string) *migrations.OpCreateIndex {
 	return &migrations.OpCreateIndex{
 		Name:              "idx_name",
 		Table:             "foo",
-		Columns:           map[string]migrations.IndexElemSettings{"bar": {}},
+		Columns:           map[string]migrations.IndexField{"bar": {}},
 		Method:            migrations.OpCreateIndexMethodBtree,
 		StorageParameters: param,
 	}

--- a/schema.json
+++ b/schema.json
@@ -419,36 +419,44 @@
       "required": ["name", "type"],
       "type": "object"
     },
-    "IndexElemSettings": {
+    "IndexField": {
       "additionalProperties": false,
       "type": "object",
       "properties": {
         "collate": {
           "type": "string",
+          "description": "Collation for the index element",
           "default": ""
         },
         "sort": {
+          "description": "Sort order, default is ascending (ASC)",
           "type": "string",
           "enum": ["ASC", "DESC"],
           "default": ""
         },
         "opclass": {
           "type": "object",
+          "description": "Operator class settings",
           "additionalProperties": false,
           "properties": {
             "name": {
+              "description": "Name of the operator class",
               "type": "string",
               "default": ""
             },
             "params": {
-              "type": "object",
+              "description": "Operator class parameters",
+              "type": "array",
               "additionalProperties": true,
-              "default": {}
+              "items": {
+                "type": "string"
+              }
             }
           }
         },
         "nulls": {
           "type": "string",
+          "description": "Nulls ordering, default is first if ascending, last if descending",
           "enum": ["FIRST", "LAST"]
         }
       }
@@ -575,8 +583,8 @@
           "description": "Names and settings of columns on which to define the index",
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/IndexElemSettings",
-            "description": "Index element settings"
+            "$ref": "#/$defs/IndexField",
+            "description": "Index field settings"
           }
         },
         "name": {

--- a/schema.json
+++ b/schema.json
@@ -624,7 +624,7 @@
           "default": false
         }
       },
-      "required": ["name", "table"],
+      "required": ["columns", "name", "table"],
       "type": "object"
     },
     "OpCreateTable": {

--- a/schema.json
+++ b/schema.json
@@ -421,6 +421,7 @@
     },
     "IndexField": {
       "additionalProperties": false,
+      "description": "Index field and its settings",
       "type": "object",
       "properties": {
         "collate": {
@@ -610,13 +611,6 @@
           "description": "Storage parameters for the index",
           "type": "string",
           "default": ""
-        },
-        "elements": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Advanced columns configuration"
         },
         "unique": {
           "description": "Indicates if the index is unique",

--- a/schema.json
+++ b/schema.json
@@ -419,6 +419,40 @@
       "required": ["name", "type"],
       "type": "object"
     },
+    "IndexElemSettings": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "collate": {
+          "type": "string",
+          "default": ""
+        },
+        "sort": {
+          "type": "string",
+          "enum": ["ASC", "DESC"],
+          "default": ""
+        },
+        "opclass": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "default": ""
+            },
+            "params": {
+              "type": "object",
+              "additionalProperties": true,
+              "default": {}
+            }
+          }
+        },
+        "nulls": {
+          "type": "string",
+          "enum": ["FIRST", "LAST"]
+        }
+      }
+    },
     "OpAddColumn": {
       "additionalProperties": false,
       "description": "Add column operation",
@@ -538,11 +572,12 @@
       "description": "Create index operation",
       "properties": {
         "columns": {
-          "description": "Names of columns on which to define the index",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
+          "description": "Names and settings of columns on which to define the index",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/IndexElemSettings",
+            "description": "Index element settings"
+          }
         },
         "name": {
           "description": "Index name",
@@ -568,13 +603,20 @@
           "type": "string",
           "default": ""
         },
+        "elements": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Advanced columns configuration"
+        },
         "unique": {
           "description": "Indicates if the index is unique",
           "type": "boolean",
           "default": false
         }
       },
-      "required": ["columns", "name", "table"],
+      "required": ["name", "table"],
       "type": "object"
     },
     "OpCreateTable": {


### PR DESCRIPTION
This PR adds a breaking change to `create_index` operation. From now on `columns` does not accept a list of column names. Instead it expects a map, so we can support for additional index elements settings.

New settings:
* `collation`: name of the collation to use on the column
* `opclass`: `opclass.name` sets the name of the operator class and `opclass.params` expects a KV pairs for operator class settings
* `sort`: change the ordering (`ASC` or `DESC`)
* `nulls`: change the position of null values in the index (`FIRST` or `LAST`)
