### PR TITLE
Make `pgroll pull` pull only migrations that don't exist in target directory

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -4,9 +4,12 @@ package migrations
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 
 	_ "github.com/lib/pq"
+	"sigs.k8s.io/yaml"
 
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
@@ -101,4 +104,23 @@ func (m *Migration) ContainsRawSQLOperation() bool {
 		}
 	}
 	return false
+}
+
+// WriteAsJSON writes the migration to the given writer in JSON format
+func (m *Migration) WriteAsJSON(w io.Writer) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+
+	return encoder.Encode(m)
+}
+
+// WriteAsYAML writes the migration to the given writer in YAML format
+func (m *Migration) WriteAsYAML(w io.Writer) error {
+	yml, err := yaml.Marshal(m)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(yml)
+	return err
 }

--- a/pkg/roll/missing.go
+++ b/pkg/roll/missing.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package roll
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+
+	"github.com/xataio/pgroll/pkg/migrations"
+)
+
+// MissingMigrations returns the slice of migrations that have been applied to
+// the target database but are missing from the local migrations directory
+// `dir`. If the local order of migrations does not match the order of
+// migrations in the schema history, an `ErrMismatchedMigration` error is
+// returned.
+func (m *Roll) MissingMigrations(ctx context.Context, dir fs.FS) ([]*migrations.Migration, error) {
+	// Determine the latest version of the database
+	latestVersion, err := m.State().LatestVersion(ctx, m.Schema())
+	if err != nil {
+		return nil, fmt.Errorf("determining latest version: %w", err)
+	}
+
+	// If no migrations are applied, return a nil slice
+	if latestVersion == nil {
+		return nil, nil
+	}
+
+	// Collect all migration files from the directory
+	files, err := migrations.CollectFilesFromDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading migration files: %w", err)
+	}
+
+	// Get the full schema history from the database
+	history, err := m.State().SchemaHistory(ctx, m.Schema())
+	if err != nil {
+		return nil, fmt.Errorf("reading schema history: %w", err)
+	}
+
+	// Ensure that the schema history and the local migration files are in the
+	// same order up to the latest version applied to the database
+	for idx, h := range history {
+		if idx >= len(files) {
+			break
+		}
+
+		localMigration, err := migrations.ReadMigration(dir, files[idx])
+		if err != nil {
+			return nil, fmt.Errorf("failed to read migration file %q: %w", h.Migration.Name, err)
+		}
+		remoteMigration := h.Migration
+
+		if remoteMigration.Name != localMigration.Name {
+			return nil, fmt.Errorf("%w: remote=%q, local=%q", ErrMismatchedMigration, remoteMigration.Name, localMigration.Name)
+		}
+	}
+
+	// Return all the missing migrations
+	migs := make([]*migrations.Migration, 0, len(history))
+	for i := len(files); i < len(history); i++ {
+		migs = append(migs, &history[i].Migration)
+	}
+
+	return migs, nil
+}

