### PR TITLE
Change local `docker-compose` setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - /var/lib/postgresql/data
     healthcheck:
       test: "pg_isready -h localhost"
-      interval: 200ms
+      start_period: 30s
+      start_interval: 100ms
+      interval: 24h
       timeout: 5s
-      retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   db:
     image: 'postgres:17'
+    user: postgres
     restart: always
     environment:
       - POSTGRES_USER=postgres


### PR DESCRIPTION
Make a couple of changes to the local `docker-compose` setup:

**Run local the postgres container as user `postgres`**:
```
So that the healthcheck can run as the `postgres` user and not add a
connection failure error to the Postgres log when the health check
attempts to connect as the `root` user.
```
**Edit healthcheck settings to avoid repeated health checks after the container has started**:

```
Set a `start_period` and a `start_interval` to ensure that the
healthcheck quickly notices that Postgres is ready after startup.

Thereafter, set the `interval` to 24h because we don't care about ongoing
healthchecks in the local dev environment.
```


