### PR TITLE
Docs Previews: /docs/ -> /docs-preview/

### DIFF
--- a/.github/workflows/docs_preview.yaml
+++ b/.github/workflows/docs_preview.yaml
@@ -15,7 +15,7 @@ jobs:
             const pr = context.payload.pull_request;
             const prOwner = pr.head.repo.full_name === context.repo.full_name ? repoOwner : pr.head.repo.owner.login;
             const branch = pr.head.ref;
-            const previewUrl = `https://pgroll.com/next/preview-path?path=/docs/${prOwner}:${branch}/`
+            const previewUrl = `https://pgroll.com/next/preview-path?path=/docs-preview/${prOwner}:${branch}/`
 
             const deployment = await github.rest.repos.createDeployment({
               owner: repoOwner,


### PR DESCRIPTION
The docs had gotten kind of slow because of the change I'd made to add previewing. 

I've fixed that by having two routes: /docs/ which is fast, and /docs-preview/ which is slow and dynamic so I need to update the url.

Example: https://pgroll.com/next/preview-path?path=/docs-preview/xataio:docs-preview-url-moved/
