### PR TITLE
New constraint type in `create_constraint`: `primary_key`

### DIFF
--- a/pkg/migrations/op_create_constraint.go
+++ b/pkg/migrations/op_create_constraint.go
@@ -85,14 +85,12 @@ func (o *OpCreateConstraint) Start(ctx context.Context, conn db.DB, latestSchema
 	}
 
 	switch o.Type {
-	case OpCreateConstraintTypeUnique:
+	case OpCreateConstraintTypeUnique, OpCreateConstraintTypePrimaryKey:
 		return table, NewCreateUniqueIndexConcurrentlyAction(conn, s.Name, o.Name, table.Name, temporaryNames(o.Columns)...).Execute(ctx)
 	case OpCreateConstraintTypeCheck:
 		return table, o.addCheckConstraint(ctx, conn, table.Name)
 	case OpCreateConstraintTypeForeignKey:
 		return table, o.addForeignKeyConstraint(ctx, conn, table)
-	case OpCreateConstraintTypePrimaryKey:
-		return table, createUniqueIndexConcurrently(ctx, conn, s.Name, o.Name, table.Name, temporaryNames(o.Columns))
 	}
 
 	return table, nil

--- a/pkg/migrations/op_create_constraint_test.go
+++ b/pkg/migrations/op_create_constraint_test.go
@@ -739,7 +739,7 @@ func TestCreateConstraint(t *testing.T) {
 			},
 		},
 		{
-			name: "create primary constraint on multiple columns",
+			name: "create primary key constraint on multiple columns",
 			migrations: []migrations.Migration{
 				{
 					Name: "01_add_table",
@@ -797,18 +797,18 @@ func TestCreateConstraint(t *testing.T) {
 				MustInsert(t, db, schema, "01_add_table", "users", map[string]string{
 					"id1":  "00000000-0000-0000-0000-000000000001",
 					"id2":  "00000000-0000-0000-0000-000000000002",
-					"name": "alice",
+					"name": "bob",
 				})
 
-				// Inserting values into the new schema that violate uniqueness should fail.
 				MustInsert(t, db, schema, "02_create_constraint", "users", map[string]string{
 					"id1":  "00000000-0000-0000-0000-000000000003",
 					"id2":  "00000000-0000-0000-0000-000000000004",
-					"name": "bob",
+					"name": "alice",
 				})
+				// Inserting values into the new schema that violate uniqueness should fail.
 				MustNotInsert(t, db, schema, "02_create_constraint", "users", map[string]string{
-					"id1":  "00000000-0000-0000-0000-000000000001",
-					"id2":  "00000000-0000-0000-0000-000000000002",
+					"id1":  "00000000-0000-0000-0000-000000000003",
+					"id2":  "00000000-0000-0000-0000-000000000004",
 					"name": "bob",
 				}, testutils.UniqueViolationErrorCode)
 			},

--- a/pkg/migrations/op_create_constraint_test.go
+++ b/pkg/migrations/op_create_constraint_test.go
@@ -738,6 +738,92 @@ func TestCreateConstraint(t *testing.T) {
 				}, testutils.UniqueViolationErrorCode)
 			},
 		},
