### PR TITLE
Fix SQL formatting

### DIFF
--- a/pkg/state/init.sql
+++ b/pkg/state/init.sql
@@ -29,7 +29,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS history_is_linear ON placeholder.migrations (s
 
 -- Add a column to tell whether the row represents an auto-detected DDL capture or a pgroll migration
 ALTER TABLE placeholder.migrations
-    ADD COLUMN IF NOT EXISTS migration_type VARCHAR(32) DEFAULT 'pgroll' CONSTRAINT migration_type_check CHECK (migration_type IN ('pgroll', 'inferred'));
+    ADD COLUMN IF NOT EXISTS migration_type varchar(32) DEFAULT 'pgroll' CONSTRAINT migration_type_check CHECK (migration_type IN ('pgroll', 'inferred'));
 
 -- Helper functions
 -- Are we in the middle of a migration?


### PR DESCRIPTION
Fix the SQL formatting issue that is causing the `main` build to fail.

[pgFormatter](https://github.com/darold/pgFormatter) released version [5.6](https://github.com/darold/pgFormatter/releases/tag/v5.6) with some fix to how typenames are formatted in `ALTER TABLE` statements and this was picked up by the [backplane/pgFormatter](https://hub.docker.com/r/backplane/pgformatter/tags) image which only offers a `latest` tag.

We could build our own `pgFormatter` image to allow us to pin to a specific version if this happens often; for now just update the SQL file.

