### PR TITLE
Remove `name` field from all examples

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -90,7 +90,7 @@ operations:
 
 Take this file and save it as `sql/01_create_users_table.yaml`.
 
-> Note: The `name` field is optional. If not provided, `pgroll` will use the filename (without the `.yaml` extension) as the migration name. In this example, the file is saved as `sql/01_create_users_table.yaml`, so the name would be `01_create_users_table` if not explicitly provided.
+> Note: The `name` field is optional. If not provided, `pgroll` will use the filename (without the `.yaml` extension) as the migration name. In this example, the file is saved as `sql/01_create_users_table.yaml`, so the name would be `01_create_users_table` if not explicitly provided. It's recommended to write migrations without an explicit `name` field and allow the filename to determine the name of the migration.
 
 The migration will create a `users` table with three columns. It is equivalent to the following SQL DDL statement:
 

--- a/examples/01_create_tables.yaml
+++ b/examples/01_create_tables.yaml
@@ -1,4 +1,3 @@
-name: 01_create_tables
 operations:
   - create_table:
       name: customers

--- a/examples/02_create_another_table.yaml
+++ b/examples/02_create_another_table.yaml
@@ -1,4 +1,3 @@
-name: 02_create_another_table
 operations:
   - create_table:
       name: products

--- a/examples/03_add_column.yaml
+++ b/examples/03_add_column.yaml
@@ -1,4 +1,3 @@
-name: 03_add_column_to_products
 operations:
   - add_column:
       table: products

--- a/examples/04_rename_table.yaml
+++ b/examples/04_rename_table.yaml
@@ -1,4 +1,3 @@
-name: 04_rename_table
 operations:
   - rename_table:
       from: customers

--- a/examples/05_sql.yaml
+++ b/examples/05_sql.yaml
@@ -1,4 +1,3 @@
-name: 05_sql
 operations:
   - sql:
       up: CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)

--- a/examples/06_add_column_to_sql_table.yaml
+++ b/examples/06_add_column_to_sql_table.yaml
@@ -1,4 +1,3 @@
-name: 06_add_column_to_sql_table
 operations:
   - add_column:
       table: users

--- a/examples/07_drop_table.yaml
+++ b/examples/07_drop_table.yaml
@@ -1,4 +1,3 @@
-name: 07_drop_table
 operations:
   - drop_table:
       name: products

--- a/examples/08_create_fruits_table.yaml
+++ b/examples/08_create_fruits_table.yaml
@@ -1,4 +1,3 @@
-name: 08_create_fruits_table
 operations:
   - create_table:
       name: fruits

--- a/examples/09_drop_column.yaml
+++ b/examples/09_drop_column.yaml
@@ -1,4 +1,3 @@
-name: 09_drop_column
 operations:
   - drop_column:
       table: fruits

--- a/examples/10_create_index.yaml
+++ b/examples/10_create_index.yaml
@@ -1,4 +1,3 @@
-name: 10_create_index
 operations:
   - create_index:
       name: idx_fruits_name

--- a/examples/11_drop_index.yaml
+++ b/examples/11_drop_index.yaml
@@ -1,4 +1,3 @@
-name: 11_drop_index
 operations:
   - drop_index:
       name: idx_fruits_name

--- a/examples/12_create_employees_table.yaml
+++ b/examples/12_create_employees_table.yaml
@@ -1,4 +1,3 @@
-name: 12_create_employees_table
 operations:
   - create_table:
       name: employees

--- a/examples/13_rename_column.yaml
+++ b/examples/13_rename_column.yaml
@@ -1,4 +1,3 @@
-name: 13_rename_column
 operations:
   - rename_column:
       table: employees

--- a/examples/14_add_reviews_table.yaml
+++ b/examples/14_add_reviews_table.yaml
@@ -1,4 +1,3 @@
-name: 14_add_reviews_table
 operations:
   - create_table:
       name: reviews

--- a/examples/15_set_column_unique.yaml
+++ b/examples/15_set_column_unique.yaml
@@ -1,4 +1,3 @@
-name: 15_set_column_unique
 operations:
   - alter_column:
       table: reviews

--- a/examples/16_set_nullable.yaml
+++ b/examples/16_set_nullable.yaml
@@ -1,4 +1,3 @@
-name: 16_set_nullable
 operations:
   - alter_column:
       table: reviews

--- a/examples/17_add_rating_column.yaml
+++ b/examples/17_add_rating_column.yaml
@@ -1,4 +1,3 @@
-name: 17_add_rating_column
 operations:
   - add_column:
       table: reviews

--- a/examples/18_change_column_type.yaml
+++ b/examples/18_change_column_type.yaml
@@ -1,4 +1,3 @@
-name: 18_change_column_type
 operations:
   - alter_column:
       table: reviews

