### PR TITLE
Publish `convert` command and add new documentation page

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -24,7 +24,6 @@ func convertCmd() *cobra.Command {
 		Long:      "Convert SQL statements to a pgroll migration. The command can read SQL statements from stdin or a file",
 		Args:      cobra.MaximumNArgs(1),
 		ValidArgs: []string{"migration-file"},
-		Hidden:    true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reader, err := openSQLReader(args)
 			if err != nil {

--- a/docs/cli/convert.mdx
+++ b/docs/cli/convert.mdx
@@ -1,0 +1,26 @@
+---
+title: Convert
+description: Convert SQL migration files to a pgroll migration
+---
+
+## Command
+
+```
+$ pgroll convert --name create_first_table /path/to/migration.sql
+```
+
+This reads the SQL statements from `/path/to/migration.sql` and translates them into a `pgroll` migration.
+The name of the migration is going to be `create_first_table`.
+
+### Read SQL statements from stdin with `pgroll convert`
+
+If file name is not specified `pgroll convert` reads the SQL statements from stdin.
+
+```
+$ cat 'CREATE TABLE my_table(name text);' | pgroll convert --name create_first_table
+```
+
+<Warning>
+The generated pgroll migrations might include `up` and `down` migrations. Those must be filled in manually because
+right now pgroll cannot guess the correct up and down migrations.
+</Warning>


### PR DESCRIPTION
This PR publishes the new subcommand `convert`, and adds a new
documentation page.

This must be merged before the v0.10.0 release.
