### PR TITLE
Introduce `DBAction` interface and refactoring of column dropping

### DIFF
--- a/pkg/migrations/dbactions.go
+++ b/pkg/migrations/dbactions.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package migrations
 
 import (

--- a/pkg/migrations/dbactions.go
+++ b/pkg/migrations/dbactions.go
@@ -1,0 +1,47 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/lib/pq"
+	"github.com/xataio/pgroll/pkg/db"
+)
+
+// DBAction is an interface for common database actions
+// pgroll runs during migrations.
+type DBAction interface {
+	Execute(context.Context) error
+}
+
+// dropColumnAction is a DBAction that drops one or more columns from a table.
+type dropColumnAction struct {
+	conn db.DB
+
+	table   string
+	columns []string
+}
+
+func NewDropColumnAction(conn db.DB, table string, columns ...string) *dropColumnAction {
+	return &dropColumnAction{
+		conn:    conn,
+		table:   table,
+		columns: columns,
+	}
+}
+
+func (a *dropColumnAction) Execute(ctx context.Context) error {
+	_, err := a.conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s %s",
+		pq.QuoteIdentifier(a.table),
+		a.dropMultipleColumns()))
+	return err
+}
+
+func (a *dropColumnAction) dropMultipleColumns() string {
+	cols := make([]string, len(a.columns))
+	for i, col := range a.columns {
+		cols[i] = "DROP COLUMN IF EXISTS " + pq.QuoteIdentifier(col)
+	}
+	return strings.Join(cols, ", ")
+}

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -119,6 +119,9 @@ func (o *OpAddColumn) Complete(ctx context.Context, conn db.DB, s *schema.Schema
 
 	removeBackfillColumn := NewDropColumnAction(conn, o.Table, CNeedsBackfillColumn)
 	err = removeBackfillColumn.Execute(ctx)
+	if err != nil {
+		return err
+	}
 
 	if !o.Column.IsNullable() && o.Column.Default == nil {
 		err = upgradeNotNullConstraintToNotNullAttribute(ctx, conn, o.Table, o.Column.Name)

--- a/pkg/migrations/op_create_constraint.go
+++ b/pkg/migrations/op_create_constraint.go
@@ -307,11 +307,3 @@ func temporaryNames(columns []string) []string {
 	}
 	return names
 }
-
-func quotedTemporaryNames(columns []string) []string {
-	names := make([]string, len(columns))
-	for i, col := range columns {
-		names[i] = pq.QuoteIdentifier(TemporaryName(col))
-	}
-	return names
-}

--- a/pkg/migrations/op_create_constraint.go
+++ b/pkg/migrations/op_create_constraint.go
@@ -133,11 +133,8 @@ func (o *OpCreateConstraint) Complete(ctx context.Context, conn db.DB, s *schema
 		}
 	}
 
-	// remove old columns
-	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s %s",
-		pq.QuoteIdentifier(o.Table),
-		dropMultipleColumns(quoteColumnNames(o.Columns)),
-	))
+	removeOldColumns := NewDropColumnAction(conn, o.Table, o.Columns...)
+	err := removeOldColumns.Execute(ctx)
 	if err != nil {
 		return err
 	}
@@ -161,10 +158,8 @@ func (o *OpCreateConstraint) Complete(ctx context.Context, conn db.DB, s *schema
 		return err
 	}
 
-	// Remove the needs backfill column
-	_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s DROP COLUMN IF EXISTS %s",
-		pq.QuoteIdentifier(o.Table),
-		pq.QuoteIdentifier(CNeedsBackfillColumn)))
+	removeBackfillColumn := NewDropColumnAction(conn, o.Table, CNeedsBackfillColumn)
+	err = removeBackfillColumn.Execute(ctx)
 
 	return err
 }
@@ -175,10 +170,8 @@ func (o *OpCreateConstraint) Rollback(ctx context.Context, conn db.DB, s *schema
 		return TableDoesNotExistError{Name: o.Table}
 	}
 
-	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s %s",
-		pq.QuoteIdentifier(table.Name),
-		dropMultipleColumns(quotedTemporaryNames(o.Columns)),
-	))
+	removeDuplicatedColumns := NewDropColumnAction(conn, table.Name, temporaryNames(o.Columns)...)
+	err := removeDuplicatedColumns.Execute(ctx)
 	if err != nil {
 		return err
 	}
@@ -187,10 +180,8 @@ func (o *OpCreateConstraint) Rollback(ctx context.Context, conn db.DB, s *schema
 		return err
 	}
 
