### PR TITLE
Fix rename column docs

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -75,11 +75,6 @@
           "noLink": true,
           "items": [
             {
-              "title": "Rename column",
-              "href": "/operations/alter_column/rename_column",
-              "file": "docs/operations/alter_column/rename_column.mdx"
-            },
-            {
               "title": "Change type",
               "href": "/operations/alter_column/change_type",
               "file": "docs/operations/alter_column/change_type.mdx"
@@ -170,6 +165,11 @@
           "title": "Rename table",
           "href": "/operations/rename_table",
           "file": "docs/operations/rename_table.mdx"
+        },
+        {
+          "title": "Rename column",
+          "href": "/operations/rename_column",
+          "file": "docs/operations/rename_column.mdx"
         },
         {
           "title": "Rename constraint",


### PR DESCRIPTION
Remove the **Rename column** entry from under **Alter column** as it's a `404` on the docs site:

<img width="864" alt="image" src="https://github.com/user-attachments/assets/ca8b7e20-d5e4-4691-86cb-ca439c90438c" />

Replace it with a top level doc for the new `rename_column` operation (the doc was already written, just not linked properly).
