### PR TITLE
Remove duplicated initialization checks across subcommands

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -26,12 +26,8 @@ var analyzeCmd = &cobra.Command{
 		defer state.Close()
 
 		// Ensure that pgroll is initialized
-		ok, err := state.IsInitialized(cmd.Context())
-		if err != nil {
+		if err := EnsureInitialized(ctx, state); err != nil {
 			return err
-		}
-		if !ok {
-			return errPGRollNotInitialized
 		}
 
 		schema, err := state.ReadSchema(ctx, flags.Schema())

--- a/cmd/complete.go
+++ b/cmd/complete.go
@@ -13,20 +13,12 @@ var completeCmd = &cobra.Command{
 	Use:   "complete <file>",
 	Short: "Complete an ongoing migration with the operations present in the given file",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		m, err := NewRoll(cmd.Context())
+		// Create a roll instance and check if pgroll is initialized
+		m, err := NewRollWithInitCheck(cmd.Context())
 		if err != nil {
 			return err
 		}
 		defer m.Close()
-
-		// Ensure that pgroll is initialized
-		ok, err := m.State().IsInitialized(cmd.Context())
-		if err != nil {
-			return err
-		}
-		if !ok {
-			return errPGRollNotInitialized
-		}
 
 		sp, _ := pterm.DefaultSpinner.WithText("Completing migration...").Start()
 		err = m.Complete(cmd.Context())

--- a/cmd/latest.go
+++ b/cmd/latest.go
@@ -79,21 +79,12 @@ func latestVersionLocal(ctx context.Context, migrationsDir string, withSchema bo
 
 // latestVersionRemote returns the latest applied migration version on the target database
 func latestVersionRemote(ctx context.Context, withSchema bool) (string, error) {
-	// Create a new Roll instance
-	m, err := NewRoll(ctx)
+	// Create a roll instance and check if pgroll is initialized
+	m, err := NewRollWithInitCheck(ctx)
 	if err != nil {
 		return "", err
 	}
 	defer m.Close()
-
-	// Ensure that pgroll is initialized
-	ok, err := m.State().IsInitialized(ctx)
-	if err != nil {
-		return "", err
-	}
-	if !ok {
-		return "", errPGRollNotInitialized
-	}
 
 	// Get the latest version in the target schema
 	latestVersion, err := m.LatestVersionRemote(ctx)

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -30,20 +30,12 @@ func migrateCmd() *cobra.Command {
 			ctx := cmd.Context()
 			migrationsDir := args[0]
 
-			m, err := NewRoll(ctx)
+			// Create a roll instance and check if pgroll is initialized
+			m, err := NewRollWithInitCheck(ctx)
 			if err != nil {
 				return err
 			}
 			defer m.Close()
-
-			// Ensure that pgroll is initialized
-			ok, err := m.State().IsInitialized(cmd.Context())
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return errPGRollNotInitialized
-			}
 
 			latestVersion, err := m.State().LatestVersion(ctx, m.Schema())
 			if err != nil {

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -27,20 +27,12 @@ func pullCmd() *cobra.Command {
 			ctx := cmd.Context()
 			targetDir := args[0]
 
-			m, err := NewRoll(ctx)
+			// Create a roll instance and check if pgroll is initialized
+			m, err := NewRollWithInitCheck(ctx)
 			if err != nil {
 				return err
 			}
 			defer m.Close()
-
-			// Ensure that pgroll is initialized
-			ok, err := m.State().IsInitialized(cmd.Context())
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return errPGRollNotInitialized
-			}
 
 			// Ensure that the target directory is valid, creating it if it doesn't
 			// exist

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -13,20 +13,12 @@ var rollbackCmd = &cobra.Command{
 	Use:   "rollback",
 	Short: "Roll back an ongoing migration",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		m, err := NewRoll(cmd.Context())
+		// Create a roll instance and check if pgroll is initialized
+		m, err := NewRollWithInitCheck(cmd.Context())
 		if err != nil {
 			return err
 		}
 		defer m.Close()
-
-		// Ensure that pgroll is initialized
-		ok, err := m.State().IsInitialized(cmd.Context())
-		if err != nil {
-			return err
-		}
-		if !ok {
-			return errPGRollNotInitialized
-		}
 
 		sp, _ := pterm.DefaultSpinner.WithText("Rolling back migration...").Start()
 		err = m.Rollback(cmd.Context())

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -33,20 +33,12 @@ func startCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fileName := args[0]
 
-			m, err := NewRoll(cmd.Context())
+			// Create a roll instance and check if pgroll is initialized
+			m, err := NewRollWithInitCheck(cmd.Context())
 			if err != nil {
 				return err
 			}
 			defer m.Close()
-
-			// Ensure that pgroll is initialized
-			ok, err := m.State().IsInitialized(cmd.Context())
-			if err != nil {
-				return err
-			}
-			if !ok {
-				return errPGRollNotInitialized
-			}
 
 			c := backfill.NewConfig(
 				backfill.WithBatchSize(batchSize),

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -25,12 +25,8 @@ var statusCmd = &cobra.Command{
 		defer state.Close()
 
 		// Ensure that pgroll is initialized
-		ok, err := state.IsInitialized(ctx)
-		if err != nil {
+		if err := EnsureInitialized(ctx, state); err != nil {
 			return err
-		}
-		if !ok {
-			return errPGRollNotInitialized
 		}
 
 		status, err := state.Status(ctx, flags.Schema())


### PR DESCRIPTION
De-duplicate the initizalization checks in various commands by extracting new functions to `cmd/root.go`.