--- a/pkg/roll/missing_test.go
+++ b/pkg/roll/missing_test.go
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package roll_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xataio/pgroll/internal/testutils"
+	"github.com/xataio/pgroll/pkg/backfill"
+	"github.com/xataio/pgroll/pkg/migrations"
+	"github.com/xataio/pgroll/pkg/roll"
+)
+
+func TestMissingMigrations(t *testing.T) {
+	t.Parallel()
+
+	t.Run("all migrations are missing; local directory is empty", func(t *testing.T) {
+		fs := fstest.MapFS{}
+
+		testutils.WithMigratorAndConnectionToContainer(t, func(roll *roll.Roll, _ *sql.DB) {
+			ctx := context.Background()
+
+			// Apply migrations to the target database
+			for _, migration := range []*migrations.Migration{
+				exampleMig(t, "01_migration_1"),
+				exampleMig(t, "02_migration_2"),
+			} {
+				err := roll.Start(ctx, migration, backfill.NewConfig())
+				require.NoError(t, err)
+				err = roll.Complete(ctx)
+				require.NoError(t, err)
+			}
+
+			// Get missing migrations
+			migs, err := roll.MissingMigrations(ctx, fs)
+			require.NoError(t, err)
+
+			// Assert that all migrations are missing in the local directory
+			require.Len(t, migs, 2)
+			require.Equal(t, "01_migration_1", migs[0].Name)
+			require.Equal(t, "02_migration_2", migs[1].Name)
+		})
+	})
+
+	t.Run("second migration is missing in the migrations directory", func(t *testing.T) {
+		fs := fstest.MapFS{
+			"01_migration_1.json": &fstest.MapFile{Data: exampleMigJSON(t, "01_migration_1")},
+		}
+
+		testutils.WithMigratorAndConnectionToContainer(t, func(roll *roll.Roll, _ *sql.DB) {
+			ctx := context.Background()
+
+			// Apply migrations to the target database
+			for _, migration := range []*migrations.Migration{
+				exampleMig(t, "01_migration_1"),
+				exampleMig(t, "02_migration_2"),
+			} {
+				err := roll.Start(ctx, migration, backfill.NewConfig())
+				require.NoError(t, err)
+				err = roll.Complete(ctx)
+				require.NoError(t, err)
+			}
+
+			// Get missing migrations
+			migs, err := roll.MissingMigrations(ctx, fs)
+			require.NoError(t, err)
+
+			// Assert that the second migration is missing in the local directory
+			require.Len(t, migs, 1)
+			require.Equal(t, "02_migration_2", migs[0].Name)
+		})
+	})
+
+	t.Run("all migrations are present in the migrations directory", func(t *testing.T) {
+		fs := fstest.MapFS{
+			"01_migration_1.json": &fstest.MapFile{Data: exampleMigJSON(t, "01_migration_1")},
+			"02_migration_2.json": &fstest.MapFile{Data: exampleMigJSON(t, "02_migration_2")},
+		}
+
+		testutils.WithMigratorAndConnectionToContainer(t, func(roll *roll.Roll, _ *sql.DB) {
+			ctx := context.Background()
+
+			// Apply migrations to the target database
+			for _, migration := range []*migrations.Migration{
+				exampleMig(t, "01_migration_1"),
+				exampleMig(t, "02_migration_2"),
+			} {
+				err := roll.Start(ctx, migration, backfill.NewConfig())
+				require.NoError(t, err)
+				err = roll.Complete(ctx)
+				require.NoError(t, err)
+			}
+
+			// Get missing migrations
+			migs, err := roll.MissingMigrations(ctx, fs)
+			require.NoError(t, err)
+
+			// Assert that no migrations are missing in the local directory
+			require.Len(t, migs, 0)
+		})
+	})
+
+	t.Run("more migrations are present in the migrations directory than on the target database", func(t *testing.T) {
+		fs := fstest.MapFS{
+			"01_migration_1.json": &fstest.MapFile{Data: exampleMigJSON(t, "01_migration_1")},
+			"02_migration_2.json": &fstest.MapFile{Data: exampleMigJSON(t, "02_migration_2")},
+			"03_migration_3.json": &fstest.MapFile{Data: exampleMigJSON(t, "03_migration_3")},
+		}
+
+		testutils.WithMigratorAndConnectionToContainer(t, func(roll *roll.Roll, _ *sql.DB) {
+			ctx := context.Background()
+
+			// Apply migrations to the target database
+			for _, migration := range []*migrations.Migration{
+				exampleMig(t, "01_migration_1"),
+				exampleMig(t, "02_migration_2"),
+			} {
+				err := roll.Start(ctx, migration, backfill.NewConfig())
+				require.NoError(t, err)
+				err = roll.Complete(ctx)
+				require.NoError(t, err)
+			}
+
+			// Get missing migrations
+			migs, err := roll.MissingMigrations(ctx, fs)
+			require.NoError(t, err)
+
+			// Assert that no migrations are missing in the local directory
+			require.Len(t, migs, 0)
+		})
+	})
+
+	t.Run("remote migration history does not match local directory migration history", func(t *testing.T) {
+		fs := fstest.MapFS{
+			"01_migration_1.json": &fstest.MapFile{Data: exampleMigJSON(t, "01_migration_1")},
+			"05_migration_5.json": &fstest.MapFile{Data: exampleMigJSON(t, "05_migration_5")},
+		}
+
+		testutils.WithMigratorAndConnectionToContainer(t, func(m *roll.Roll, _ *sql.DB) {
+			ctx := context.Background()
+
+			// Apply migrations to the target database
+			for _, migration := range []*migrations.Migration{
+				exampleMig(t, "01_migration_1"),
+				exampleMig(t, "02_migration_2"),
+			} {
+				err := m.Start(ctx, migration, backfill.NewConfig())
+				require.NoError(t, err)
+				err = m.Complete(ctx)
+				require.NoError(t, err)
+			}
+
+			// Get missing migrations
+			_, err := m.MissingMigrations(ctx, fs)
+
+			// Assert that a mismatched migration error is returned
+			require.ErrorIs(t, err, roll.ErrMismatchedMigration)
+		})
+	})
+
+	t.Run("migrations with no name use filename as migration name", func(t *testing.T) {
+		fs := fstest.MapFS{
+			"01_migration_1.json": &fstest.MapFile{Data: exampleMigJSON(t, "")},
+		}
+
+		testutils.WithMigratorAndConnectionToContainer(t, func(m *roll.Roll, _ *sql.DB) {
+			ctx := context.Background()
+
+			// Apply migrations to the target database
+			for _, migration := range []*migrations.Migration{
+				exampleMig(t, "01_migration_1"),
+			} {
+				err := m.Start(ctx, migration, backfill.NewConfig())
+				require.NoError(t, err)
+				err = m.Complete(ctx)
+				require.NoError(t, err)
+			}
+
+			// Get missing migrations
+			migs, err := m.MissingMigrations(ctx, fs)
+			require.NoError(t, err)
+
+			// Assert that no migrations are missing in the local directory; the
+			// unamed migration uses the filename as the name
+			require.Len(t, migs, 0)
+		})
+	})
+}
+
+func exampleMig(t *testing.T, name string) *migrations.Migration {
+	t.Helper()
+
+	migration := &migrations.Migration{
+		Name: name,
+		Operations: migrations.Operations{
+			&migrations.OpRawSQL{
+				Up: "SELECT 1",
+			},
+		},
+	}
+
+	return migration
+}
+
+func exampleMigJSON(t *testing.T, name string) []byte {
+	t.Helper()
+
+	migration := exampleMig(t, name)
+	json, err := json.Marshal(migration)
+	require.NoError(t, err)
+
+	return json
+}

