### PR TITLE
Docs preview

### DIFF
--- a/.github/workflows/docs_preview.yaml
+++ b/.github/workflows/docs_preview.yaml
@@ -25,12 +25,11 @@ jobs:
               environment: 'Docs Preview',
               description: 'Creating a preview',
             });
-            console.log('zzz', deployment)
             if (deployment.status !== 201) {
               throw new Error('Failed to create deployment');
             }
             await github.rest.repos.createDeploymentStatus({
-              deployment_id: deployment.id,
+              deployment_id: deployment.data.id,
               owner: repoOwner,
               repo,
               state: 'success',

--- a/.github/workflows/docs_preview.yaml
+++ b/.github/workflows/docs_preview.yaml
@@ -1,9 +1,7 @@
 name: Docs Preview
-
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-
 jobs:
   docs-preview:
     runs-on: ubuntu-latest
@@ -13,16 +11,18 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
+            const { owner: repoOwner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const prOwner = pr.head.repo.full_name === context.repo.full_name ? repoOwner : pr.head.repo.owner.login;
+            const branch = pr.head.ref;
             const deployment = await github.rest.repos.createDeployment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: context.payload.pull_request.head.sha,
+              owner: repoOwner,
+              repo,
+              ref: pr.head.sha,
               state: 'success',
               description: 'Created a preview',
-              environment_url: 'https://pgroll.com/next/preview-path?path=/docs/${{ context.payload.pull_request.head.repo.owner.login }}:${{ context.payload.pull_request.head.ref }}/'
+              environment_url: `https://pgroll.com/next/preview-path?path=/docs/${prOwner}:${branch}/`
             });
-
             if (deployment.status !== 201) {
               throw new Error('Failed to create deployment');
             }
-

--- a/.github/workflows/docs_preview.yaml
+++ b/.github/workflows/docs_preview.yaml
@@ -25,6 +25,7 @@ jobs:
               environment: 'Docs Preview',
               description: 'Creating a preview',
             });
+            console.log('zzz', deployment)
             if (deployment.status !== 201) {
               throw new Error('Failed to create deployment');
             }

--- a/.github/workflows/docs_preview.yaml
+++ b/.github/workflows/docs_preview.yaml
@@ -19,6 +19,7 @@ jobs:
               owner: repoOwner,
               repo,
               ref: pr.head.sha,
+              required_contexts: [], // Don't require checks to pass
               state: 'success',
               description: 'Created a preview',
               environment_url: `https://pgroll.com/next/preview-path?path=/docs/${prOwner}:${branch}/`

--- a/.github/workflows/docs_preview.yaml
+++ b/.github/workflows/docs_preview.yaml
@@ -1,0 +1,28 @@
+name: Docs Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  docs-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Docs Preview GitHub Deployment
+        id: create_deployment
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.payload.pull_request.head.sha,
+              state: 'success',
+              description: 'Created a preview',
+              environment_url: 'https://pgroll.com/next/preview-path?path=/docs/${{ context.payload.pull_request.head.repo.owner.login }}:${{ context.payload.pull_request.head.ref }}/'
+            });
+
+            if (deployment.status !== 201) {
+              throw new Error('Failed to create deployment');
+            }
+

--- a/.github/workflows/docs_preview.yaml
+++ b/.github/workflows/docs_preview.yaml
@@ -20,6 +20,7 @@ jobs:
               repo,
               ref: pr.head.sha,
               required_contexts: [], // Don't require checks to pass
+              environment: 'Docs Preview',
               state: 'success',
               description: 'Created a preview',
               environment_url: `https://pgroll.com/next/preview-path?path=/docs/${prOwner}:${branch}/`

--- a/.github/workflows/docs_preview.yaml
+++ b/.github/workflows/docs_preview.yaml
@@ -15,16 +15,25 @@ jobs:
             const pr = context.payload.pull_request;
             const prOwner = pr.head.repo.full_name === context.repo.full_name ? repoOwner : pr.head.repo.owner.login;
             const branch = pr.head.ref;
+            const previewUrl = `https://pgroll.com/next/preview-path?path=/docs/${prOwner}:${branch}/`
+
             const deployment = await github.rest.repos.createDeployment({
               owner: repoOwner,
               repo,
               ref: pr.head.sha,
               required_contexts: [], // Don't require checks to pass
               environment: 'Docs Preview',
-              state: 'success',
-              description: 'Created a preview',
-              environment_url: `https://pgroll.com/next/preview-path?path=/docs/${prOwner}:${branch}/`
+              description: 'Creating a preview',
             });
             if (deployment.status !== 201) {
               throw new Error('Failed to create deployment');
             }
+            await github.rest.repos.createDeploymentStatus({
+              deployment_id: deployment.id,
+              owner: repoOwner,
+              repo,
+              state: 'success',
+              description: 'Created a preview',
+              environment_url: previewUrl
+            });
+


### PR DESCRIPTION
Creates a 'View deployment' button on the pull request which links to pgroll.com docs for this branch. For this PR it is:

https://pgroll.com/next/preview-path?path=/docs/xataio:docs-preview/

It's not working for forks (I think you'd need to update some settings on the repo). Example: https://github.com/xataio/pgroll/pull/704