### PR TITLE
Make `pgroll pull` and `pgroll migrate` command able to handle incompatible migration file formats

### DIFF
--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -87,7 +87,7 @@ func pullCmd() *cobra.Command {
 // WriteToFile writes the migration to a file in `targetDir`, prefixing the
 // filename with `prefix`. The output format defaults to YAML, but can
 // be changed to JSON by setting `useJSON` to true.
-func writeMigrationToFile(m *migrations.Migration, targetDir, prefix string, useJSON bool) error {
+func writeMigrationToFile(m *migrations.RawMigration, targetDir, prefix string, useJSON bool) error {
 	err := os.MkdirAll(targetDir, 0o755)
 	if err != nil {
 		return err

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -6,10 +6,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 
 	_ "github.com/lib/pq"
-	"sigs.k8s.io/yaml"
 
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
@@ -54,9 +52,12 @@ type RequiresSchemaRefreshOperation interface {
 type (
 	Operations []Operation
 	Migration  struct {
-		Name string `json:"name,omitempty"`
-
+		Name       string     `json:"name,omitempty"`
 		Operations Operations `json:"operations"`
+	}
+	RawMigration struct {
+		Name       string          `json:"name"`
+		Operations json.RawMessage `json:"operations"`
 	}
 )
 
@@ -104,23 +105,4 @@ func (m *Migration) ContainsRawSQLOperation() bool {
 		}
 	}
 	return false
-}
-
-// WriteAsJSON writes the migration to the given writer in JSON format
-func (m *Migration) WriteAsJSON(w io.Writer) error {
-	encoder := json.NewEncoder(w)
-	encoder.SetIndent("", "  ")
-
-	return encoder.Encode(m)
-}
-
-// WriteAsYAML writes the migration to the given writer in YAML format
-func (m *Migration) WriteAsYAML(w io.Writer) error {
-	yml, err := yaml.Marshal(m)
-	if err != nil {
-		return err
-	}
-
-	_, err = w.Write(yml)
-	return err
 }

--- a/pkg/roll/missing.go
+++ b/pkg/roll/missing.go
@@ -13,7 +13,7 @@ import (
 // MissingMigrations returns the slice of migrations that have been applied to
 // the target database but are missing from the local migrations directory
 // `dir`.
-func (m *Roll) MissingMigrations(ctx context.Context, dir fs.FS) ([]*migrations.Migration, error) {
+func (m *Roll) MissingMigrations(ctx context.Context, dir fs.FS) ([]*migrations.RawMigration, error) {
 	// Determine the latest version of the database
 	latestVersion, err := m.State().LatestVersion(ctx, m.Schema())
 	if err != nil {
@@ -34,7 +34,7 @@ func (m *Roll) MissingMigrations(ctx context.Context, dir fs.FS) ([]*migrations.
 	// Create a set of local migration names for fast lookup
 	localMigNames := make(map[string]struct{}, len(files))
 	for _, file := range files {
-		mig, err := migrations.ReadMigration(dir, file)
+		mig, err := migrations.ReadRawMigration(dir, file)
 		if err != nil {
 			return nil, fmt.Errorf("reading migration file %s: %w", file, err)
 		}
@@ -49,7 +49,7 @@ func (m *Roll) MissingMigrations(ctx context.Context, dir fs.FS) ([]*migrations.
 
 	// Find all migrations that have been applied to the database but are missing
 	// from the local directory
-	migs := make([]*migrations.Migration, 0, len(history))
+	migs := make([]*migrations.RawMigration, 0, len(history))
 	for _, h := range history {
 		if _, ok := localMigNames[h.Migration.Name]; ok {
 			continue

--- a/pkg/roll/unapplied.go
+++ b/pkg/roll/unapplied.go
@@ -16,7 +16,7 @@ import (
 //
 // If the local order of migrations does not match the order of migrations in
 // the schema history, an `ErrMismatchedMigration` error is returned.
-func (m *Roll) UnappliedMigrations(ctx context.Context, dir fs.FS) ([]*migrations.Migration, error) {
+func (m *Roll) UnappliedMigrations(ctx context.Context, dir fs.FS) ([]*migrations.RawMigration, error) {
 	latestVersion, err := m.State().LatestVersion(ctx, m.Schema())
 	if err != nil {
 		return nil, fmt.Errorf("determining latest version: %w", err)
@@ -36,7 +36,7 @@ func (m *Roll) UnappliedMigrations(ctx context.Context, dir fs.FS) ([]*migration
 	var idx int
 	if latestVersion != nil {
 		for _, file := range files {
-			migration, err := migrations.ReadMigration(dir, file)
+			migration, err := migrations.ReadRawMigration(dir, file)
 			if err != nil {
 				return nil, fmt.Errorf("reading migration file %q: %w", file, err)
 			}
@@ -54,9 +54,9 @@ func (m *Roll) UnappliedMigrations(ctx context.Context, dir fs.FS) ([]*migration
 	}
 
 	// Return all unapplied migrations
-	migs := make([]*migrations.Migration, 0, len(files))
+	migs := make([]*migrations.RawMigration, 0, len(files))
 	for _, file := range files[idx:] {
-		migration, err := migrations.ReadMigration(dir, file)
+		migration, err := migrations.ReadRawMigration(dir, file)
 		if err != nil {
 			return nil, fmt.Errorf("reading migration file %q: %w", file, err)
 		}

--- a/pkg/state/history_test.go
+++ b/pkg/state/history_test.go
@@ -61,16 +61,21 @@ func TestSchemaHistoryReturnsFullSchemaHistory(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		// Ensure that the schema history is correct
+		// Get the schema history
 		res, err := state.SchemaHistory(ctx, "public")
 		require.NoError(t, err)
 
-		assert.Equal(t, 2, len(res))
-		assert.Equal(t, migs[0].Name, res[0].Migration.Name)
-		assert.Equal(t, migs[1].Name, res[1].Migration.Name)
+		// Parse the raw migrations from the schema history into actual migrations
+		actualMigs := make([]migrations.Migration, len(migs))
+		for i := range res {
+			m, err := migrations.ParseMigration(&res[i].Migration)
+			require.NoError(t, err)
+			actualMigs[i] = *m
+		}
 
-		assert.Equal(t, migs[0].Operations, res[0].Migration.Operations)
-		assert.Equal(t, migs[1].Operations, res[1].Migration.Operations)
+		// Assert that the schema history is correct
+		assert.Equal(t, 2, len(res))
+		assert.Equal(t, migs, actualMigs)
 	})
 }
 


### PR DESCRIPTION
Ensure that the `pgroll pull` and `pgroll migrate` commands are able to operate safely when either:

* The local migration directory contains migrations that can not be deserialized by the current version of `pgroll`.
* The migration history in the target database contains migrations that can not be deserialized by the current version of `pgroll`.

This ensures that these commands work in the presence of older migration formats, either locally or in the remote schema history.

This is done by adding a new `RawMigration` type to the `migrations` package, which does not deserialize the `Operations` in the migration but leaves them as a `json.RawMessage`. 

The following methods in the `roll` and `state` packages are then updated to work with and return `RawMigrations`:

* `SchemaHistory` - used to return the schema history from the target database.
* `MissingMigrations` - used to find remote migrations that don't exist in the local history
* `UnappliedMigrations` - used to find local migrations that don't exist in the remote.

By updating these methods and the `pull` and `migrate` commands that use them, these commands can work safely even with local or remote migrations that can't be deserialized by the current version of `pgroll`.

Tests are added for both the `MissingMigrations` and `UnappliedMigrations` methods to ensure that they work with un-deserializable migrations.

Part of https://github.com/xataio/pgroll/issues/770