### PR TITLE
Set Postgres `application_name` for `pgroll`'s migrator and state connections

### DIFF
--- a/pkg/roll/roll.go
+++ b/pkg/roll/roll.go
@@ -18,6 +18,10 @@ type PGVersion int
 
 const (
 	PGVersion15 PGVersion = 15
+
+	// applicationName is the Postgres application_name set on the connection
+	// used by the the Roll instance
+	applicationName = "pgroll"
 )
 
 var ErrMismatchedMigration = fmt.Errorf("remote migration does not match local migration")
@@ -77,7 +81,8 @@ func setupConn(ctx context.Context, pgURL, schema string, options options) (*sql
 	}
 
 	searchPath := append([]string{schema}, options.searchPath...)
-	dsn += " search_path=" + strings.Join(searchPath, ",")
+	dsn += fmt.Sprintf(" search_path=%s application_name=%s",
+		strings.Join(searchPath, ","), applicationName)
 
 	conn, err := sql.Open("postgres", dsn)
 	if err != nil {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -80,6 +80,10 @@ func (s *State) Init(ctx context.Context) error {
 	return tx.Commit()
 }
 
+func (s *State) PgConn() *sql.DB {
+	return s.pgConn
+}
+
 func (s *State) IsInitialized(ctx context.Context) (bool, error) {
 	var isInitialized bool
 	err := s.pgConn.QueryRowContext(ctx,

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -20,6 +20,10 @@ import (
 //go:embed init.sql
 var sqlInit string
 
+// applicationName is the Postgres application_name set on the connection used
+// by the the State instance
+const applicationName = "pgroll-state"
+
 type State struct {
 	pgConn *sql.DB
 	schema string
@@ -31,7 +35,7 @@ func New(ctx context.Context, pgURL, stateSchema string) (*State, error) {
 		dsn = pgURL
 	}
 
-	dsn += " search_path=" + stateSchema
+	dsn += fmt.Sprintf(" search_path=%s application_name=%s", stateSchema, applicationName)
 
 	conn, err := sql.Open("postgres", dsn)
 	if err != nil {


### PR DESCRIPTION
Set the `application_name` parameter on the two PostgreSQL connections used by `pgroll`  to help identify `pgroll` connections in monitoring tools.

Migrator connections use `"pgroll"` while state connections use `"pgroll-state"` as their application name.

These application names are visible in the `pg_stat_activity` table. For example, run this migration:

```yaml
operations:
  - sql:
      up: |
        select pg_sleep(60);
```

And then

```sql
select application_name, query from pg_stat_activity
```

shows rows identifying the connections:

```
+------------------+------------------------------------------------------+
| application_name | query                                                |
|------------------+------------------------------------------------------|
| pgroll-state     | SELECT "pgroll".read_schema($1)                      |
| pgroll           | select pg_sleep(60);                                 |
| pgcli            | select application_name, query from pg_stat_activity |
+------------------+------------------------------------------------------+

```

Testcases are added to verify this behavior works as expected.