### PR TITLE
Fix backfill on tables with case sensitive names

### DIFF
--- a/pkg/backfill/backfill.go
+++ b/pkg/backfill/backfill.go
@@ -122,7 +122,7 @@ func getRowCount(ctx context.Context, conn db.DB, tableName string) (int64, erro
 	}
 
 	// If the estimate is zero, fall back to full count
-	rows, err = conn.QueryContext(ctx, fmt.Sprintf(`SELECT count(*) from %s`, tableName))
+	rows, err = conn.QueryContext(ctx, fmt.Sprintf(`SELECT count(*) from %s`, pq.QuoteIdentifier(tableName)))
 	if err != nil {
 		return 0, fmt.Errorf("getting row count for %q: %w", tableName, err)
 	}

--- a/pkg/migrations/op_common_test.go
+++ b/pkg/migrations/op_common_test.go
@@ -575,7 +575,7 @@ func triggerExists(t *testing.T, db *sql.DB, schema, table, trigger string) bool
       WHERE tgrelid = $1::regclass
       AND tgname = $2
     )`,
-		fmt.Sprintf("%s.%s", schema, table), trigger).Scan(&exists)
+		fmt.Sprintf("%s.%s", pq.QuoteIdentifier(schema), pq.QuoteIdentifier(table)), trigger).Scan(&exists)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Ensure that the table name is correctly quoted when retrieving table rows counts as part of the backfill operation.

Fixes https://github.com/xataio/pgroll/issues/826