--- a/pkg/state/history.go
+++ b/pkg/state/history.go
@@ -6,13 +6,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/lib/pq"
-	"sigs.k8s.io/yaml"
 
 	"github.com/xataio/pgroll/pkg/migrations"
 )
@@ -62,51 +58,4 @@ func (s *State) SchemaHistory(ctx context.Context, schema string) ([]Migration, 
 	}
 
 	return entries, nil
-}
-
-// WriteToFile writes the migration to a file in `targetDir`, prefixing the
-// filename with `prefix`. The output format defaults to YAML, but can
-// be changed to JSON by setting `useJSON` to true.
-func (m *Migration) WriteToFile(targetDir, prefix string, useJSON bool) error {
-	err := os.MkdirAll(targetDir, 0o755)
-	if err != nil {
-		return err
-	}
-
-	suffix := "yaml"
-	if useJSON {
-		suffix = "json"
-	}
-
-	fileName := fmt.Sprintf("%s%s.%s", prefix, m.Migration.Name, suffix)
-	filePath := filepath.Join(targetDir, fileName)
-
-	file, err := os.Create(filePath)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	if useJSON {
-		return m.writeAsJSON(file)
-	} else {
-		return m.writeAsYAML(file)
-	}
-}
-
-func (m *Migration) writeAsJSON(w io.Writer) error {
-	encoder := json.NewEncoder(w)
-	encoder.SetIndent("", "  ")
-
-	return encoder.Encode(m.Migration)
-}
-
-func (m *Migration) writeAsYAML(w io.Writer) error {
-	yml, err := yaml.Marshal(m.Migration)
-	if err != nil {
-		return err
-	}
-
-	_, err = w.Write(yml)
-	return err
 }


### PR DESCRIPTION
Make the `pgroll pull` command pull only those migrations from the target database that are missing in the local directory.

This ensures that existing migrations in the local directory are not overwritten or modified when pulling from the target database, for example with formatting or order-of-field changes.