### PR TITLE
 `sql2pgroll`: Ignore `IF NOT EXISTS` in `CREATE INDEX` statement conversion

### DIFF
--- a/pkg/sql2pgroll/create_index.go
+++ b/pkg/sql2pgroll/create_index.go
@@ -145,10 +145,6 @@ func canConvertCreateIndexStmt(stmt *pgq.IndexStmt) bool {
 	if stmt.GetNullsNotDistinct() {
 		return false
 	}
-	// IF NOT EXISTS is unsupported
-	if stmt.GetIfNotExists() {
-		return false
-	}
 	// Indexes defined on expressions are not supported
 	for _, node := range stmt.GetIndexParams() {
 		if node.GetIndexElem().GetExpr() != nil {

--- a/pkg/sql2pgroll/create_index_test.go
+++ b/pkg/sql2pgroll/create_index_test.go
@@ -140,6 +140,10 @@ func TestConvertCreateIndexStatements(t *testing.T) {
 			sql:        "CREATE INDEX idx_name ON foo (bar opclass1, baz opclass2)",
 			expectedOp: expect.CreateIndexOp11,
 		},
+		{
+			sql:        "CREATE INDEX IF NOT EXISTS idx_name ON foo (bar)",
+			expectedOp: expect.CreateIndexOp1,
+		},
 	}
 
 	for _, tc := range tests {
@@ -166,8 +170,6 @@ func TestUnconvertableCreateIndexStatements(t *testing.T) {
 		"CREATE INDEX idx_name ON ONLY foo (bar)",
 		// Indexes with NULLS NOT DISTINCT are not supported
 		"CREATE INDEX idx_name ON foo(a) NULLS NOT DISTINCT",
-		// IF NOT EXISTS is unsupported
-		"CREATE INDEX IF NOT EXISTS idx_name ON foo(a)",
 		// Indexes defined on expressions are not supported
 		"CREATE INDEX idx_name ON foo(LOWER(a))",
 		"CREATE INDEX idx_name ON foo(a, LOWER(b))",


### PR DESCRIPTION
Convert `CREATE INDEX IF NOT EXISTS` statements to `create_index` operations as though the `IF NOT EXISTS` clause was not present.

A `CREATE INDEX` statement like this:

```sql
CREATE INDEX IF NOT EXISTS "name" ON "dogs" USING btree ("name");
```

is now converted to:

```json
{
  "operations": [
    {
      "create_index": {
        "columns": {
          "name": {}
        },
        "method": "btree",
        "name": "name",
        "table": "dogs"
      }
    }
  ]
}
```

rather than a raw SQL migration.

See the discussion on https://github.com/xataio/pgroll/issues/719 for the rationale behind this change.

Fixes #719 and #720