### PR TITLE
Idempotent `migrate` command

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -52,7 +52,8 @@ func migrateCmd() *cobra.Command {
 				return fmt.Errorf("unable to determine active migration period: %w", err)
 			}
 			if active {
-				return fmt.Errorf("migration %q is active and must be completed first", *latestVersion)
+				fmt.Printf("migration %q is active\n", *latestVersion)
+				return nil
 			}
 
 			info, err := os.Stat(migrationsDir)


### PR DESCRIPTION
This PR makes the command `migrate` idempotent.

If there is an active migration, `pgroll` does not return an error. The command just returns and lets the user know that there is an active migration.

Closes #798