### PR TITLE
Do not run tests against PostgreSQL 14

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -73,22 +73,18 @@ branches:
 
       # Required. The list of status checks to require in order to merge into this branch
       contexts:
-      - test (pg: 14.8, schema: public)
       - test (pg: 15.3, schema: public)
       - test (pg: 16.0, schema: public)
       - test (pg: 17.0, schema: public)
       - test (pg: latest, schema: public)
-      - test (pg: 14.8, schema: non_public)
       - test (pg: 15.3, schema: non_public)
       - test (pg: 16.0, schema: non_public)
       - test (pg: 17.0, schema: non_public)
       - test (pg: latest, schema: non_public)
-      - examples (pg: 14.8, schema: public)
       - examples (pg: 15.3, schema: public)
       - examples (pg: 16.0, schema: public)
       - examples (pg: 17.0, schema: public)
       - examples (pg: latest, schema: public)
-      - examples (pg: 14.8, schema: non_public)
       - examples (pg: 15.3, schema: non_public)
       - examples (pg: 16.0, schema: non_public)
       - examples (pg: 17.0, schema: non_public)

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pgVersion: ['14.8', '15.3', '16.4', '17.0' ,'latest']
+        pgVersion: ['15.3', '16.4', '17.0' ,'latest']
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pgVersion: ['14.8', '15.3', '16.4', '17.0' ,'latest']
+        pgVersion: ['15.3', '16.4', '17.0' ,'latest']
         testSchema: [ 'public', 'non_public' ]
     steps:
     - uses: actions/checkout@v4
@@ -217,7 +217,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pgVersion: ['14.8', '15.3', '16.4', '17.0' ,'latest']
+        pgVersion: ['15.3', '16.4', '17.0' ,'latest']
         testSchema: [ 'public', 'non_public' ]
     services:
       postgres:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See the [introductory blog post](https://pgroll.com/blog/introducing-pgroll-zero
 - Automatic columns backfilling when needed.
 - Instant rollback in case of issues during migration.
 - Works against existing schemas, no need to start from scratch.
-- Works with Postgres 14.0 or later.
+- Works with Postgres 15.0 or later.
 - Works with any Postgres service (including RDS and Aurora).
 - Written in Go, cross-platform single binary with no external dependencies.
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ For more advanced usage, tutorials, and detailed options refer to the guides and
 
 ## Benchmarks
 
-Some performance benchmarks are run on each commit to `main` in order to track performance over time. Each benchmark is run against Postgres 14.8, 15.3, 16.4, 17.0 and "latest". Each line on the chart represents the number of rows the benchmark was run against, currently 10k, 100k and 300k rows.
+Some performance benchmarks are run on each commit to `main` in order to track performance over time. Each benchmark is run against Postgres 15.3, 16.4, 17.0 and "latest". Each line on the chart represents the number of rows the benchmark was run against, currently 10k, 100k and 300k rows.
 
 * `Backfill:` Rows/s to backfill a text column with the value `placeholder`. We use our default batching strategy of 10k rows per batch with no backoff.
 * `WriteAmplification/NoTrigger:` Baseline rows/s when writing data to a table without a `pgroll` trigger.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,7 +84,4 @@ brew install pgroll
 
 ## Supported Postgres versions
 
-`pgroll` supports Postgres versions >= 14.
-
-:warning: In Postgres 14, row level security policies on tables are not respected by `pgroll`'s versioned views. This is because `pgroll` is unable to create the views with the `(security_invoker = true)` option, as the ability to do so was added in Postgres 15. If you use RLS in Postgres 14 `pgroll` is likely a poor choice of migration tool. All other `pgroll` features are fully supported across all supported Postgres versions.
-
+`pgroll` supports Postgres versions >= 15.

--- a/pkg/roll/execute_test.go
+++ b/pkg/roll/execute_test.go
@@ -427,10 +427,6 @@ func TestViewsAreCreatedWithSecurityInvokerTrue(t *testing.T) {
 		ctx := context.Background()
 		version := "1_create_table"
 
-		if mig.PGVersion() < roll.PGVersion15 {
-			t.Skip("Skipping test for postgres < 15 as `security_invoker` views are not supported")
-		}
-
 		// Start and complete a migration to create a simple `users` table
 		if err := mig.Start(ctx, &migrations.Migration{Name: version, Operations: migrations.Operations{createTableOp("users")}}, backfill.NewConfig()); err != nil {
 			t.Fatalf("Failed to start migration: %v", err)

--- a/pkg/roll/roll.go
+++ b/pkg/roll/roll.go
@@ -16,10 +16,6 @@ import (
 
 type PGVersion int
 
-const (
-	PGVersion15 PGVersion = 15
-)
-
 var ErrMismatchedMigration = fmt.Errorf("remote migration does not match local migration")
 
 type Roll struct {

--- a/pkg/roll/roll.go
+++ b/pkg/roll/roll.go
@@ -111,11 +111,6 @@ func (m *Roll) Init(ctx context.Context) error {
 	return m.state.Init(ctx)
 }
 
-// PGVersion returns the postgres version
-func (m *Roll) PGVersion() PGVersion {
-	return m.pgVersion
-}
-
 // PgConn returns the underlying database connection
 func (m *Roll) PgConn() db.DB {
 	return m.pgConn


### PR DESCRIPTION
Remove jobs that run against PostgreSQL 14. We agreed to support the last 3 version
of PostgreSQL. The lastest version of PostgreSQL is 17. So the last 3 versions we need to support is 15, 16 and 17.
