### PR TITLE
Dont require database access to `pgroll latest --local`

### DIFF
--- a/cmd/latest.go
+++ b/cmd/latest.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/xataio/pgroll/pkg/roll"
 )
 
 func latestCmd() *cobra.Command {
@@ -37,7 +38,7 @@ func latestCmd() *cobra.Command {
 					return fmt.Errorf("migrations directory %q is not a directory", migrationsDir)
 				}
 
-				latestVersion, err = m.LatestVersionLocal(ctx, os.DirFS(migrationsDir))
+				latestVersion, err = roll.LatestVersionLocal(ctx, os.DirFS(migrationsDir))
 				if err != nil {
 					return fmt.Errorf("failed to get latest version from directory %q: %w", migrationsDir, err)
 				}

--- a/cmd/latest.go
+++ b/cmd/latest.go
@@ -3,10 +3,12 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/xataio/pgroll/cmd/flags"
 	"github.com/xataio/pgroll/pkg/roll"
 )
 
@@ -22,48 +24,21 @@ func latestCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
-			m, err := NewRoll(ctx)
-			if err != nil {
-				return err
-			}
-			defer m.Close()
-
 			var latestVersion string
+			var err error
 			if migrationsDir != "" {
-				info, err := os.Stat(migrationsDir)
-				if err != nil {
-					return fmt.Errorf("failed to stat directory: %w", err)
-				}
-				if !info.IsDir() {
-					return fmt.Errorf("migrations directory %q is not a directory", migrationsDir)
-				}
-
-				latestVersion, err = roll.LatestVersionLocal(ctx, os.DirFS(migrationsDir))
+				latestVersion, err = latestVersionLocal(ctx, migrationsDir, withSchema)
 				if err != nil {
 					return fmt.Errorf("failed to get latest version from directory %q: %w", migrationsDir, err)
 				}
 			} else {
-				// Ensure that pgroll is initialized
-				ok, err := m.State().IsInitialized(cmd.Context())
-				if err != nil {
-					return err
-				}
-				if !ok {
-					return errPGRollNotInitialized
-				}
-
-				latestVersion, err = m.LatestVersionRemote(ctx)
+				latestVersion, err = latestVersionRemote(ctx, withSchema)
 				if err != nil {
 					return fmt.Errorf("failed to get latest version from database: %w", err)
 				}
 			}
 
-			var prefix string
-			if withSchema {
-				prefix = m.Schema() + "_"
-			}
-
-			fmt.Printf("%s%s\n", prefix, latestVersion)
+			fmt.Println(latestVersion)
 
 			return nil
 		},
@@ -73,4 +48,63 @@ func latestCmd() *cobra.Command {
 	latestCmd.Flags().StringVarP(&migrationsDir, "local", "l", "", "retrieve the latest version from a local migration directory")
 
 	return latestCmd
+}
+
+// latestVersionLocal returns the latest migration version from a local
+// migration directory on disk, assuming the migration files are
+// lexicographically ordered by filename
+func latestVersionLocal(ctx context.Context, migrationsDir string, withSchema bool) (string, error) {
+	// Ensure that the directory exists
+	info, err := os.Stat(migrationsDir)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("not a directory: %q", migrationsDir)
+	}
+
+	// Get the latest migration in the directory
+	latestVersion, err := roll.LatestVersionLocal(ctx, os.DirFS(migrationsDir))
+	if err != nil {
+		return "", err
+	}
+
+	// Prepend the schema name to the latest version if requested
+	if withSchema {
+		latestVersion = flags.Schema() + "_" + latestVersion
+	}
+
+	return latestVersion, nil
+}
+
+// latestVersionRemote returns the latest applied migration version on the target database
+func latestVersionRemote(ctx context.Context, withSchema bool) (string, error) {
+	// Create a new Roll instance
+	m, err := NewRoll(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer m.Close()
+
+	// Ensure that pgroll is initialized
+	ok, err := m.State().IsInitialized(ctx)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", errPGRollNotInitialized
+	}
+
+	// Get the latest version in the target schema
+	latestVersion, err := m.LatestVersionRemote(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	// Prepend the schema name to the latest version if requested
+	if withSchema {
+		latestVersion = m.Schema() + "_" + latestVersion
+	}
+
+	return latestVersion, nil
 }

--- a/pkg/roll/latest.go
+++ b/pkg/roll/latest.go
@@ -17,7 +17,7 @@ var (
 
 // LatestVersionLocal returns the name of the last migration in `dir`, where the
 // migration files are lexicographically ordered by filename.
-func (m *Roll) LatestVersionLocal(ctx context.Context, dir fs.FS) (string, error) {
+func LatestVersionLocal(ctx context.Context, dir fs.FS) (string, error) {
 	files, err := migrations.CollectFilesFromDir(dir)
 	if err != nil {
 		return "", fmt.Errorf("getting migration files from dir: %w", err)

--- a/pkg/roll/latest_test.go
+++ b/pkg/roll/latest_test.go
@@ -26,30 +26,26 @@ func TestLatestVersionLocal(t *testing.T) {
 			"03_migration_3.json": &fstest.MapFile{Data: exampleMigration(t, "03_migration_3")},
 		}
 
-		testutils.WithMigratorAndConnectionToContainer(t, func(roll *roll.Roll, _ *sql.DB) {
-			ctx := context.Background()
+		ctx := context.Background()
 
-			// Get the latest migration in the directory
-			latest, err := roll.LatestVersionLocal(ctx, fs)
-			require.NoError(t, err)
+		// Get the latest migration in the directory
+		latest, err := roll.LatestVersionLocal(ctx, fs)
+		require.NoError(t, err)
 
-			// Assert last migration name
-			assert.Equal(t, "03_migration_3", latest)
-		})
+		// Assert last migration name
+		assert.Equal(t, "03_migration_3", latest)
 	})
 
 	t.Run("returns an error if the directory is empty", func(t *testing.T) {
 		fs := fstest.MapFS{}
 
-		testutils.WithMigratorAndConnectionToContainer(t, func(m *roll.Roll, _ *sql.DB) {
-			ctx := context.Background()
+		ctx := context.Background()
 
-			// Get the latest migration in the directory
-			_, err := m.LatestVersionLocal(ctx, fs)
+		// Get the latest migration in the directory
+		_, err := roll.LatestVersionLocal(ctx, fs)
 
-			// Assert expected error
-			assert.ErrorIs(t, err, roll.ErrNoMigrationFiles)
-		})
+		// Assert expected error
+		assert.ErrorIs(t, err, roll.ErrNoMigrationFiles)
 	})
 }
 


### PR DESCRIPTION
Ensure that the `latest` command does not require database access when the `--local` flag is provided. 

In this case the command should act only locally, with the migrations on disk and not require a connection to the database.

The reason it used to require a DB connection was to support the `--with-schema` flag which took the schema name from an instantiated `Roll` instance. Change this so that the schema name is instead taken from the command line `--schema` flag (or the `PGROLL_SCHEMA` env var) directly instead.

Fixes https://github.com/xataio/pgroll/issues/726