### PR TITLE
Add rename constraint action as `DBAction`

### DIFF
--- a/pkg/migrations/dbactions.go
+++ b/pkg/migrations/dbactions.go
@@ -73,3 +73,28 @@ func (a *renameColumnAction) Execute(ctx context.Context) error {
 		pq.QuoteIdentifier(a.to)))
 	return err
 }
+
+// renameConstraintAction is a DBAction that renames a constraint in a table.
+type renameConstraintAction struct {
+	conn  db.DB
+	table string
+	from  string
+	to    string
+}
+
+func NewRenameConstraintAction(conn db.DB, table, from, to string) *renameConstraintAction {
+	return &renameConstraintAction{
+		conn:  conn,
+		table: table,
+		from:  from,
+		to:    to,
+	}
+}
+
+func (a *renameConstraintAction) Execute(ctx context.Context) error {
+	_, err := a.conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s RENAME CONSTRAINT %s TO %s",
+		pq.QuoteIdentifier(a.table),
+		pq.QuoteIdentifier(a.from),
+		pq.QuoteIdentifier(a.to)))
+	return err
+}

--- a/pkg/migrations/op_rename_constraint.go
+++ b/pkg/migrations/op_rename_constraint.go
@@ -4,9 +4,6 @@ package migrations
 
 import (
 	"context"
-	"fmt"
-
-	"github.com/lib/pq"
 
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
@@ -21,11 +18,7 @@ func (o *OpRenameConstraint) Start(ctx context.Context, conn db.DB, latestSchema
 
 func (o *OpRenameConstraint) Complete(ctx context.Context, conn db.DB, s *schema.Schema) error {
 	// rename the constraint in the underlying table
-	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s RENAME CONSTRAINT %s TO %s",
-		pq.QuoteIdentifier(o.Table),
-		pq.QuoteIdentifier(o.From),
-		pq.QuoteIdentifier(o.To)))
-	return err
+	return NewRenameConstraintAction(conn, o.Table, o.From, o.To).Execute(ctx)
 }
 
 func (o *OpRenameConstraint) Rollback(ctx context.Context, conn db.DB, s *schema.Schema) error {


### PR DESCRIPTION
This PR adds a new `DBAction` for renaming constraints. The new action is used in `rename_constraint` operations and in `RenameDuplicatedColumn` function.