--- a/examples/19_create_orders_table.yaml
+++ b/examples/19_create_orders_table.yaml
@@ -1,4 +1,3 @@
-name: 19_create_orders_table
 operations:
   - create_table:
       name: orders

--- a/examples/20_create_posts_table.yaml
+++ b/examples/20_create_posts_table.yaml
@@ -1,4 +1,3 @@
-name: 20_create_posts_table
 operations:
   - create_table:
       name: posts

--- a/examples/21_add_foreign_key_constraint.yaml
+++ b/examples/21_add_foreign_key_constraint.yaml
@@ -1,4 +1,3 @@
-name: 21_add_foreign_key_constraint
 operations:
   - alter_column:
       table: posts

--- a/examples/22_add_check_constraint.yaml
+++ b/examples/22_add_check_constraint.yaml
@@ -1,4 +1,3 @@
-name: 22_add_check_constraint
 operations:
   - alter_column:
       table: posts

--- a/examples/23_drop_check_constraint.yaml
+++ b/examples/23_drop_check_constraint.yaml
@@ -1,4 +1,3 @@
-name: 23_drop_check_constraint
 operations:
   - drop_constraint:
       table: posts

--- a/examples/24_drop_foreign_key_constraint.yaml
+++ b/examples/24_drop_foreign_key_constraint.yaml
@@ -1,4 +1,3 @@
-name: 24_drop_foreign_key_constraint
 operations:
   - drop_constraint:
       table: posts

--- a/examples/25_add_table_with_check_constraint.yaml
+++ b/examples/25_add_table_with_check_constraint.yaml
@@ -1,4 +1,3 @@
-name: 25_add_table_with_check_constraint
 operations:
   - create_table:
       name: people

--- a/examples/26_add_column_with_check_constraint.yaml
+++ b/examples/26_add_column_with_check_constraint.yaml
@@ -1,4 +1,3 @@
-name: 26_add_column_with_check_constraint
 operations:
   - add_column:
       table: people

--- a/examples/27_drop_unique_constraint.yaml
+++ b/examples/27_drop_unique_constraint.yaml
@@ -1,4 +1,3 @@
-name: 27_drop_unique_constraint
 operations:
   - drop_constraint:
       table: reviews

--- a/examples/28_different_defaults.yaml
+++ b/examples/28_different_defaults.yaml
@@ -1,4 +1,3 @@
-name: 28_different_defaults
 operations:
   - create_table:
       name: items

--- a/examples/29_set_replica_identity.yaml
+++ b/examples/29_set_replica_identity.yaml
@@ -1,4 +1,3 @@
-name: 29_set_replica_identity
 operations:
   - set_replica_identity:
       table: fruits

--- a/examples/30_add_column_simple_up.yaml
+++ b/examples/30_add_column_simple_up.yaml
@@ -1,4 +1,3 @@
-name: 30_add_column_simple_up
 operations:
   - add_column:
       table: people

--- a/examples/31_unset_not_null.yaml
+++ b/examples/31_unset_not_null.yaml
@@ -1,4 +1,3 @@
-name: 31_unset_not_null
 operations:
   - alter_column:
       table: posts

--- a/examples/32_sql_on_complete.yaml
+++ b/examples/32_sql_on_complete.yaml
@@ -1,4 +1,3 @@
-name: 32_sql_on_complete
 operations:
   - sql:
       up: ALTER TABLE people ADD COLUMN birth_date timestamp

--- a/examples/33_rename_check_constraint.yaml
+++ b/examples/33_rename_check_constraint.yaml
@@ -1,4 +1,3 @@
-name: 33_rename_check_constraint
 operations:
   - rename_constraint:
       table: people

--- a/examples/34_create_events_table.yaml
+++ b/examples/34_create_events_table.yaml
@@ -1,4 +1,3 @@
-name: 34_create_events_table
 operations:
   - create_table:
       name: events

--- a/examples/35_alter_column_multiple.yaml
+++ b/examples/35_alter_column_multiple.yaml
@@ -1,4 +1,3 @@
-name: 35_alter_column_multiple
 operations:
   - alter_column:
       table: events

--- a/examples/36_set_comment_to_null.yaml
+++ b/examples/36_set_comment_to_null.yaml
@@ -1,4 +1,3 @@
-name: 36_set_comment_to_null
 operations:
   - alter_column:
       table: events

--- a/examples/37_create_partial_index.yaml
+++ b/examples/37_create_partial_index.yaml
@@ -1,4 +1,3 @@
-name: 37_create_partial_index
 operations:
   - create_index:
       name: idx_fruits_id_gt_10

