### PR TITLE
Add support for running SQL migrations as a regular migrator

### DIFF
--- a/cli-definition.json
+++ b/cli-definition.json
@@ -124,6 +124,24 @@
       "args": []
     },
     {
+      "name": "sqlmigrate",
+      "short": "Run SQL migration scripts",
+      "use": "sqlmigrate <path to file with migrations>",
+      "example": "",
+      "flags": [
+        {
+          "name": "name",
+          "shorthand": "n",
+          "description": "Name of the migration",
+          "default": "{current_timestamp}"
+        }
+      ],
+      "subcommands": [],
+      "args": [
+        "migration-file"
+      ]
+    },
+    {
       "name": "start",
       "short": "Start a migration for the operations present in the given file",
       "use": "start <file>",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,6 +69,7 @@ func Prepare() *cobra.Command {
 	rootCmd.AddCommand(pullCmd())
 	rootCmd.AddCommand(latestCmd())
 	rootCmd.AddCommand(convertCmd())
+	rootCmd.AddCommand(sqlMigrateCmd())
 
 	return rootCmd
 }

--- a/cmd/sqlmigrate.go
+++ b/cmd/sqlmigrate.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/xataio/pgroll/pkg/migrations"
+)
+
+func sqlMigrateCmd() *cobra.Command {
+	var migrationName string
+
+	convertCmd := &cobra.Command{
+		Use:       "sqlmigrate <path to file with migrations>",
+		Short:     "Run SQL migration scripts",
+		Long:      "Run SQL migration scripts without turning them into pgroll migrations. The command can read SQL statements from stdin or a file",
+		Args:      cobra.MaximumNArgs(1),
+		ValidArgs: []string{"migration-file"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reader, err := openSQLReader(args)
+			if err != nil {
+				return fmt.Errorf("open SQL migration: %w", err)
+			}
+			defer reader.Close()
+
+			if migrationName == "{current_timestamp}" {
+				migrationName = time.Now().Format("20060102150405")
+			}
+			migration, err := sqlStatementsToSQLMigration(reader, migrationName)
+			if err != nil {
+				return err
+			}
+
+			m, err := NewRoll(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer m.Close()
+
+			return runMigration(cmd.Context(), m, migration, true, nil)
+		},
+	}
+
+	convertCmd.Flags().StringVarP(&migrationName, "name", "n", "{current_timestamp}", "Name of the migration")
+
+	return convertCmd
+}
+
+func sqlStatementsToSQLMigration(reader io.Reader, name string) (*migrations.Migration, error) {
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, reader)
+	if err != nil {
+		return nil, err
+	}
+
+	return &migrations.Migration{
+		Name: name,
+		Operations: migrations.Operations{
+			&migrations.OpRawSQL{Up: buf.String()},
+		},
+	}, nil
+}


### PR DESCRIPTION
This PR adds a new command called `sqlmigrate`. This lets users run regular SQL migration scripts as they are written in the files. It does not add any pgroll guarantees like avoiding locks or providing multiple schema versions.

The command is for people who want to use pgroll as a regular SQL migrator.
