### PR TITLE
Fail early in `migrate` if there is an incompatible migration file

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -80,7 +80,6 @@ func migrateCmd() *cobra.Command {
 
 			// fail early if there is an incompatible migration
 			migs, err := parseMigrations(rawMigs)
-			fmt.Println(migs)
 			if err != nil {
 				return fmt.Errorf("failed to run migrate: %w", err)
 			}

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -80,6 +80,7 @@ func migrateCmd() *cobra.Command {
 
 			// fail early if there is an incompatible migration
 			migs, err := parseMigrations(rawMigs)
+			fmt.Println(migs)
 			if err != nil {
 				return fmt.Errorf("failed to run migrate: %w", err)
 			}
@@ -112,7 +113,7 @@ func migrateCmd() *cobra.Command {
 // parseMigrations tries to parse all RawMigrations and collects all the errors
 // if any.
 func parseMigrations(migs []*migrations.RawMigration) ([]*migrations.Migration, error) {
-	var parsedMigrations []*migrations.Migration
+	parsedMigrations := make([]*migrations.Migration, 0, len(migs))
 	var errs error
 	for _, rawMigration := range migs {
 		m, err := migrations.ParseMigration(rawMigration)

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -123,7 +123,7 @@ func parseMigrations(migs []*migrations.RawMigration) ([]*migrations.Migration, 
 		parsedMigrations = append(parsedMigrations, m)
 	}
 	if errs != nil {
-		return nil, fmt.Errorf("incompatible migration(s) found: %w. please update the files.", errs)
+		return nil, fmt.Errorf("incompatible migration(s): %w", errs)
 	}
 	return parsedMigrations, nil
 }

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -112,16 +113,16 @@ func migrateCmd() *cobra.Command {
 // if any.
 func parseMigrations(migs []*migrations.RawMigration) ([]*migrations.Migration, error) {
 	parsedMigrations := make([]*migrations.Migration, len(migs))
-	var errs []error
+	var errs error
 	for i, rawMigration := range migs {
 		m, err := migrations.ParseMigration(rawMigration)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("migration %q: %w", rawMigration.Name, err))
+			errs = errors.Join(errs, err)
 		}
 		parsedMigrations[i] = m
 	}
-	if len(errs) > 0 {
-		return nil, fmt.Errorf("incompatible migration(s) found: %v. please update the files.", errs)
+	if errs != nil {
+		return nil, fmt.Errorf("incompatible migration(s) found: %w. please update the files.", errs)
 	}
 	return parsedMigrations, nil
 }

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -114,12 +114,12 @@ func migrateCmd() *cobra.Command {
 func parseMigrations(migs []*migrations.RawMigration) ([]*migrations.Migration, error) {
 	parsedMigrations := make([]*migrations.Migration, len(migs))
 	var errs error
-	for i, rawMigration := range migs {
+	for _, rawMigration := range migs {
 		m, err := migrations.ParseMigration(rawMigration)
 		if err != nil {
 			errs = errors.Join(errs, err)
 		}
-		parsedMigrations[i] = m
+		parsedMigrations = append(parsedMigrations, m)
 	}
 	if errs != nil {
 		return nil, fmt.Errorf("incompatible migration(s) found: %w. please update the files.", errs)

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -112,7 +112,7 @@ func migrateCmd() *cobra.Command {
 // parseMigrations tries to parse all RawMigrations and collects all the errors
 // if any.
 func parseMigrations(migs []*migrations.RawMigration) ([]*migrations.Migration, error) {
-	parsedMigrations := make([]*migrations.Migration, len(migs))
+	var parsedMigrations []*migrations.Migration
 	var errs error
 	for _, rawMigration := range migs {
 		m, err := migrations.ParseMigration(rawMigration)

--- a/docs/cli/migrate.mdx
+++ b/docs/cli/migrate.mdx
@@ -15,6 +15,8 @@ will apply migrations from `41_add_enum_column` onwards to the target database.
 
 If the `--complete` flag is passed to `pgroll migrate` the final migration to be applied will be completed. Otherwise the final migration will be left active (started but not completed).
 
+If any of the migration files are incompatible with your `pgroll` version, the command will report the errors and exit before running any migrations.
+
 ## Existing Database Schema
 
 If you attempt to run `pgroll migrate` against a database that has existing tables but no migration history, the command will fail with an error message. In this case, you should first run `pgroll baseline` to establish a baseline migration that captures the current schema state before applying any new migrations.


### PR DESCRIPTION
This PR changes the `migrate` command. It does not start any migrations before it makes sure that the outstanding migration files are  compatible with the current version.

Closes #766