--- a/examples/38_create_hash_index_with_fillfactor.yaml
+++ b/examples/38_create_hash_index_with_fillfactor.yaml
@@ -1,4 +1,3 @@
-name: 38_create_hash_index_with_fillfactor
 operations:
   - create_index:
       name: idx_fruits_name

--- a/examples/39_add_column_with_multiple_pk_in_table.yaml
+++ b/examples/39_add_column_with_multiple_pk_in_table.yaml
@@ -1,4 +1,3 @@
-name: 39_add_column_with_multiple_pk_in_table
 operations:
   - add_column:
       table: sellers

--- a/examples/40_create_enum_type.yaml
+++ b/examples/40_create_enum_type.yaml
@@ -1,4 +1,3 @@
-name: 40_create_enum_type
 operations:
   - sql:
       up: CREATE TYPE fruit_size AS ENUM ('small', 'medium', 'large');

--- a/examples/41_add_enum_column.yaml
+++ b/examples/41_add_enum_column.yaml
@@ -1,4 +1,3 @@
-name: 41_add_enum_column
 operations:
   - add_column:
       table: fruits

--- a/examples/42_create_unique_index.yaml
+++ b/examples/42_create_unique_index.yaml
@@ -1,4 +1,3 @@
-name: 42_create_unique_index
 operations:
   - create_index:
       name: idx_fruits_unique_name

--- a/examples/43_create_tickets_table.yaml
+++ b/examples/43_create_tickets_table.yaml
@@ -1,4 +1,3 @@
-name: 43_create_tickets_table
 operations:
   - create_table:
       name: tickets

--- a/examples/44_add_table_unique_constraint.yaml
+++ b/examples/44_add_table_unique_constraint.yaml
@@ -1,4 +1,3 @@
-name: 44_add_table_unique_constraint
 operations:
   - create_constraint:
       type: unique

--- a/examples/45_add_table_check_constraint.yaml
+++ b/examples/45_add_table_check_constraint.yaml
@@ -1,4 +1,3 @@
-name: 45_add_table_check_constraint
 operations:
   - create_constraint:
       type: check

--- a/examples/46_alter_column_drop_default.yaml
+++ b/examples/46_alter_column_drop_default.yaml
@@ -1,4 +1,3 @@
-name: 46_alter_column_drop_default
 operations:
   - alter_column:
       table: tickets

--- a/examples/47_add_table_foreign_key_constraint.yaml
+++ b/examples/47_add_table_foreign_key_constraint.yaml
@@ -1,4 +1,3 @@
-name: 47_add_table_foreign_key_constraint
 operations:
   - create_constraint:
       type: foreign_key

--- a/examples/48_drop_tickets_check.yaml
+++ b/examples/48_drop_tickets_check.yaml
@@ -1,4 +1,3 @@
-name: 48_drop_tickets_check
 operations:
   - drop_multicolumn_constraint:
       table: tickets

--- a/examples/49_unset_not_null_on_indexed_column.yaml
+++ b/examples/49_unset_not_null_on_indexed_column.yaml
@@ -1,4 +1,3 @@
-name: 49_unset_not_null_on_indexed_column
 operations:
   - alter_column:
       table: fruits

--- a/examples/50_create_table_with_table_constraint.yaml
+++ b/examples/50_create_table_with_table_constraint.yaml
@@ -1,4 +1,3 @@
-name: 50_create_table_with_table_constraint
 operations:
   - create_table:
       name: telephone_providers

--- a/examples/51_create_table_with_table_foreign_key_constraint.yaml
+++ b/examples/51_create_table_with_table_foreign_key_constraint.yaml
@@ -1,4 +1,3 @@
-name: 51_create_table_with_table_foreign_key_constraint
 operations:
   - create_table:
       name: phonebook

--- a/examples/52_create_table_with_exclusion_constraint.yaml
+++ b/examples/52_create_table_with_exclusion_constraint.yaml
@@ -1,4 +1,3 @@
-name: 52_create_table_with_table_exclusion_constraint
 operations:
   - create_table:
       name: library

--- a/examples/53_add_column_with_volatile_default.yaml
+++ b/examples/53_add_column_with_volatile_default.yaml
@@ -1,4 +1,3 @@
-name: 53_add_column_with_volatile_default
 operations:
   - add_column:
       table: library

--- a/examples/54_create_index_with_opclass.yaml
+++ b/examples/54_create_index_with_opclass.yaml
@@ -1,4 +1,3 @@
-name: 54_create_index_with_opclass
 operations:
   - create_index:
       name: idx_fruits_custom_opclass


### PR DESCRIPTION
Remove the `name` field from all example migrations.

Migration names now default to the file name if a `name` field is not present and we recommend that approach over explicitly naming the migration in the JSON/YAML.