### PR TITLE
Default `pgroll pull` to write in YAML format and add a `--json` flag

### DIFF
--- a/cli-definition.json
+++ b/cli-definition.json
@@ -103,6 +103,12 @@
       "example": "",
       "flags": [
         {
+          "name": "json",
+          "shorthand": "j",
+          "description": "output each migration in JSON format instead of YAML",
+          "default": "false"
+        },
+        {
           "name": "with-prefixes",
           "shorthand": "p",
           "description": "prefix each migration filename with its position in the schema history",

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -14,8 +14,9 @@ import (
 func pullCmd() *cobra.Command {
 	opts := map[string]string{
 		"p": "prefix each migration filename with its position in the schema history",
+		"j": "output each migration in JSON format instead of YAML",
 	}
-	var withPrefixes bool
+	var withPrefixes, useJSON bool
 
 	pullCmd := &cobra.Command{
 		Use:       "pull <target directory>",
@@ -51,7 +52,7 @@ func pullCmd() *cobra.Command {
 				if withPrefixes {
 					prefix = fmt.Sprintf("%04d", i+1) + "_"
 				}
-				err := mig.WriteToFile(targetDir, prefix)
+				err := mig.WriteToFile(targetDir, prefix, useJSON)
 				if err != nil {
 					return fmt.Errorf("failed to write migration %q: %w", mig.Migration.Name, err)
 				}
@@ -61,6 +62,7 @@ func pullCmd() *cobra.Command {
 	}
 
 	pullCmd.Flags().BoolVarP(&withPrefixes, "with-prefixes", "p", false, opts["p"])
+	pullCmd.Flags().BoolVarP(&useJSON, "json", "j", false, opts["j"])
 
 	return pullCmd
 }

--- a/docs/cli/pull.mdx
+++ b/docs/cli/pull.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pull
-description: Pull the complete schema history of applied migrations from the target database and write the migrations to disk.
+description: Pull migrations from the target database into a local migrations directory
 ---
 
 ## Command
@@ -11,17 +11,17 @@ Assuming that all [example migrations](https://github.com/xataio/pgroll/tree/mai
 $ pgroll pull migrations/
 ```
 
-will write the complete schema history as `.json` files to the `migrations/` directory:
+will write the complete schema history as `.yaml` files to the `migrations/` directory:
 
 ```
 $ ls migrations/
 
-01_create_tables.json
-02_create_another_table.json
-03_add_column_to_products.json
-04_rename_table.json
-05_sql.json
-06_add_column_to_sql_table.json
+01_create_tables.yaml
+02_create_another_table.yaml
+03_add_column_to_products.yaml
+04_rename_table.yaml
+05_sql.yaml
+06_add_column_to_sql_table.yaml
 ...
 ```
 
@@ -30,15 +30,19 @@ The command takes an optional `--with-prefixes` flag which will write each filen
 ```
 $ ls migrations/
 
-0001_01_create_tables.json
-0002_02_create_another_table.json
-0003_03_add_column_to_products.json
-0004_04_rename_table.json
-0005_05_sql.json
-0006_06_add_column_to_sql_table.json
+0001_01_create_tables.yaml
+0002_02_create_another_table.yaml
+0003_03_add_column_to_products.yaml
+0004_04_rename_table.yaml
+0005_05_sql.yaml
+0006_06_add_column_to_sql_table.yaml
 ...
 ```
 
 The `--with-prefixes` flag ensures that files are sorted lexicographically by their time of application.
 
-If the directory specified as the required argument to `pgroll pull` does not exist, `pgroll pull` will create it.
+Use the `--json` flag to pull migrations in JSON format rather than YAML.
+
+If the target directory given to `pgroll pull` does not exist, `pgroll pull` will create it.
+
+If the target directory is empty, `pgroll pull` will pull all migrations from the target database. If the target directory contains migration files, `pgroll pull` will pull only those migrations that don't already exist in the directory.


### PR DESCRIPTION
Make `pgroll pull` default to pulling migrations in YAML format, rather than JSON.

Add a `--json` flag to the `pull` command to allow users to output migrations in JSON format instead of YAML.

We want to default to YAML as the output format, but provide an option for users to choose JSON if they prefer it. This is useful for users who may want to integrate the output with other tools or systems that work better with JSON.