### PR TITLE
Docs Previews: No auto merge creating deployment

### DIFF
--- a/.github/workflows/docs_preview.yaml
+++ b/.github/workflows/docs_preview.yaml
@@ -21,6 +21,7 @@ jobs:
               owner: repoOwner,
               repo,
               ref: pr.head.sha,
+              auto_merge: false,
               required_contexts: [], // Don't require checks to pass
               environment: 'Docs Preview',
               description: 'Creating a preview',


### PR DESCRIPTION
Attempt to fix [failing builds](https://github.com/xataio/pgroll/actions/runs/14068215886/job/39395891422?pr=740) by switching [auto_merge](https://docs.github.com/en/rest/deployments/deployments?apiVersion=2022-11-28#create-a-deployment) off when creating deployments.

The way this action works, it's always runs off of code on `main` (to get extra priviledges) using `pull_request_target` so I am not sure how to test this...
 