### PR TITLE
Add logger interface for migrations and implement it

### DIFF
--- a/pkg/migrations/logger.go
+++ b/pkg/migrations/logger.go
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package migrations
+
+import "github.com/pterm/pterm"
+
+// Logger is responsible for logging all migration steps.
+type Logger interface {
+	LogMigrationStart(*Migration)
+	LogMigrationComplete(*Migration)
+	LogMigrationRollback(*Migration)
+	LogMigrationRollbackComplete(*Migration)
+
+	LogOperationStart(Operation)
+	LogOperationComplete(Operation)
+	LogOperationRollback(Operation)
+
+	LogBackfillStart(table string)
+	LogBackfillComplete(table string)
+	LogSchemaCreation(migration, schema string)
+	LogSchemaDeletion(migration, schema string)
+
+	Info(msg string, args ...any)
+}
+
+type migrationLogger struct {
+	logger pterm.Logger
+}
+
+type noopLogger struct{}
+
+func NewLogger() Logger {
+	return &migrationLogger{logger: pterm.DefaultLogger}
+}
+
+func NewNoopLogger() Logger {
+	return &noopLogger{}
+}
+
+func (l *migrationLogger) LogMigrationStart(m *Migration) {
+	l.logger.Info("starting migration", l.logger.Args([]any{
+		"name", m.Name,
+		"operation_count", len(m.Operations),
+	}))
+}
+
+func (l *migrationLogger) LogMigrationComplete(m *Migration) {
+	l.logger.Info("completing migration", l.logger.Args([]any{
+		"name", m.Name,
+		"operation_count", len(m.Operations),
+	}))
+}
+
+func (l *migrationLogger) LogMigrationRollback(m *Migration) {
+	l.logger.Info("rolling back migration", l.logger.Args([]any{
+		"name", m.Name,
+		"operation_count", len(m.Operations),
+	}))
+}
+
+func (l *migrationLogger) LogMigrationRollbackComplete(m *Migration) {
+	l.logger.Info("rolled back migration", l.logger.Args([]any{
+		"name", m.Name,
+		"operation_count", len(m.Operations),
+	}))
+}
+
+func (l *migrationLogger) LogBackfillStart(table string) {
+	l.logger.Info("backfilling started", l.logger.Args("table", table))
+}
+
+func (l *migrationLogger) LogBackfillComplete(table string) {
+	l.logger.Info("backfilling completed", l.logger.Args("table", table))
+}
+
+func (l *migrationLogger) LogSchemaCreation(migration, schema string) {
+	l.logger.Info("created versioned schema for migration", l.logger.Args("migration", migration, "schema_name", schema))
+}
+
+func (l *migrationLogger) LogSchemaDeletion(migration, schema string) {
+	l.logger.Info("dropped versioned schema for migration", l.logger.Args("migration", migration, "schema_name", schema))
+}
+
+func (l migrationLogger) LogOperationStart(op Operation) {
+	l.logger.Info("starting operation", l.logger.Args(l.extractOpArgs(op)))
+}
+
+func (l migrationLogger) LogOperationComplete(op Operation) {
+	l.logger.Info("completing operation", l.logger.Args(l.extractOpArgs(op)))
+}
+
+func (l migrationLogger) LogOperationRollback(op Operation) {
+	l.logger.Info("rolling back operation", l.logger.Args(l.extractOpArgs(op)))
+}
+
+func (l migrationLogger) Info(msg string, args ...any) {
+	l.logger.Info(msg, l.logger.Args(args))
+}
+
+func (l migrationLogger) extractOpArgs(op Operation) []any {
+	switch o := op.(type) {
+	case *OpAddColumn:
+		return []any{
+			"operation", OpNameAddColumn,
+			"name", o.Column.Name,
+			"type", o.Column.Type,
+			"table", o.Table,
+			"nullable", o.Column.Nullable,
+			"unique", o.Column.Unique,
+		}
+	case *OpAlterColumn:
+		return []any{
+			"operation", OpNameAlterColumn,
+			"column", o.Column,
+			"table", o.Table,
+		}
+	case *OpChangeType:
+		return []any{
+			"operation", OpNameAlterColumn,
+			"column", o.Column,
+			"table", o.Table,
+			"type", o.Type,
+		}
+	case *OpCreateConstraint:
+		return []any{
+			"operation", OpCreateConstraintName,
+			"table", o.Table,
+			"name", o.Name,
+			"type", o.Type,
+		}
+	case *OpCreateIndex:
+		return []any{
+			"operation", OpNameCreateIndex,
+			"name", o.Name,
+			"table", o.Table,
+			"index_type", o.Method,
+		}
+	case *OpCreateTable:
+		return []any{
+			"operation", OpNameCreateTable,
+			"name", o.Name,
+			"columns", getColumnNames(o.Columns),
+			"comment", o.Comment,
+			"constraints", getConstraintNames(o.Constraints),
+		}
+	case *OpDropColumn:
+		return []any{
+			"operation", OpNameDropColumn,
+			"column", o.Column,
+			"table", o.Table,
+		}
+	case *OpDropConstraint:
+		return []any{
+			"operation", OpNameDropConstraint,
+			"constraint", o.Name,
+			"table", o.Table,
+		}
+	case *OpDropIndex:
+		return []any{
+			"operation", OpNameDropIndex,
+			"name", o.Name,
+		}
+
+	case *OpDropMultiColumnConstraint:
+		return []any{
+			"operation", OpNameDropMultiColumnConstraint,
+			"constraint", o.Name,
+			"table", o.Table,
+		}
+	case *OpDropTable:
+		return []any{
+			"operation", OpNameDropTable,
+			"name", o.Name,
+		}
+	case *OpRawSQL:
+		return []any{
+			"operation", OpRawSQLName,
+			"up_expression", o.Up,
+			"down_expression", o.Down,
+		}
+	case *OpRenameColumn:
+		return []any{
+			"operation", OpNameRenameColumn,
+			"from", o.From,
+			"to", o.To,
+			"table", o.Table,
+		}
+	case *OpRenameConstraint:
+		return []any{
+			"operation", OpNameRenameConstraint,
+			"from", o.From,
+			"to", o.To,
+			"table", o.Table,
+		}
+	case *OpRenameTable:
+		return []any{
+			"operation", OpNameRenameTable,
+			"from", o.From,
+			"to", o.To,
+		}
+	case *OpSetCheckConstraint:
+		return []any{
+			"operation", OpNameAlterColumn,
+			"column", o.Column,
+			"table", o.Table,
+			"constraint", o.Check.Name,
+			"check", o.Check.Constraint,
+		}
+	case *OpSetComment:
+		args := []any{
+			"operation", OpNameAlterColumn,
+			"column", o.Column,
+			"table", o.Table,
+		}
+		if o.Comment != nil {
+			args = append(args, "comment", *o.Comment)
+		}
+		return args
+	case *OpSetDefault:
+		args := []any{
+			"operation", OpNameAlterColumn,
+			"table", o.Table,
+			"column", o.Column,
+		}
+		if o.Default != nil {
+			args = append(args, "default", *o.Default)
+		}
+		return args
+	case *OpSetForeignKey:
+		return []any{
+			"operation", OpNameAlterColumn,
+			"table", o.Table,
+			"column", o.Column,
+			"references", o.References.Name,
+		}
+	case *OpSetNotNull:
+		return []any{
+			"operation", OpNameAlterColumn,
+			"column", o.Column,
+			"table", o.Table,
+			"nullable", false,
+		}
+	case *OpSetReplicaIdentity:
+		return []any{
+			"operation", OpNameSetReplicaIdentity,
+			"table", o.Table,
+			"identity_type", o.Identity.Type,
+			"identity_index", o.Identity.Index,
+		}
+	case *OpSetUnique:
+		return []any{
+			"operation", OpNameAlterColumn,
+			"column", o.Column,
+			"table", o.Table,
+			"unique", true,
+		}
+	default:
+		return []any{}
+	}
+}
+
+func getColumnNames(cols []Column) []string {
+	columns := make([]string, len(cols))
+	for i, c := range cols {
+		columns[i] = c.Name
+	}
+	return columns
+}
+
+func getConstraintNames(cons []Constraint) []string {
+	constraints := make([]string, len(cons))
+	for i, c := range cons {
+		constraints[i] = c.Name
+	}
+	return constraints
+}
+
+func (l *noopLogger) LogMigrationStart(m *Migration)             {}
+func (l *noopLogger) LogMigrationComplete(m *Migration)          {}
+func (l *noopLogger) LogMigrationRollback(m *Migration)          {}
+func (l *noopLogger) LogMigrationRollbackComplete(m *Migration)  {}
+func (l *noopLogger) LogBackfillStart(table string)              {}
+func (l *noopLogger) LogBackfillComplete(table string)           {}
+func (l *noopLogger) LogSchemaCreation(migration, schema string) {}
+func (l *noopLogger) LogSchemaDeletion(migration, schema string) {}
+func (l *noopLogger) LogOperationStart(op Operation)             {}
+func (l *noopLogger) LogOperationComplete(op Operation)          {}
+func (l *noopLogger) LogOperationRollback(op Operation)          {}
+func (l *noopLogger) Info(msg string, args ...any)               {}

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	_ "github.com/lib/pq"
-	"github.com/pterm/pterm"
 
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
@@ -19,16 +18,16 @@ type Operation interface {
 	// version in the database (through a view)
 	// update the given views to expose the new schema version
 	// Returns the table that requires backfilling, if any.
-	Start(ctx context.Context, logger pterm.Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error)
+	Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error)
 
 	// Complete will update the database schema to match the current version
 	// after calling Start.
 	// This method should be called once the previous version is no longer used.