+		{
+			name: "create primary constraint on multiple columns",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_add_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "users",
+							Columns: []migrations.Column{
+								{
+									Name: "id1",
+									Type: "uuid",
+								},
+								{
+									Name: "id2",
+									Type: "uuid",
+								},
+								{
+									Name:     "name",
+									Type:     "varchar(255)",
+									Nullable: false,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_create_constraint",
+					Operations: migrations.Operations{
+						&migrations.OpCreateConstraint{
+							Name:    "id_pkey",
+							Table:   "users",
+							Type:    "primary_key",
+							Columns: []string{"id1", "id2"},
+							Up: map[string]string{
+								"id1": "gen_random_uuid()",
+								"id2": "gen_random_uuid()",
+							},
+							Down: map[string]string{
+								"id1": "id1",
+								"id2": "id2",
+							},
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
+				// The index has been created on the underlying table.
+				IndexMustExist(t, db, schema, "users", "id_pkey")
+
+				// Inserting values into the old schema that violate uniqueness should succeed.
+				MustInsert(t, db, schema, "01_add_table", "users", map[string]string{
+					"id1":  "00000000-0000-0000-0000-000000000001",
+					"id2":  "00000000-0000-0000-0000-000000000002",
+					"name": "alice",
+				})
+				MustInsert(t, db, schema, "01_add_table", "users", map[string]string{
+					"id1":  "00000000-0000-0000-0000-000000000001",
+					"id2":  "00000000-0000-0000-0000-000000000002",
+					"name": "alice",
+				})
+
+				// Inserting values into the new schema that violate uniqueness should fail.
+				MustInsert(t, db, schema, "02_create_constraint", "users", map[string]string{
+					"id1":  "00000000-0000-0000-0000-000000000003",
+					"id2":  "00000000-0000-0000-0000-000000000004",
+					"name": "bob",
+				})
+				MustNotInsert(t, db, schema, "02_create_constraint", "users", map[string]string{
+					"id1":  "00000000-0000-0000-0000-000000000001",
+					"id2":  "00000000-0000-0000-0000-000000000002",
+					"name": "bob",
+				}, testutils.UniqueViolationErrorCode)
+			},
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
+				// The index has been dropped from the the underlying table.
+				IndexMustNotExist(t, db, schema, "users", "id_pkey")
+
+				// Functions, triggers and temporary columns are dropped.
+				TableMustBeCleanedUp(t, db, schema, "users", "id1")
+				TableMustBeCleanedUp(t, db, schema, "users", "id2")
+			},
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+				PrimaryKeyConstraintMustExist(t, db, schema, "users", "id_pkey")
+			},
+		},
 	})
 }
 

--- a/pkg/migrations/types.go
+++ b/pkg/migrations/types.go
@@ -282,6 +282,9 @@ type OpCreateConstraint struct {
 	// SQL expressions for down migrations
 	Down MultiColumnDownSQL `json:"down"`
 
+	// IndexParameters corresponds to the JSON schema field "index_parameters".
+	IndexParameters *OpCreateConstraintIndexParameters `json:"index_parameters,omitempty"`
+
 	// Name of the constraint
 	Name string `json:"name"`
 
@@ -301,10 +304,22 @@ type OpCreateConstraint struct {
 	Up MultiColumnUpSQL `json:"up"`
 }
 
+type OpCreateConstraintIndexParameters struct {
+	// IncludeColumns corresponds to the JSON schema field "include_columns".
+	IncludeColumns []string `json:"include_columns,omitempty"`
+
+	// StorageParameters corresponds to the JSON schema field "storage_parameters".
+	StorageParameters string `json:"storage_parameters,omitempty"`
+
+	// Tablespace corresponds to the JSON schema field "tablespace".
+	Tablespace string `json:"tablespace,omitempty"`
+}
+
 type OpCreateConstraintType string
 
 const OpCreateConstraintTypeCheck OpCreateConstraintType = "check"
 const OpCreateConstraintTypeForeignKey OpCreateConstraintType = "foreign_key"
+const OpCreateConstraintTypePrimaryKey OpCreateConstraintType = "primary_key"
 const OpCreateConstraintTypeUnique OpCreateConstraintType = "unique"
 
 // Create index operation

--- a/schema.json
+++ b/schema.json
@@ -837,7 +837,7 @@
         "type": {
           "description": "Type of the constraint",
           "type": "string",
-          "enum": ["unique", "check", "foreign_key"]
+          "enum": ["unique", "check", "foreign_key", "primary_key"]
         },
         "check": {
           "description": "Check constraint expression",
@@ -847,6 +847,26 @@
           "description": "Do not propagate constraint to child tables",
           "type": "boolean",
           "default": false
+        },
+        "index_parameters": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "tablespace": {
+              "type": "string",
+              "default": ""
+            },
+            "storage_parameters": {
+              "type": "string",
+              "default": ""
+            },
+            "include_columns": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
         },
         "references": {
           "description": "Reference to the foreign key",
@@ -877,6 +897,9 @@
               },
               "no_inherit": {
                 "const": false
+              },
+              "index_params": {
+                "const": {}
               }
             },
             "required": ["columns", "references"]
@@ -897,9 +920,35 @@
               },
               "references": {
                 "const": {}
+              },
+              "index_params": {
+                "const": {}
               }
             },
             "required": ["check"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "primary_key"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "check": {
+                "const": ""
+              },
+              "no_inherit": {
+                "const": false
+              },
+              "references": {
+                "const": {}
+              }
+            },
+            "required": ["columns"]
           }
         }
       ],


### PR DESCRIPTION
This PR adds a new constraint type to `create_constraint` named `primary_key`.
This new option lets you add a primary key constraint to existing tables.
