### PR TITLE
Remove redundant `pgroll.internal` parameter

### DIFF
--- a/pkg/roll/roll.go
+++ b/pkg/roll/roll.go
@@ -102,11 +102,6 @@ func setupConn(ctx context.Context, pgURL, schema string, options options) (*sql
 		return nil, err
 	}
 
-	_, err = conn.ExecContext(ctx, "SET LOCAL pgroll.internal to 'TRUE'")
-	if err != nil {
-		return nil, fmt.Errorf("unable to set pgroll.internal to true: %w", err)
-	}
-
 	if options.lockTimeoutMs > 0 {
 		_, err = conn.ExecContext(ctx, fmt.Sprintf("SET lock_timeout to '%dms'", options.lockTimeoutMs))
 		if err != nil {

--- a/pkg/state/init.sql
+++ b/pkg/state/init.sql
@@ -317,10 +317,6 @@ DECLARE
     schemaname text;
     migration_id text;
 BEGIN
-    -- Ignore migrations done by pgroll
-    IF (pg_catalog.current_setting('pgroll.internal', 'TRUE') <> 'TRUE') THEN
-        RETURN;
-    END IF;
     IF tg_event = 'sql_drop' AND tg_tag = 'DROP SCHEMA' THEN
         -- Take the schema name from the drop schema command
         SELECT

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -46,11 +46,6 @@ func New(ctx context.Context, pgURL, stateSchema string) (*State, error) {
 		return nil, err
 	}
 
-	_, err = conn.ExecContext(ctx, "SET LOCAL pgroll.internal to 'TRUE'")
-	if err != nil {
-		return nil, fmt.Errorf("unable to set pgroll.internal to true: %w", err)
-	}
-
 	return &State{
 		pgConn: conn,
 		schema: stateSchema,


### PR DESCRIPTION
The `pgroll.internal` custom parameter never worked, because it was set outside of a transaction using `SET LOCAL`, so it had no effect other than spitting out a warning to the Postgres logs.

The `pgroll.internal` parameter was meant to be used to ensure that DDL done by `pgroll` operations was not captured as an `inferred` migration. However, the `raw_migration` function also uses the `is_active_migration_period` function for this same purpose, so the `pgroll.internal` parameter was redundant even if it had worked.