### PR TITLE
Make `name` field in migration JSON optional

### DIFF
--- a/cli-definition.json
+++ b/cli-definition.json
@@ -29,7 +29,7 @@
           "name": "name",
           "shorthand": "n",
           "description": "Name of the migration",
-          "default": "{current_timestamp}"
+          "default": ""
         }
       ],
       "subcommands": [],

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/xataio/pgroll/pkg/migrations"
@@ -31,9 +30,6 @@ func convertCmd() *cobra.Command {
 			}
 			defer reader.Close()
 
-			if migrationName == "{current_timestamp}" {
-				migrationName = time.Now().Format("20060102150405")
-			}
 			migration, err := sqlStatementsToMigration(reader, migrationName)
 			if err != nil {
 				return err
@@ -47,7 +43,7 @@ func convertCmd() *cobra.Command {
 		},
 	}
 
-	convertCmd.Flags().StringVarP(&migrationName, "name", "n", "{current_timestamp}", "Name of the migration")
+	convertCmd.Flags().StringVarP(&migrationName, "name", "n", "", "Name of the migration")
 
 	return convertCmd
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/pterm/pterm"
@@ -107,7 +109,10 @@ func readMigration(fileName string) (*migrations.Migration, error) {
 	}
 	defer file.Close()
 
-	migration, err := migrations.ReadMigration(file)
+	// Extract base filename without extension as the default migration name
+	defaultName := strings.TrimSuffix(filepath.Base(fileName), filepath.Ext(fileName))
+
+	migration, err := migrations.ReadMigration(file, defaultName)
 	if err != nil {
 		return nil, fmt.Errorf("reading migration file: %w", err)
 	}

--- a/docs/cli/convert.mdx
+++ b/docs/cli/convert.mdx
@@ -6,10 +6,12 @@ description: Convert SQL migration files to a pgroll migration
 ## Command
 
 ```
-$ pgroll convert --name 01_create_first_table /path/to/migration.sql
+$ pgroll convert /path/to/migration.sql
 ```
 
-This reads the SQL statements from `/path/to/migration.sql` and translates them into a `pgroll` migration. The name of the migration will be `01_create_first_table`.
+This reads the SQL statements from `/path/to/migration.sql` and translates them into a `pgroll` migration.
+
+The optional `--name` flag can be used to specify the name of the migration.
 
 ### Read SQL statements from stdin
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -72,6 +72,8 @@ With `pgroll` initialized, let's run our first migration. Here is a migration to
 
 Take this file and save it as `sql/01_create_users_table.json`.
 
+> Note: The `name` field is optional. If not provided, `pgroll` will use the filename (without the `.json` extension) as the migration name. In this example, the file is saved as `sql/01_create_users_table.json`, so the name would be `01_create_users_table` if not explicitly provided.
+
 The migration will create a `users` table with three columns. It is equivalent to the following SQL DDL statement:
 
 ```sql
@@ -146,6 +148,8 @@ Here is the `pgroll` migration that will perform the migration to make the `desc
   ]
 }
 ```
+
+> As mentioned earlier, the `name` field is optional. If the file is saved as `sql/02_user_description_set_nullable.json`, `pgroll` will use `02_user_description_set_nullable` as the migration name if the name field is not provided.
 
 Save this migration as `sql/02_user_description_set_nullable.json` and start the migration:
 
@@ -455,6 +459,8 @@ Looking at the second of these items, rollbacks, let's see how to roll back a `p
   ]
 }
 ```
+
+> Again, the `name` field is optional. The filename will be used as the default name if not specified.
 
 (the misspelling of `is_active` is intentional!)
 

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -51,7 +51,7 @@ type RequiresSchemaRefreshOperation interface {
 type (
 	Operations []Operation
 	Migration  struct {
-		Name string `json:"name"`
+		Name string `json:"name,omitempty"`
 
 		Operations Operations `json:"operations"`
 	}

--- a/pkg/migrations/op_common.go
+++ b/pkg/migrations/op_common.go
@@ -48,7 +48,8 @@ func DeletionName(name string) string {
 }
 
 // ReadMigration reads a migration from an io.Reader, like a file.
-func ReadMigration(r io.Reader) (*Migration, error) {
+// If the migration doesn't have a name field, defaultName will be used as the name.
+func ReadMigration(r io.Reader, defaultName string) (*Migration, error) {
 	byteValue, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -60,6 +61,11 @@ func ReadMigration(r io.Reader) (*Migration, error) {
 	mig := Migration{}
 	if err = dec.Decode(&mig); err != nil {
 		return nil, err
+	}
+
+	// Use the default name (filename without extension) if no name is provided
+	if mig.Name == "" {
+		mig.Name = defaultName
 	}
 
 	return &mig, nil

--- a/pkg/roll/unapplied.go
+++ b/pkg/roll/unapplied.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"path/filepath"
+	"strings"
 
 	"github.com/xataio/pgroll/pkg/migrations"
 )
@@ -73,10 +75,8 @@ func openAndReadMigrationFile(dir fs.FS, filename string) (*migrations.Migration
 	}
 	defer file.Close()
 
-	migration, err := migrations.ReadMigration(file)
-	if err != nil {
-		return nil, err
-	}
+	// Extract base filename without extension as the default migration name
+	defaultName := strings.TrimSuffix(filepath.Base(filename), filepath.Ext(filename))
 
-	return migration, nil
+	return migrations.ReadMigration(file, defaultName)
 }


### PR DESCRIPTION
Make the `name` field in a migration JSON file optional.

If a `name` is not provided, the migration filename (minus the `.json` suffix) is used as the migration name.

```json
{
  "name": "02_create_another_table",    <-- no longer required
  "operations": [
    {
      "create_table": {
        "name": "products",
        "columns": [
          {
            "name": "id",
            "type": "serial",
            "pk": true
          },
          {
            "name": "name",
            "type": "varchar(255)",
            "unique": true
          },
          {
            "name": "price",
            "type": "decimal(10,2)"
          }
        ]
      }
    }
  ]
}
```

The `--name` flag to `pgroll convert` is also changed to default to empty (rather than the current timestamp) as part of this change.

Closes https://github.com/xataio/pgroll/issues/715