### PR TITLE
Use `-tags=netgo,osusergo` when building `pgroll` binary

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,6 +9,8 @@ before:
 builds:
   - id: build_cgo
     binary: pgroll
+    flags:
+      - -tags=netgo,osusergo
     ldflags:
       - -X github.com/xataio/pgroll/cmd.Version={{ .Version }}
     env:


### PR DESCRIPTION
Ensure that static linking is possible by using native go implementations of `net` package functionality. This avoids the requirement to dynamically link against `glibc` system libraries.

See for example:

* https://www.dimoulis.net/posts/static-compilation-of-go-programs/
* https://mt165.co.uk/blog/static-link-go/