### PR TITLE
Add `convert.mdx` to `docs/config.json`

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -54,6 +54,11 @@
           "title": "Pull",
           "href": "/cli/pull",
           "file": "docs/cli/pull.mdx"
+        },
+        {
+          "title": "Convert",
+          "href": "/cli/convert",
+          "file": "docs/cli/convert.mdx"
         }
       ]
     },


### PR DESCRIPTION
Add `convert.mdx` to `docs/config.json`.

The documentation was written but was not linked from the config, so it did not appear on the docs site.

Closes #714 