### PR TITLE
`sql2pgroll`: Ignore `IF NOT EXISTS` in `CREATE TABLE` statement conversion

### DIFF
--- a/pkg/sql2pgroll/create_table.go
+++ b/pkg/sql2pgroll/create_table.go
@@ -79,8 +79,6 @@ func canConvertCreateStatement(stmt *pgq.CreateStmt) bool {
 	case
 		// Temporary and unlogged tables are not supported
 		stmt.GetRelation().GetRelpersistence() != "p",
-		// CREATE TABLE IF NOT EXISTS is not supported
-		stmt.GetIfNotExists(),
 		// Table inheritance is not supported
 		len(stmt.GetInhRelations()) != 0,
 		// Paritioned tables are not supported

--- a/pkg/sql2pgroll/create_table_test.go
+++ b/pkg/sql2pgroll/create_table_test.go
@@ -257,6 +257,10 @@ func TestConvertCreateTableStatements(t *testing.T) {
 			sql:        "CREATE TABLE foo(id integer, b text, EXCLUDE USING btree (id WITH =) DEFERRABLE INITIALLY DEFERRED)",
 			expectedOp: expect.CreateTableOp36,
 		},
+		{
+			sql:        "CREATE TABLE IF NOT EXISTS foo(a int)",
+			expectedOp: expect.CreateTableOp1,
+		},
 	}
 
 	for _, tc := range tests {
@@ -282,9 +286,6 @@ func TestUnconvertableCreateTableStatements(t *testing.T) {
 		// Temporary and unlogged tables are not supported
 		"CREATE TEMPORARY TABLE foo(a int)",
 		"CREATE UNLOGGED TABLE foo(a int)",
-
-		// The IF NOT EXISTS clause is not supported
-		"CREATE TABLE IF NOT EXISTS foo(a int)",
 
 		// Table inheritance is not supported
 		"CREATE TABLE foo(a int) INHERITS (bar)",


### PR DESCRIPTION
Convert `CREATE TABLE IF NOT EXISTS` statements to `create_table` operations as though the `IF NOT EXISTS` clause was not present.

A `CREATE TABLE` statement like this:

```sql
CREATE TABLE IF NOT EXISTS "dogs" (
        "id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "dogs_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
        "name" varchar(255) NOT NULL,
        "age" integer NOT NULL
);
```

is now converted to:

```json
{
  "operations": [
    {
      "create_table": {
        "columns": [
          {
            "generated": {
              "identity": {
                "sequence_options": "SEQUENCE NAME dogs_id_seq INCREMENT 1 MINVALUE 1 MAXVALUE 2147483647 START 1 CACHE 1 ",
                "user_specified_values": "ALWAYS"
              }
            },
            "name": "id",
            "pk": true,
            "type": "int"
          },
          {
            "name": "name",
            "type": "varchar(255)"
          },
          {
            "name": "age",
            "type": "int"
          }
        ],
        "name": "dogs"
      }
    }
  ]
}
```

rather than a raw SQL migration.

See the discussion on https://github.com/xataio/pgroll/issues/719 for the rationale behind this change.