### PR TITLE
Add missing attributes to column info in virtual schema

### DIFF
--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -207,9 +207,13 @@ func (o *OpCreateTable) updateSchema(s *schema.Schema) *schema.Schema {
 			Unique:   col.Unique,
 			Nullable: col.Nullable,
 			Type:     col.Type,
+			Default:  col.Default,
 		}
 		if col.Pk {
 			primaryKeys = append(primaryKeys, col.Name)
+		}
+		if col.Comment != nil {
+			columns[col.Name].Comment = *col.Comment
 		}
 	}
 


### PR DESCRIPTION
When a table was added, `pgroll` did not store all required column metadata. Default values and comments were missing from columns. So when `pgroll` tried to duplicate the column, these got lost.

Example to reproduce the issue:
```json
{
    "operations": [
        {
            "create_table": {
                "name": "useres",
                "comment": "my_comment",
                "columns": [
                    {
                        "name": "id",
                        "type": "uuid",
                        "pk": true,
                        "nullable": false,
                        "default": "gen_random_uuid()",
                        "comment": "my_comment"
                    }
                ]
            }
        },
        {
            "create_constraint": {
                "table": "users",
                "columns": ["id"],
                "type": "unique",
                "name": "my_unique",
                "up": {
                    "id": "id"
                },
                "down": {
                    "id": "id"
                }
            }
        }
    ]
}
```