### PR TITLE
Improve error messages when `pgroll init` has not been run

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -25,6 +25,15 @@ var analyzeCmd = &cobra.Command{
 		}
 		defer state.Close()
 
+		// Ensure that pgroll is initialized
+		ok, err := state.IsInitialized(cmd.Context())
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return errPGRollNotInitialized
+		}
+
 		schema, err := state.ReadSchema(ctx, flags.Schema())
 		if err != nil {
 			return err

--- a/cmd/complete.go
+++ b/cmd/complete.go
@@ -19,6 +19,15 @@ var completeCmd = &cobra.Command{
 		}
 		defer m.Close()
 
+		// Ensure that pgroll is initialized
+		ok, err := m.State().IsInitialized(cmd.Context())
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return errPGRollNotInitialized
+		}
+
 		sp, _ := pterm.DefaultSpinner.WithText("Completing migration...").Start()
 		err = m.Complete(cmd.Context())
 		if err != nil {

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import "errors"
+
+var errPGRollNotInitialized = errors.New("pgroll is not initialized, run 'pgroll init' to initialize")

--- a/cmd/latest.go
+++ b/cmd/latest.go
@@ -42,6 +42,15 @@ func latestCmd() *cobra.Command {
 					return fmt.Errorf("failed to get latest version from directory %q: %w", migrationsDir, err)
 				}
 			} else {
+				// Ensure that pgroll is initialized
+				ok, err := m.State().IsInitialized(cmd.Context())
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return errPGRollNotInitialized
+				}
+
 				latestVersion, err = m.LatestVersionRemote(ctx)
 				if err != nil {
 					return fmt.Errorf("failed to get latest version from database: %w", err)

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -33,6 +33,15 @@ func migrateCmd() *cobra.Command {
 			}
 			defer m.Close()
 
+			// Ensure that pgroll is initialized
+			ok, err := m.State().IsInitialized(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return errPGRollNotInitialized
+			}
+
 			latestVersion, err := m.State().LatestVersion(ctx, m.Schema())
 			if err != nil {
 				return fmt.Errorf("unable to determine latest version: %w", err)

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -32,6 +32,15 @@ func pullCmd() *cobra.Command {
 			}
 			defer state.Close()
 
+			// Ensure that pgroll is initialized
+			ok, err := state.IsInitialized(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return errPGRollNotInitialized
+			}
+
 			migs, err := state.SchemaHistory(ctx, flags.Schema())
 			if err != nil {
 				return fmt.Errorf("failed to read schema history: %w", err)

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -19,6 +19,15 @@ var rollbackCmd = &cobra.Command{
 		}
 		defer m.Close()
 
+		// Ensure that pgroll is initialized
+		ok, err := m.State().IsInitialized(cmd.Context())
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return errPGRollNotInitialized
+		}
+
 		sp, _ := pterm.DefaultSpinner.WithText("Rolling back migration...").Start()
 		err = m.Rollback(cmd.Context())
 		if err != nil {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -38,6 +38,15 @@ func startCmd() *cobra.Command {
 			}
 			defer m.Close()
 
+			// Ensure that pgroll is initialized
+			ok, err := m.State().IsInitialized(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return errPGRollNotInitialized
+			}
+
 			c := backfill.NewConfig(
 				backfill.WithBatchSize(batchSize),
 				backfill.WithBatchDelay(batchDelay),

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -17,11 +17,21 @@ var statusCmd = &cobra.Command{
 	Short: "Show pgroll status",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		ctx := cmd.Context()
+
 		state, err := state.New(ctx, flags.PostgresURL(), flags.StateSchema())
 		if err != nil {
 			return err
 		}
 		defer state.Close()
+
+		// Ensure that pgroll is initialized
+		ok, err := state.IsInitialized(ctx)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return errPGRollNotInitialized
+		}
 
 		status, err := state.Status(ctx, flags.Schema())
 		if err != nil {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -80,6 +80,18 @@ func (s *State) Init(ctx context.Context) error {
 	return tx.Commit()
 }
 
+func (s *State) IsInitialized(ctx context.Context) (bool, error) {
+	var isInitialized bool
+	err := s.pgConn.QueryRowContext(ctx,
+		"SELECT EXISTS (SELECT 1 from pg_catalog.pg_namespace WHERE nspname = $1)",
+		s.schema).Scan(&isInitialized)
+	if err != nil {
+		return false, err
+	}
+
+	return isInitialized, nil
+}
+
 func (s *State) Close() error {
 	return s.pgConn.Close()
 }

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -338,6 +338,32 @@ func TestPgRollInitializationInANonDefaultSchema(t *testing.T) {
 	})
 }
 
+func TestIsInitializedMethodReturnsTrueAfterInitialization(t *testing.T) {
+	t.Parallel()
+
+	testutils.WithUninitializedState(t, func(state *state.State) {
+		ctx := context.Background()
+
+		// Get whether the state is initialized
+		ok, err := state.IsInitialized(ctx)
+		require.NoError(t, err)
+
+		// Assert that the state is not initialized as `Init` has not been called
+		require.False(t, ok)
+
+		// Invoke `Init` to initialize the state
+		err = state.Init(ctx)
+		require.NoError(t, err)
+
+		// Get whether the state is initialized
+		ok, err = state.IsInitialized(ctx)
+		require.NoError(t, err)
+
+		// Assert that the state is initialized
+		require.True(t, ok)
+	})
+}
+
 func TestConcurrentInitialization(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Improve the error messages displayed by the CLI when attempting to run commands that require `pgroll init` to have been run.

Old example of `pgroll start` before `pgroll init`:

```
ERROR   Failed to start migration: pq: schema "pgroll" does not exist
```

New error message:

```
Error: pgroll is not initialized, run 'pgroll init' to initialize
```

The same change is applied to all other commands that need to run against an initialized database.

Closes https://github.com/xataio/pgroll/issues/723