### PR TITLE
Improve error message during JSON unmarshalling

### DIFF
--- a/pkg/migrations/op_common.go
+++ b/pkg/migrations/op_common.go
@@ -7,6 +7,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
+	"slices"
+	"strings"
 )
 
 type OpName string
@@ -79,7 +82,8 @@ func (v *Operations) UnmarshalJSON(data []byte) error {
 		var opName OpName
 		var logBody json.RawMessage
 		if len(opObj) != 1 {
-			return fmt.Errorf("invalid migration: %v", opObj)
+			return fmt.Errorf("multiple keys in operation object at index %d: %v",
+				i, strings.Join(slices.Collect(maps.Keys(opObj)), ", "))
 		}
 		for k, v := range opObj {
 			opName = OpName(k)


### PR DESCRIPTION
When an operation object has multiple keys, like this:

```json
{
  "name": "31_add_constraint",
  "operations": [
    {
      "alter_column": {
        "table": "items",
        "column": "assignee",
        "check": {
          "name": "items_assignee_check",
          "constraint": "assignee IN ('alice', 'bob')"
        }
      },
      "up": "(SELECT CASE WHEN assignee in ('alice', 'bob') THEN assignee ELSE 'alice' END)",
      "down": "assignee"
    }
  ]
}
```
improve the error message to show the keys that are present in the object.

(Here `up` and `down` need to be moved inside `alter_column`).

Previously, the error messasge was of no use:

```
Error: reading migration file: invalid migration: map[alter_column:[123 10 32 32 32 32 32 32 32 32 34 116 97 98 108 101 34 58 32 34 105 116 101 109 115 34 44 10 32 32 32 32 32 32 32 32 34 99 111 108 117 109 110 34 58 32 34 97 115 115 105 103 110 101 101 34 44 10 32 32 32 32 32 32 32 32 34 99 104 101 99 107 34 58 32 123 10 32 32 32 32 32 32 32 32 32 32 34 110 97 109 101 34 58 32 34 105 116 101 109 115 95 97 115 115 105 103 110 101 101 95 99 104 101 99 107 34 44 10 32 32 32 32 32 32 32 32 32 32 34 99 111 110 115 116 114 97 105 110 116 34 58 32 34 97 115 115 105 103 110 101 101 32 73 78 32 40 39 97 108 105 99 101 39 44 32 39 98 111 98 39 41 34 10 32 32 32 32 32 32 32 32 125 10 32 32 32 32 32 32 125] down:[34 97 115 115 105 103 110 101 101 34] up:[34 40 83 69 76 69 67 84 32 67 65 83 69 32 87 72 69 78 32 97 115 115 105 103 110 101 101 32 105 110 32 40 39 97 108 105 99 101 39 44 32 39 98 111 98 39 41 32 84 72 69 78 32 97 115 115 105 103 110 101 101 32 69 76 83 69 32 39 97 108 105 99 101 39 32 69 78 68 41 34]]
```

The new error message is:

```
Error: reading migration file: multiple keys in operation object at index 0: alter_column, up, down
```