### PR TITLE
Convert `pgroll.migrations` `created_at` and `updated_at` fields to use `timestamptz` type

### DIFF
--- a/pkg/state/init.sql
+++ b/pkg/state/init.sql
@@ -31,6 +31,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS history_is_linear ON placeholder.migrations (s
 ALTER TABLE placeholder.migrations
     ADD COLUMN IF NOT EXISTS migration_type varchar(32) DEFAULT 'pgroll' CONSTRAINT migration_type_check CHECK (migration_type IN ('pgroll', 'inferred'));
 
+-- Change timestamp columns to use timestamptz
+ALTER TABLE placeholder.migrations
+    ALTER COLUMN created_at SET DATA TYPE timestamptz USING created_at AT TIME ZONE 'UTC',
+    ALTER COLUMN updated_at SET DATA TYPE timestamptz USING updated_at AT TIME ZONE 'UTC';
+
 -- Helper functions
 -- Are we in the middle of a migration?
 CREATE OR REPLACE FUNCTION placeholder.is_active_migration_period (schemaname name)


### PR DESCRIPTION
Change `pkg/state/init.sql` to update the timestamp columns in the `placeholder.migrations` table.

The change ensures that the `created_at` and `updated_at` columns use the `timestamptz` data type.

`timestamptz` is preferred for storing timestamp data for our use case. See eg [here](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_timestamp_.28without_time_zone.29).

Fixes https://github.com/xataio/pgroll/issues/711