### PR TITLE
Rename generate and format jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,8 +96,8 @@ jobs:
           fi
         done
 
-  type-generation:
-    name: type generation
+  format:
+    name: format
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -111,16 +111,40 @@ jobs:
         run: |
           go install mvdan.cc/gofumpt@latest
 
-      - name: Generate types
+      - name: Run make format
+        run: |
+          chmod 666 pkg/state/init.sql
+          make format
+
+      - name: Ensure code is formatted
+        run: |
+          if ! git diff --quiet; then
+            echo "code formatting is out-of-date!"
+            echo "run 'make format' to reformat"
+            exit 1
+          fi
+
+  code-generation:
+    name: code generation
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Generate code
         run: |
           chmod 666 pkg/state/init.sql
           make generate
 
-      - name: Ensure generated types are up-to-date
+      - name: Ensure generated code is up-to-date
         run: |
           if ! git diff --quiet; then
-            echo "generated types are out of date!"
-            echo "run 'make generate' to regenerate type definitions"
+            echo "generated code is out of date!"
+            echo "run 'make generate' to regenerate"
             exit 1
           fi
 
@@ -232,7 +256,7 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: goreleaser/goreleaser-cross:v1.24
-    needs: [test, lint, examples-schema-validation, examples, license-check, type-generation, dead-code-check, check-ledger, cross-build]
+    needs: [test, lint, examples-schema-validation, examples, license-check, format, code-generation, dead-code-check, check-ledger, cross-build]
     if: startsWith(github.ref, 'refs/tags/')
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"

--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,15 @@ format:
 	docker run --rm -v $$PWD/schema.json:/mnt/schema.json node:alpine npx prettier /mnt/schema.json --parser json --tab-width 2 --single-quote --trailing-comma all --no-semi --arrow-parens always --print-width 120 --write
 	# Format embedded SQL
 	docker run --rm -v $$PWD/pkg/state/init.sql:/data/init.sql backplane/pgformatter --inplace /data/init.sql
+	# Run gofumpt
 	gofumpt -w .
 
-generate: format
+generate:
 	# Generate the types from the JSON schema
 	docker run --rm -v $$PWD/schema.json:/mnt/schema.json omissis/go-jsonschema:0.17.0 --only-models -p migrations --tags json /mnt/schema.json > pkg/migrations/types.go
-	
-	# Add the license header
+	# Add the license header to the generated type file
 	echo "// SPDX-License-Identifier: Apache-2.0" | cat - pkg/migrations/types.go > pkg/migrations/types.go.tmp
 	mv pkg/migrations/types.go.tmp pkg/migrations/types.go
-
 	# Generate the cli-definition.json file
 	go run tools/build-cli-definition.go
 


### PR DESCRIPTION
Split the `type-generation` job into to separate `format` and `code-generation` jobs.

Previously, the `type-generation` job could fail for a variety of reasons related to either formatting, type generation, or CLI definition JSON generation.

This change will make build failures easier to diagnose.