### PR TITLE
Pass all column attributes to new temporary column when adding a new one to the table

### DIFF
--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -99,9 +99,17 @@ func (o *OpAddColumn) Start(ctx context.Context, conn db.DB, latestSchema string
 		tableToBackfill = table
 	}
 
-	table.AddColumn(o.Column.Name, &schema.Column{
-		Name: TemporaryName(o.Column.Name),
-	})
+	tmpColumn := &schema.Column{
+		Name:     TemporaryName(o.Column.Name),
+		Type:     o.Column.Type,
+		Default:  o.Column.Default,
+		Nullable: o.Column.Nullable,
+		Unique:   o.Column.Unique,
+	}
+	if o.Column.Comment != nil {
+		tmpColumn.Comment = *o.Column.Comment
+	}
+	table.AddColumn(o.Column.Name, tmpColumn)
 
 	return tableToBackfill, nil
 }

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -99,19 +99,25 @@ func (o *OpAddColumn) Start(ctx context.Context, conn db.DB, latestSchema string
 		tableToBackfill = table
 	}
 
-	tmpColumn := &schema.Column{
-		Name:     TemporaryName(o.Column.Name),
-		Type:     o.Column.Type,
-		Default:  o.Column.Default,
-		Nullable: o.Column.Nullable,
-		Unique:   o.Column.Unique,
-	}
-	if o.Column.Comment != nil {
-		tmpColumn.Comment = *o.Column.Comment
-	}
+	tmpColumn := toSchemaColumn(o.Column)
+	tmpColumn.Name = TemporaryName(o.Column.Name)
 	table.AddColumn(o.Column.Name, tmpColumn)
 
 	return tableToBackfill, nil
+}
+
+func toSchemaColumn(c Column) *schema.Column {
+	tmpColumn := &schema.Column{
+		Name:     c.Name,
+		Type:     c.Type,
+		Default:  c.Default,
+		Nullable: c.Nullable,
+		Unique:   c.Unique,
+	}
+	if c.Comment != nil {
+		tmpColumn.Comment = *c.Comment
+	}
+	return tmpColumn
 }
 
 func (o *OpAddColumn) Complete(ctx context.Context, conn db.DB, s *schema.Schema) error {


### PR DESCRIPTION
The following migration was failing due to several reasons:

```json
{
  "operations": [
    {
      "create_table": {
        "name": "users",
        "columns": [
          {
            "name": "id",
            "type": "uuid",
            "pk": true
          }
        ]
      }
    },
    {
      "add_column": {
        "table": "users",
        "column": {
          "name": "name",
          "type": "text",
          "nullable": true
        }
      }
    },
    {
      "create_constraint": {
        "table": "users",
        "columns": [
          "name"
        ],
        "type": "unique",
        "name": "my_custom_name",
        "up": {
          "name": "name"
        },
        "down": {
          "name": "name"
        }
      }
    }
  ]
}
```

This PR fixes the first problem with the migration. The first problem is when `pgroll` adds the new column with the temporary name to the table schema it lacks all column attributes. Thus, if a later operation tries to duplicate this duplicated column it fails because we do not know the type of the column, the default value, etc. The SQL statement generated has a syntax error because of the lack of information:

```
Failed to start migration: unable to execute start operation: failed to duplicate column: pq: syntax error at or near ","
```
