### PR TITLE
Remove the unnecessary file parameter from the help text

### DIFF
--- a/cli-definition.json
+++ b/cli-definition.json
@@ -117,7 +117,7 @@
     {
       "name": "rollback",
       "short": "Roll back an ongoing migration",
-      "use": "rollback <file>",
+      "use": "rollback",
       "example": "",
       "flags": [],
       "subcommands": [],

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -10,7 +10,7 @@ import (
 )
 
 var rollbackCmd = &cobra.Command{
-	Use:   "rollback <file>",
+	Use:   "rollback",
 	Short: "Roll back an ongoing migration",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		m, err := NewRoll(cmd.Context())


### PR DESCRIPTION
Closes #776