-	// Remove the needs backfill column
-	_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s DROP COLUMN IF EXISTS %s",
-		pq.QuoteIdentifier(table.Name),
-		pq.QuoteIdentifier(CNeedsBackfillColumn)))
+	removeBackfillColumn := NewDropColumnAction(conn, table.Name, CNeedsBackfillColumn)
+	err = removeBackfillColumn.Execute(ctx)
 
 	return err
 }
@@ -205,13 +196,6 @@ func (o *OpCreateConstraint) removeTriggers(ctx context.Context, conn db.DB) err
 		strings.Join(dropFuncs, ", "),
 	))
 	return err
-}
-
-func dropMultipleColumns(columns []string) string {
-	for i, col := range columns {
-		columns[i] = "DROP COLUMN IF EXISTS " + col
-	}
-	return strings.Join(columns, ", ")
 }
 
 func (o *OpCreateConstraint) Validate(ctx context.Context, s *schema.Schema) error {

--- a/pkg/migrations/op_drop_constraint.go
+++ b/pkg/migrations/op_drop_constraint.go
@@ -122,7 +122,7 @@ func (o *OpDropConstraint) Rollback(ctx context.Context, conn db.DB, s *schema.S
 	table := s.GetTable(o.Table)
 	columnName := table.GetConstraintColumns(o.Name)[0]
 
-	removeNewColumn := NewDropColumnAction(conn, o.Table, columnName)
+	removeNewColumn := NewDropColumnAction(conn, o.Table, TemporaryName(columnName))
 	err := removeNewColumn.Execute(ctx)
 	if err != nil {
 		return err

--- a/pkg/migrations/op_drop_constraint.go
+++ b/pkg/migrations/op_drop_constraint.go
@@ -95,18 +95,16 @@ func (o *OpDropConstraint) Complete(ctx context.Context, conn db.DB, s *schema.S
 		return err
 	}
 
-	// Remove the needs backfill column
-	_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s DROP COLUMN IF EXISTS %s",
-		pq.QuoteIdentifier(table.Name),
-		pq.QuoteIdentifier(CNeedsBackfillColumn)))
+	removeBackfillColumn := NewDropColumnAction(conn, table.Name, CNeedsBackfillColumn)
+	err = removeBackfillColumn.Execute(ctx)
 	if err != nil {
 		return err
 	}
 
-	// Drop the old column
-	_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s DROP COLUMN IF EXISTS %s",
-		pq.QuoteIdentifier(o.Table),
-		pq.QuoteIdentifier(column.Name)))
+	removeOldColumn := NewDropColumnAction(conn,
+		o.Table,
+		column.Name)
+	err = removeOldColumn.Execute(ctx)
 	if err != nil {
 		return err
 	}
@@ -124,11 +122,8 @@ func (o *OpDropConstraint) Rollback(ctx context.Context, conn db.DB, s *schema.S
 	table := s.GetTable(o.Table)
 	columnName := table.GetConstraintColumns(o.Name)[0]
 
-	// Drop the new column
-	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s DROP COLUMN IF EXISTS %s",
-		pq.QuoteIdentifier(o.Table),
-		pq.QuoteIdentifier(TemporaryName(columnName)),
-	))
+	removeNewColumn := NewDropColumnAction(conn, o.Table, columnName)
+	err := removeNewColumn.Execute(ctx)
 	if err != nil {
 		return err
 	}
@@ -149,10 +144,8 @@ func (o *OpDropConstraint) Rollback(ctx context.Context, conn db.DB, s *schema.S
 		return err
 	}
 
-	// Remove the needs backfill column
-	_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s DROP COLUMN IF EXISTS %s",
-		pq.QuoteIdentifier(table.Name),
-		pq.QuoteIdentifier(CNeedsBackfillColumn)))
+	removeBackfillColumn := NewDropColumnAction(conn, table.Name, CNeedsBackfillColumn)
+	err = removeBackfillColumn.Execute(ctx)
 
 	return err
 }


### PR DESCRIPTION
This PR is part of a refactoring effort. My goal is to unify all database actions pgroll is executing. Example actions include dropping columns, renaming columns, creating and dropping triggers, creating constraints, etc.

We can define a list of these actions in a migration phase and run them sequentially. The following example is a `Complete` phase of an imaginary migration:

```golang
func Complete(ctx context.Context) error {
    actions := []DBAction{
        NewDropColumnAction(conn, tableName, columnName),
        NewRenameColumnAction(conn, tableName, newName, oldName),
        NewDropColumnAction(conn, tableName, CNeedsBackfill),
        NewDropTriggerAction(conn, triggerName),
    }

    for _, action := actions {
       if err := action.Execute(ctx); err != nil {
           return err
       }
    }
}
```

In this step I implemented column dropping as an action. In later PRs I would like to add creating and dropping triggers, functions, etc.
