### PR TITLE
Refactoring of writing migrations to file

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -4,7 +4,6 @@ package cmd
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -16,6 +15,7 @@ import (
 
 func convertCmd() *cobra.Command {
 	var migrationName string
+	var useJSON bool
 
 	convertCmd := &cobra.Command{
 		Use:       "convert <path to file with migrations>",
@@ -34,16 +34,16 @@ func convertCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			enc := json.NewEncoder(os.Stdout)
-			enc.SetIndent("", "  ")
-			if err := enc.Encode(migration); err != nil {
-				return fmt.Errorf("encode migration: %w", err)
+			err = migrations.NewWriter(os.Stdout, migrations.NewMigrationFormat(useJSON)).Write(&migration)
+			if err != nil {
+				return fmt.Errorf("failed to write migration to stdout: %w", err)
 			}
 			return nil
 		},
 	}
 
 	convertCmd.Flags().StringVarP(&migrationName, "name", "n", "", "Name of the migration")
+	convertCmd.Flags().BoolVarP(&useJSON, "json", "j", false, "Output migration file in JSON format instead of YAML")
 
 	return convertCmd
 }

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -85,12 +85,8 @@ func writeMigrationToFile(m *migrations.RawMigration, targetDir, prefix string, 
 		return err
 	}
 
-	suffix := "yaml"
-	if useJSON {
-		suffix = "json"
-	}
-
-	fileName := fmt.Sprintf("%s%s.%s", prefix, m.Name, suffix)
+	format := migrations.NewMigrationFormat(useJSON)
+	fileName := fmt.Sprintf("%s%s.%s", prefix, m.Name, format.Extension())
 	filePath := filepath.Join(targetDir, fileName)
 
 	file, err := os.Create(filePath)
@@ -99,9 +95,5 @@ func writeMigrationToFile(m *migrations.RawMigration, targetDir, prefix string, 
 	}
 	defer file.Close()
 
-	if useJSON {
-		return m.WriteAsJSON(file)
-	} else {
-		return m.WriteAsYAML(file)
-	}
+	return migrations.NewWriter(file, format).WriteRaw(m)
 }

--- a/pkg/migrations/op_common.go
+++ b/pkg/migrations/op_common.go
@@ -322,22 +322,3 @@ func OperationFromName(name OpName) (Operation, error) {
 	}
 	return nil, fmt.Errorf("unknown migration type: %v", name)
 }
-
-// WriteAsJSON writes the migration to the given writer in JSON format
-func (m *RawMigration) WriteAsJSON(w io.Writer) error {
-	encoder := json.NewEncoder(w)
-	encoder.SetIndent("", "  ")
-
-	return encoder.Encode(m)
-}
-
-// WriteAsYAML writes the migration to the given writer in YAML format
-func (m *RawMigration) WriteAsYAML(w io.Writer) error {
-	yml, err := yaml.Marshal(m)
-	if err != nil {
-		return err
-	}
-
-	_, err = w.Write(yml)
-	return err
-}

--- a/pkg/migrations/writer.go
+++ b/pkg/migrations/writer.go
@@ -1,0 +1,86 @@
+package migrations
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"sigs.k8s.io/yaml"
+)
+
+type MigrationFormat int
+
+const (
+	InvalidMigrationFormat MigrationFormat = iota
+	YAMLMigrationFormat
+	JSONMigrationFormat
+)
+
+var (
+	ErrInvalidMigrationFormat = errors.New("invalid migration format")
+)
+
+// MigrationWriter is responsible for writing Migrations and RawMigrations
+// to the configured io.Writer instance in either YAML or JSON.
+type MigrationWriter struct {
+	writer io.Writer
+	format MigrationFormat
+}
+
+// NewMigrationFormat returns YAML or JSON format
+func NewMigrationFormat(useJSON bool) MigrationFormat {
+	if useJSON {
+		return JSONMigrationFormat
+	}
+	return YAMLMigrationFormat
+}
+
+// Extension returns the extension name for the migration file
+func (f MigrationFormat) Extension() string {
+	switch f {
+	case YAMLMigrationFormat:
+		return "yaml"
+	case JSONMigrationFormat:
+		return "json"
+	}
+	return ""
+}
+
+// NewWriter creates a new MigrationWriter
+func NewWriter(w io.Writer, f MigrationFormat) *MigrationWriter {
+	return &MigrationWriter{
+		writer: w,
+		format: f,
+	}
+}
+
+func (w *MigrationWriter) Write(m *Migration) error {
+	return w.writeAny(m)
+}
+
+func (w *MigrationWriter) WriteRaw(m *RawMigration) error {
+	return w.writeAny(m)
+}
+
+func (w *MigrationWriter) writeAny(migration any) error {
+	switch w.format {
+	case YAMLMigrationFormat:
+		yml, err := yaml.Marshal(migration)
+		if err != nil {
+			return err
+		}
+		_, err = w.writer.Write(yml)
+		return fmt.Errorf("encode yaml migration: %w", err)
+	case JSONMigrationFormat:
+		enc := json.NewEncoder(w.writer)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(migration); err != nil {
+			return fmt.Errorf("encode json migration: %w", err)
+		}
+	default:
+		return ErrInvalidMigrationFormat
+	}
+	return nil
+
+}


### PR DESCRIPTION
This PR adds a new type `MigrationWriter` to provied a unified way to write migrations
to file either in YAML or in JSON format. It is used in 3 commands: `convert`, `create` and `pull`.

Also with this change I added a new flag to `convert` called `json`. Previously, the command serialized migrations
into JSON format. From now on, it follows the same pattern like `create` and `pull`. It writes migrations in YAML format unless the user sets `--json` flag.
