### PR TITLE
Add an extra test case for missing local migrations

### DIFF
--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -60,7 +60,7 @@ func pullCmd() *cobra.Command {
 			// the target database but are missing in the local directory).
 			migs, err := m.MissingMigrations(ctx, os.DirFS(targetDir))
 			if err != nil {
-				return fmt.Errorf("failed to read migrations from target directory: %w", err)
+				return fmt.Errorf("failed to get missing migrations: %w", err)
 			}
 
 			// Write the missing migrations to the target directory

--- a/pkg/roll/missing_test.go
+++ b/pkg/roll/missing_test.go
@@ -166,6 +166,24 @@ func TestMissingMigrations(t *testing.T) {
 		})
 	})
 
+	t.Run("no migrations have been applied to the target database", func(t *testing.T) {
+		fs := fstest.MapFS{
+			"01_migration_1.json": &fstest.MapFile{Data: exampleMigJSON(t, "01_migration_1")},
+			"02_migration_2.json": &fstest.MapFile{Data: exampleMigJSON(t, "02_migration_2")},
+		}
+
+		testutils.WithMigratorAndConnectionToContainer(t, func(m *roll.Roll, _ *sql.DB) {
+			ctx := context.Background()
+
+			// Get missing migrations
+			migs, err := m.MissingMigrations(ctx, fs)
+			require.NoError(t, err)
+
+			// Assert that no migrations are missing from the local directory
+			require.Len(t, migs, 0)
+		})
+	})
+
 	t.Run("migrations with no name use filename as migration name", func(t *testing.T) {
 		fs := fstest.MapFS{
 			"01_migration_1.json": &fstest.MapFile{Data: exampleMigJSON(t, "")},


### PR DESCRIPTION
Ensure that when no migrations have been applied to the target database, the `MissingMigrations` function returns an empty slice.

Also, update an error message in the pull command to be more accurate.

This should have been part of https://github.com/xataio/pgroll/pull/811