-	Complete(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error
+	Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error
 
 	// Rollback will revert the changes made by Start. It is not possible to
 	// rollback a completed migration.
-	Rollback(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error
+	Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error
 
 	// Validate returns a descriptive error if the operation cannot be applied to the given schema.
 	Validate(ctx context.Context, s *schema.Schema) error
@@ -83,12 +82,11 @@ func (m *Migration) Validate(ctx context.Context, s *schema.Schema) error {
 // made by the migration. No changes are made to the physical database.
 func (m *Migration) UpdateVirtualSchema(ctx context.Context, s *schema.Schema) error {
 	db := &db.FakeDB{}
-	logger := pterm.Logger{Level: pterm.LogLevelDisabled}
 
 	// Run `Start` on each operation using the fake DB. Updates will be made to
 	// the in-memory schema `s` without touching the physical database.
 	for _, op := range m.Operations {
-		if _, err := op.Start(ctx, logger, db, "", s); err != nil {
+		if _, err := op.Start(ctx, NewNoopLogger(), db, "", s); err != nil {
 			return err
 		}
 	}

--- a/pkg/migrations/op_change_type.go
+++ b/pkg/migrations/op_change_type.go
@@ -5,7 +5,6 @@ package migrations
 import (
 	"context"
 
-	"github.com/pterm/pterm"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
@@ -20,8 +19,8 @@ type OpChangeType struct {
 
 var _ Operation = (*OpChangeType)(nil)
 
-func (o *OpChangeType) Start(ctx context.Context, logger pterm.Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
-	logger.Info("starting operation", logger.Args(o.loggerArgs()...))
+func (o *OpChangeType) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
 	if table == nil {
@@ -31,14 +30,14 @@ func (o *OpChangeType) Start(ctx context.Context, logger pterm.Logger, conn db.D
 	return table, nil
 }
 
-func (o *OpChangeType) Complete(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("completing operation", logger.Args(o.loggerArgs()...))
+func (o *OpChangeType) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationComplete(o)
 
 	return nil
 }
 
-func (o *OpChangeType) Rollback(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("rolling back operation", logger.Args(o.loggerArgs()...))
+func (o *OpChangeType) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationRollback(o)
 
 	return nil
 }
@@ -52,13 +51,4 @@ func (o *OpChangeType) Validate(ctx context.Context, s *schema.Schema) error {
 		return FieldRequiredError{Name: "down"}
 	}
 	return nil
-}
-
-func (o *OpChangeType) loggerArgs() []any {
-	return []any{
-		"operation", OpNameAlterColumn,
-		"column", o.Column,
-		"table", o.Table,
-		"type", o.Type,
-	}
 }

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/lib/pq"
-	"github.com/pterm/pterm"
 
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
@@ -17,8 +16,8 @@ import (
 
 var _ Operation = (*OpCreateTable)(nil)
 
-func (o *OpCreateTable) Start(ctx context.Context, logger pterm.Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
-	logger.Info("starting operation", logger.Args(o.loggerArgs()...))
+func (o *OpCreateTable) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+	l.LogOperationStart(o)
 
 	// Generate SQL for the columns in the table
 	columnsSQL, err := columnsToSQL(o.Columns)
@@ -60,14 +59,16 @@ func (o *OpCreateTable) Start(ctx context.Context, logger pterm.Logger, conn db.
 	return nil, nil
 }
 
-func (o *OpCreateTable) Complete(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("completing operation", logger.Args(o.loggerArgs()...))
+func (o *OpCreateTable) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationComplete(o)
+
 	// No-op
 	return nil
 }
 
-func (o *OpCreateTable) Rollback(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("rolling back operation", logger.Args(o.loggerArgs()...))
+func (o *OpCreateTable) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationRollback(o)
+
 	_, err := conn.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s",
 		pq.QuoteIdentifier(o.Name)))
 	return err
@@ -338,30 +339,4 @@ func constraintsToSQL(constraints []Constraint) (string, error) {
 		return "", nil
 	}
 	return ", " + strings.Join(constraintsSQL, ", "), nil
-}
-
-func (o *OpCreateTable) loggerArgs() []any {
-	return []any{
-		"operation", OpNameCreateTable,
-		"name", o.Name,
-		"columns", getColumnNames(o.Columns),
-		"comment", o.Comment,
-		"constraints", getConstraintNames(o.Constraints),
-	}
-}
-
-func getColumnNames(cols []Column) []string {
-	columns := make([]string, len(cols))
-	for i, c := range cols {
-		columns[i] = c.Name
-	}
-	return columns
-}
-
-func getConstraintNames(cons []Constraint) []string {
-	constraints := make([]string, len(cons))
-	for i, c := range cons {
-		constraints[i] = c.Name
-	}
-	return constraints
 }

--- a/pkg/migrations/op_drop_constraint.go
+++ b/pkg/migrations/op_drop_constraint.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/lib/pq"
-	"github.com/pterm/pterm"
 
 	"github.com/xataio/pgroll/pkg/backfill"
 	"github.com/xataio/pgroll/pkg/db"
@@ -16,8 +15,8 @@ import (
 
 var _ Operation = (*OpDropConstraint)(nil)
 
-func (o *OpDropConstraint) Start(ctx context.Context, logger pterm.Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
-	logger.Info("starting operation", logger.Args(o.loggerArgs()...))
+func (o *OpDropConstraint) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
 	if table == nil {
@@ -80,8 +79,8 @@ func (o *OpDropConstraint) Start(ctx context.Context, logger pterm.Logger, conn 
 	return table, nil
 }
 
-func (o *OpDropConstraint) Complete(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("completing operation", logger.Args(o.loggerArgs()...))
+func (o *OpDropConstraint) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationComplete(o)
 
 	// We have already validated that there is single column related to this constraint.
 	table := s.GetTable(o.Table)
@@ -119,8 +118,8 @@ func (o *OpDropConstraint) Complete(ctx context.Context, logger pterm.Logger, co
 	return err
 }
 
-func (o *OpDropConstraint) Rollback(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("rolling back operation", logger.Args(o.loggerArgs()...))
+func (o *OpDropConstraint) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationRollback(o)
 
 	// We have already validated that there is single column related to this constraint.
 	table := s.GetTable(o.Table)
@@ -192,12 +191,4 @@ func (o *OpDropConstraint) upSQL(column string) string {
 	}
 
 	return pq.QuoteIdentifier(column)
-}
-
-func (o *OpDropConstraint) loggerArgs() []any {
-	return []any{
-		"operation", OpNameDropConstraint,
-		"constraint", o.Name,
-		"table", o.Table,
-	}
 }

--- a/pkg/migrations/op_drop_index.go
+++ b/pkg/migrations/op_drop_index.go
@@ -5,26 +5,28 @@ package migrations
 import (
 	"context"
 
-	"github.com/pterm/pterm"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
 
 var _ Operation = (*OpDropIndex)(nil)
 
-func (o *OpDropIndex) Start(ctx context.Context, logger pterm.Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
-	logger.Info("starting operation", logger.Args(o.loggerArgs()...))
+func (o *OpDropIndex) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+	l.LogOperationStart(o)
+
 	// no-op
 	return nil, nil
 }
 
-func (o *OpDropIndex) Complete(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("completing operation", logger.Args(o.loggerArgs()...))
+func (o *OpDropIndex) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationComplete(o)
+
 	return NewDropIndexAction(conn, o.Name).Execute(ctx)
 }
 
-func (o *OpDropIndex) Rollback(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("rolling back operation", logger.Args(o.loggerArgs()...))
+func (o *OpDropIndex) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationRollback(o)
+
 	// no-op
 	return nil
 }
@@ -37,11 +39,4 @@ func (o *OpDropIndex) Validate(ctx context.Context, s *schema.Schema) error {
 		}
 	}
 	return IndexDoesNotExistError{Name: o.Name}
-}
-
-func (o *OpDropIndex) loggerArgs() []any {
-	return []any{
-		"operation", OpNameDropIndex,
-		"name", o.Name,
-	}
 }

--- a/pkg/migrations/op_drop_multicolumn_constraint.go
+++ b/pkg/migrations/op_drop_multicolumn_constraint.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 
 	"github.com/lib/pq"
-	"github.com/pterm/pterm"
 
 	"github.com/xataio/pgroll/pkg/backfill"
 	"github.com/xataio/pgroll/pkg/db"
@@ -17,8 +16,8 @@ import (
 
 var _ Operation = (*OpDropMultiColumnConstraint)(nil)
 
-func (o *OpDropMultiColumnConstraint) Start(ctx context.Context, logger pterm.Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
-	logger.Info("starting operation", logger.Args(o.loggerArgs()...))
+func (o *OpDropMultiColumnConstraint) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
 	if table == nil {
@@ -95,8 +94,8 @@ func (o *OpDropMultiColumnConstraint) Start(ctx context.Context, logger pterm.Lo
 	return table, nil
 }
 
-func (o *OpDropMultiColumnConstraint) Complete(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("completing operation", logger.Args(o.loggerArgs()...))
+func (o *OpDropMultiColumnConstraint) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationComplete(o)
 
 	table := s.GetTable(o.Table)
 
@@ -133,8 +132,8 @@ func (o *OpDropMultiColumnConstraint) Complete(ctx context.Context, logger pterm
 	return nil
 }
 
-func (o *OpDropMultiColumnConstraint) Rollback(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("rolling back operation", logger.Args(o.loggerArgs()...))
+func (o *OpDropMultiColumnConstraint) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationRollback(o)
 
 	table := s.GetTable(o.Table)
 
@@ -212,12 +211,4 @@ func (o *OpDropMultiColumnConstraint) upSQL(column string) string {
 	}
 
 	return pq.QuoteIdentifier(column)
-}
-
-func (o *OpDropMultiColumnConstraint) loggerArgs() []any {
-	return []any{
-		"operation", OpNameDropMultiColumnConstraint,
-		"constraint", o.Name,
-		"table", o.Table,
-	}
 }

--- a/pkg/migrations/op_drop_not_null.go
+++ b/pkg/migrations/op_drop_not_null.go
@@ -5,7 +5,6 @@ package migrations
 import (
 	"context"
 
-	"github.com/pterm/pterm"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
@@ -20,8 +19,8 @@ type OpDropNotNull struct {
 
 var _ Operation = (*OpDropNotNull)(nil)
 
-func (o *OpDropNotNull) Start(ctx context.Context, logger pterm.Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
-	logger.Info("starting operation", logger.Args(o.loggerArgs()...))
+func (o *OpDropNotNull) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
 	if table == nil {
@@ -31,13 +30,13 @@ func (o *OpDropNotNull) Start(ctx context.Context, logger pterm.Logger, conn db.
 	return table, nil
 }
 
-func (o *OpDropNotNull) Complete(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("completing operation", logger.Args(o.loggerArgs()...))
+func (o *OpDropNotNull) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationComplete(o)
 	return nil
 }
 
-func (o *OpDropNotNull) Rollback(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("rolling back operation", logger.Args(o.loggerArgs()...))
+func (o *OpDropNotNull) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationRollback(o)
 	return nil
 }
 
@@ -52,12 +51,4 @@ func (o *OpDropNotNull) Validate(ctx context.Context, s *schema.Schema) error {
 	}
 
 	return nil
-}
-
-func (o *OpDropNotNull) loggerArgs() []any {
-	return []any{
-		"operation", OpNameAlterColumn,
-		"column", o.Column,
-		"table", o.Table,
-	}
 }

--- a/pkg/migrations/op_drop_table.go
+++ b/pkg/migrations/op_drop_table.go
@@ -6,15 +6,14 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pterm/pterm"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
 
 var _ Operation = (*OpDropTable)(nil)
 
-func (o *OpDropTable) Start(ctx context.Context, logger pterm.Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
-	logger.Info("starting operation", logger.Args(o.loggerArgs()...))
+func (o *OpDropTable) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Name)
 	if table == nil {
@@ -34,8 +33,8 @@ func (o *OpDropTable) Start(ctx context.Context, logger pterm.Logger, conn db.DB
 	return nil, nil
 }
 
-func (o *OpDropTable) Complete(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("completing operation", logger.Args(o.loggerArgs()...))
+func (o *OpDropTable) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationComplete(o)
 
 	deletionName := DeletionName(o.Name)
 
@@ -43,8 +42,8 @@ func (o *OpDropTable) Complete(ctx context.Context, logger pterm.Logger, conn db
 	return NewDropTableAction(conn, deletionName).Execute(ctx)
 }
 
-func (o *OpDropTable) Rollback(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("rolling back operation", logger.Args(o.loggerArgs()...))
+func (o *OpDropTable) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationRollback(o)
 
 	// Mark the table as no longer deleted so that it is visible to preceding
 	// Rollbacks in the same migration
@@ -70,11 +69,4 @@ func (o *OpDropTable) Validate(ctx context.Context, s *schema.Schema) error {
 
 	s.RemoveTable(table.Name)
 	return nil
-}
-
-func (o *OpDropTable) loggerArgs() []any {
-	return []any{
-		"operation", OpNameDropTable,
-		"name", o.Name,
-	}
 }

--- a/pkg/migrations/op_raw_sql.go
+++ b/pkg/migrations/op_raw_sql.go
@@ -5,15 +5,14 @@ package migrations
 import (
 	"context"
 
-	"github.com/pterm/pterm"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
 
 var _ Operation = (*OpRawSQL)(nil)
 
-func (o *OpRawSQL) Start(ctx context.Context, logger pterm.Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
-	logger.Info("starting operation", logger.Args(o.loggerArgs()...))
+func (o *OpRawSQL) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+	l.LogOperationStart(o)
 
 	if o.OnComplete {
 		return nil, nil
@@ -23,8 +22,8 @@ func (o *OpRawSQL) Start(ctx context.Context, logger pterm.Logger, conn db.DB, l
 	return nil, err
 }
 
-func (o *OpRawSQL) Complete(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("completing operation", logger.Args(o.loggerArgs()...))
+func (o *OpRawSQL) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationComplete(o)
 
 	if !o.OnComplete {
 		return nil
@@ -34,8 +33,8 @@ func (o *OpRawSQL) Complete(ctx context.Context, logger pterm.Logger, conn db.DB
 	return err
 }
 
-func (o *OpRawSQL) Rollback(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("rolling back operation", logger.Args(o.loggerArgs()...))
+func (o *OpRawSQL) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationRollback(o)
 
 	if o.Down == "" {
 		return nil
@@ -63,11 +62,3 @@ func (o *OpRawSQL) IsIsolated() bool {
 }
 
 func (o *OpRawSQL) RequiresSchemaRefresh() {}
-
-func (o *OpRawSQL) loggerArgs() []any {
-	return []any{
-		"operation", OpRawSQLName,
-		"up_expression", o.Up,
-		"down_expression", o.Down,
-	}
-}

--- a/pkg/migrations/op_rename_column.go
+++ b/pkg/migrations/op_rename_column.go
@@ -5,15 +5,14 @@ package migrations
 import (
 	"context"
 
-	"github.com/pterm/pterm"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
 
 var _ Operation = (*OpRenameColumn)(nil)
 
-func (o *OpRenameColumn) Start(ctx context.Context, logger pterm.Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
-	logger.Info("starting operation", logger.Args(o.loggerArgs()...))
+func (o *OpRenameColumn) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+	l.LogOperationStart(o)
 
 	// Rename the table in the in-memory schema.
 	table := s.GetTable(o.Table)
@@ -33,13 +32,13 @@ func (o *OpRenameColumn) Start(ctx context.Context, logger pterm.Logger, conn db
 	return nil, nil
 }
 
-func (o *OpRenameColumn) Complete(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("completing operation", logger.Args(o.loggerArgs()...))
+func (o *OpRenameColumn) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationComplete(o)
 	return NewRenameColumnAction(conn, o.Table, o.From, o.To).Execute(ctx)
 }
 
-func (o *OpRenameColumn) Rollback(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("rolling back operation", logger.Args(o.loggerArgs()...))
+func (o *OpRenameColumn) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationRollback(o)
 
 	// Rename the column back to the original name in the in-memory schema.
 	table := s.GetTable(o.Table)
@@ -82,13 +81,4 @@ func (o *OpRenameColumn) Validate(ctx context.Context, s *schema.Schema) error {
 	table.RenameConstraintColumns(o.From, o.To)
 
 	return nil
-}
-
-func (o *OpRenameColumn) loggerArgs() []any {
-	return []any{
-		"operation", OpNameRenameColumn,
-		"from", o.From,
-		"to", o.To,
-		"table", o.Table,
-	}
 }

--- a/pkg/migrations/op_rename_constraint.go
+++ b/pkg/migrations/op_rename_constraint.go
@@ -5,27 +5,29 @@ package migrations
 import (
 	"context"
 
-	"github.com/pterm/pterm"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
 
 var _ Operation = (*OpRenameConstraint)(nil)
 
-func (o *OpRenameConstraint) Start(ctx context.Context, logger pterm.Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
-	logger.Info("starting operation", logger.Args(o.loggerArgs()...))
+func (o *OpRenameConstraint) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+	l.LogOperationStart(o)
+
 	// no-op
 	return nil, nil
 }
 
-func (o *OpRenameConstraint) Complete(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("completing operation", logger.Args(o.loggerArgs()...))
+func (o *OpRenameConstraint) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationComplete(o)
+
 	// rename the constraint in the underlying table
 	return NewRenameConstraintAction(conn, o.Table, o.From, o.To).Execute(ctx)
 }
 
-func (o *OpRenameConstraint) Rollback(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("rolling back operation", logger.Args(o.loggerArgs()...))
+func (o *OpRenameConstraint) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationRollback(o)
+
 	// no-op
 	return nil
 }
@@ -50,13 +52,4 @@ func (o *OpRenameConstraint) Validate(ctx context.Context, s *schema.Schema) err
 	}
 
 	return nil
-}
-
-func (o *OpRenameConstraint) loggerArgs() []any {
-	return []any{
-		"operation", OpNameRenameConstraint,
-		"from", o.From,
-		"to", o.To,
-		"table", o.Table,
-	}
 }

--- a/pkg/migrations/op_set_default.go
+++ b/pkg/migrations/op_set_default.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/lib/pq"
-	"github.com/pterm/pterm"
 
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
@@ -23,8 +22,8 @@ type OpSetDefault struct {
 
 var _ Operation = (*OpSetDefault)(nil)
 
-func (o *OpSetDefault) Start(ctx context.Context, logger pterm.Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
-	logger.Info("starting operation", logger.Args(o.loggerArgs()...))
+func (o *OpSetDefault) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
 	if table == nil {
@@ -53,28 +52,18 @@ func (o *OpSetDefault) Start(ctx context.Context, logger pterm.Logger, conn db.D
 	return table, nil
 }
 
-func (o *OpSetDefault) Complete(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("completing operation", logger.Args(o.loggerArgs()...))
+func (o *OpSetDefault) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationComplete(o)
+
 	return nil
 }
 
-func (o *OpSetDefault) Rollback(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("rolling back operation", logger.Args(o.loggerArgs()...))
+func (o *OpSetDefault) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationRollback(o)
+
 	return nil
 }
 
 func (o *OpSetDefault) Validate(ctx context.Context, s *schema.Schema) error {
 	return nil
-}
-
-func (o *OpSetDefault) loggerArgs() []any {
-	args := []any{
-		"operation", OpNameAlterColumn,
-		"table", o.Table,
-		"column", o.Column,
-	}
-	if o.Default != nil {
-		args = append(args, "default", *o.Default)
-	}
-	return args
 }

--- a/pkg/migrations/op_set_notnull.go
+++ b/pkg/migrations/op_set_notnull.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/lib/pq"
-	"github.com/pterm/pterm"
 
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
@@ -22,8 +21,8 @@ type OpSetNotNull struct {
 
 var _ Operation = (*OpSetNotNull)(nil)
 
-func (o *OpSetNotNull) Start(ctx context.Context, logger pterm.Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
-	logger.Info("starting operation", logger.Args(o.loggerArgs()...))
+func (o *OpSetNotNull) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
 	if table == nil {
@@ -42,8 +41,8 @@ func (o *OpSetNotNull) Start(ctx context.Context, logger pterm.Logger, conn db.D
 	return table, nil
 }
 
-func (o *OpSetNotNull) Complete(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("completing operation", logger.Args(o.loggerArgs()...))
+func (o *OpSetNotNull) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationComplete(o)
 
 	// Validate the NOT NULL constraint on the old column.
 	// The constraint must be valid because:
@@ -75,8 +74,8 @@ func (o *OpSetNotNull) Complete(ctx context.Context, logger pterm.Logger, conn d
 	return nil
 }
 
-func (o *OpSetNotNull) Rollback(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("rolling back operation", logger.Args(o.loggerArgs()...))
+func (o *OpSetNotNull) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationRollback(o)
 
 	return nil
 }
@@ -93,13 +92,4 @@ func (o *OpSetNotNull) Validate(ctx context.Context, s *schema.Schema) error {
 	}
 
 	return nil
-}
-
-func (o *OpSetNotNull) loggerArgs() []any {
-	return []any{
-		"operation", OpNameAlterColumn,
-		"column", o.Column,
-		"table", o.Table,
-		"nullable", false,
-	}
 }

--- a/pkg/migrations/op_set_replica_identity.go
+++ b/pkg/migrations/op_set_replica_identity.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/lib/pq"
-	"github.com/pterm/pterm"
 
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
@@ -17,8 +16,8 @@ import (
 
 var _ Operation = (*OpSetReplicaIdentity)(nil)
 
-func (o *OpSetReplicaIdentity) Start(ctx context.Context, logger pterm.Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
-	logger.Info("starting operation", logger.Args(o.loggerArgs()...))
+func (o *OpSetReplicaIdentity) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+	l.LogOperationStart(o)
 
 	// build the correct form of the `SET REPLICA IDENTITY` statement based on the`identity type
 	identitySQL := strings.ToUpper(o.Identity.Type)
@@ -33,14 +32,16 @@ func (o *OpSetReplicaIdentity) Start(ctx context.Context, logger pterm.Logger, c
 	return nil, err
 }
 
-func (o *OpSetReplicaIdentity) Complete(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("completing operation", logger.Args(o.loggerArgs()...))
+func (o *OpSetReplicaIdentity) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationComplete(o)
+
 	// No-op
 	return nil
 }
 
-func (o *OpSetReplicaIdentity) Rollback(ctx context.Context, logger pterm.Logger, conn db.DB, s *schema.Schema) error {
-	logger.Info("rolling back operation", logger.Args(o.loggerArgs()...))
+func (o *OpSetReplicaIdentity) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+	l.LogOperationRollback(o)
+
 	// No-op
 	return nil
 }
@@ -65,13 +66,4 @@ func (o *OpSetReplicaIdentity) Validate(ctx context.Context, s *schema.Schema) e
 	}
 
 	return nil
-}
-
-func (o *OpSetReplicaIdentity) loggerArgs() []any {
-	return []any{
-		"operation", OpNameSetReplicaIdentity,
-		"table", o.Table,
-		"identity_type", o.Identity.Type,
-		"identity_index", o.Identity.Index,
-	}
 }

--- a/pkg/roll/options.go
+++ b/pkg/roll/options.go
@@ -2,8 +2,6 @@
 
 package roll
 
-import "github.com/pterm/pterm"
-
 type options struct {
 	// lock timeout in milliseconds for pgroll DDL operations
 	lockTimeoutMs int
@@ -25,7 +23,7 @@ type options struct {
 
 	migrationHooks MigrationHooks
 
-	logLevel pterm.LogLevel
+	verbose bool
 }
 
 // MigrationHooks defines hooks that can be set to be called at various points
@@ -101,7 +99,7 @@ func WithSkipValidation(skip bool) Option {
 func WithLogging(enabled bool) Option {
 	return func(o *options) {
 		if enabled {
-			o.logLevel = pterm.LogLevelInfo
+			o.verbose = enabled
 		}
 	}
 }


### PR DESCRIPTION
As requested in #804, I added a `Logger` interface for verbose mode. I have kept the interface minimal. I only added an extra `Info` function. But the idea is that we can extend this interface when we need to emit more logs.
