### PR TITLE
Improve error message when `start` and `rollack` fails

### DIFF
--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -89,10 +89,12 @@ func (m *Roll) StartDDLOperations(ctx context.Context, migration *migrations.Mig
 		table, err := op.Start(ctx, m.pgConn, latestSchema, newSchema)
 		if err != nil {
 			errRollback := m.Rollback(ctx)
-
-			return nil, errors.Join(
-				fmt.Errorf("unable to execute start operation: %w", err),
-				errRollback)
+			if errRollback != nil {
+				return nil, errors.Join(
+					fmt.Errorf("unable to execute start operation of %q: %w", migration.Name, err),
+					fmt.Errorf("unable to roll back failed operation: %w", errRollback))
+			}
+			return nil, fmt.Errorf("rolled back %q because start command has failed: %w", migration.Name, err)
 		}
 		// refresh schema when the op is isolated and requires a refresh (for example raw sql)
 		// we don't want to refresh the schema if the operation is not isolated as it would

--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -94,7 +94,7 @@ func (m *Roll) StartDDLOperations(ctx context.Context, migration *migrations.Mig
 					fmt.Errorf("unable to execute start operation of %q: %w", migration.Name, err),
 					fmt.Errorf("unable to roll back failed operation: %w", errRollback))
 			}
-			return nil, fmt.Errorf("rolled back %q because start command has failed: %w", migration.Name, err)
+			return nil, fmt.Errorf("failed to start %q migration, changes rolled back: %w", migration.Name, err)
 		}
 		// refresh schema when the op is isolated and requires a refresh (for example raw sql)
 		// we don't want to refresh the schema if the operation is not isolated as it would


### PR DESCRIPTION
When `pgroll` fails to execute `start` phase of the migration, it runs `rollback` immediately. If `rollback` fails as well, the errors are joined. This made the error message hard to understand.

Previously, `pgroll` emitted this message:
```
Error: unable to execute start operation: pq: relation "qsdf" does not exist
pq: current transaction is aborted, commands ignored until end of transaction block
```

From now on, the message is clearer.
```
Error: unable to execute start operation of 'my_migration_name': pq: relation "qsdf" does not exist
unable to roll back failed operation: pq: current transaction is aborted, commands ignored until end of transaction block
```

If `start` fails but rollback succeeds, we emit a clearer error message:
```
Error: rolled back 'my_migration_name' because start command has failed: pq: relation "qsdf" does not exist
```
