### PR TITLE
Add new section to docs sidebar: Release notes

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -221,6 +221,11 @@
           "file": "docs/operations/set_replica_identity.mdx"
         }
       ]
+    },
+    {
+      "title": "Release notes",
+      "href": "/releases",
+      "file": "docs/releases/README.md"
     }
   ]
 }

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,0 +1,20 @@
+# Release notes
+
+Check out the release notes of past versions:
+
+* [v0.12.0](https://github.com/xataio/pgroll/releases/tag/v0.12.0)
+* [v0.11.1](https://github.com/xataio/pgroll/releases/tag/v0.11.1)
+* [v0.11.0](https://github.com/xataio/pgroll/releases/tag/v0.11.0)
+* [v0.10.0](https://github.com/xataio/pgroll/releases/tag/v0.10.0)
+* [v0.9.0](https://github.com/xataio/pgroll/releases/tag/v0.9.0)
+* [v0.8.0](https://github.com/xataio/pgroll/releases/tag/v0.8.0)
+* [v0.7.0](https://github.com/xataio/pgroll/releases/tag/v0.7.0)
+* [v0.6.0](https://github.com/xataio/pgroll/releases/tag/v0.5.0)
+* [v0.5.0](https://github.com/xataio/pgroll/releases/tag/v0.5.0)
+* [v0.4.4](https://github.com/xataio/pgroll/releases/tag/v0.4.4)
+* [v0.4.1](https://github.com/xataio/pgroll/releases/tag/v0.4.1)
+* [v0.4.0](https://github.com/xataio/pgroll/releases/tag/v0.4.0)
+* [v0.3.0](https://github.com/xataio/pgroll/releases/tag/v0.3.0)
+* [v0.2.1](https://github.com/xataio/pgroll/releases/tag/v0.2.1)
+* [v0.2.0](https://github.com/xataio/pgroll/releases/tag/v0.2.0)
+* [v0.1.0](https://github.com/xataio/pgroll/releases/tag/v0.1.0)


### PR DESCRIPTION
This PR adds a new section to the left sidebar called: release notes. It contains links to past `pgroll` release notes on Github. It is more of an idea, than a thought. I have seen other documentations linking to past release notes. Maybe we can include such a page as well.
