### PR TITLE
[baseline] Add `pgroll baseline` command

### DIFF
--- a/cli-definition.json
+++ b/cli-definition.json
@@ -11,6 +11,25 @@
       "args": []
     },
     {
+      "name": "baseline",
+      "short": "Create a baseline migration for an existing database schema",
+      "use": "baseline <version> <target directory>",
+      "example": "",
+      "flags": [
+        {
+          "name": "json",
+          "shorthand": "j",
+          "description": "output in JSON format instead of YAML",
+          "default": "false"
+        }
+      ],
+      "subcommands": [],
+      "args": [
+        "version",
+        "directory"
+      ]
+    },
+    {
       "name": "complete",
       "short": "Complete an ongoing migration with the operations present in the given file",
       "use": "complete <file>",

--- a/cmd/baseline.go
+++ b/cmd/baseline.go
@@ -4,7 +4,9 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
@@ -68,6 +70,7 @@ func baselineCmd() *cobra.Command {
 			err = m.CreateBaseline(ctx, version)
 			if err != nil {
 				sp.Fail(fmt.Sprintf("Failed to create baseline: %s", err))
+				err = errors.Join(err, os.Remove(filePath))
 				return err
 			}
 

--- a/cmd/baseline.go
+++ b/cmd/baseline.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+	"github.com/xataio/pgroll/pkg/migrations"
+)
+
+func baselineCmd() *cobra.Command {
+	var useJSON bool
+
+	baselineCmd := &cobra.Command{
+		Use:       "baseline <version> <target directory>",
+		Short:     "Create a baseline migration for an existing database schema",
+		Args:      cobra.ExactArgs(2),
+		ValidArgs: []string{"version", "directory"},
+		Hidden:    true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			version := args[0]
+			targetDir := args[1]
+
+			ctx := cmd.Context()
+
+			// Create a roll instance
+			m, err := NewRollWithInitCheck(ctx)
+			if err != nil {
+				return err
+			}
+			defer m.Close()
+
+			// Ensure that the target directory exists
+			if err := ensureDirectoryExists(targetDir); err != nil {
+				return err
+			}
+
+			// Prompt for confirmation
+			fmt.Println("Creating a baseline migration will restart the migration history.")
+			ok, _ := pterm.DefaultInteractiveConfirm.Show()
+			if !ok {
+				return nil
+			}
+
+			// Create a placeholder baseline migration
+			ops := migrations.Operations{&migrations.OpRawSQL{Up: ""}}
+			opsJSON, err := json.Marshal(ops)
+			if err != nil {
+				return fmt.Errorf("failed to marshal operations: %w", err)
+			}
+			mig := &migrations.RawMigration{
+				Name:       version,
+				Operations: opsJSON,
+			}
+
+			// Write the placeholder migration to disk
+			filePath, err := writeMigrationToFile(mig, targetDir, "", useJSON)
+			if err != nil {
+				return fmt.Errorf("failed to write placeholder baseline migration: %w", err)
+			}
+
+			sp, _ := pterm.DefaultSpinner.WithText(fmt.Sprintf("Creating baseline migration %q...", version)).Start()
+
+			// Create the baseline in the target database
+			err = m.CreateBaseline(ctx, version)
+			if err != nil {
+				sp.Fail(fmt.Sprintf("Failed to create baseline: %s", err))
+				return err
+			}
+
+			sp.Success(fmt.Sprintf("Baseline created successfully. Placeholder migration %q written", filePath))
+			return nil
+		},
+	}
+
+	baselineCmd.Flags().BoolVarP(&useJSON, "json", "j", false, "output in JSON format instead of YAML")
+
+	return baselineCmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -106,6 +106,7 @@ func Prepare() *cobra.Command {
 	rootCmd.AddCommand(pullCmd())
 	rootCmd.AddCommand(latestCmd())
 	rootCmd.AddCommand(convertCmd())
+	rootCmd.AddCommand(baselineCmd())
 
 	return rootCmd
 }

--- a/pkg/roll/baseline.go
+++ b/pkg/roll/baseline.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package roll
+
+import (
+	"context"
+)
+
+// CreateBaseline creates a baseline migration for an existing database schema.
+// This is used when starting pgroll with an existing database - it captures
+// the current schema state as a baseline version without applying any changes.
+// Future migrations will build upon this baseline version.
+func (m *Roll) CreateBaseline(ctx context.Context, baselineVersion string) error {
+	// Log the operation
+	m.logger.Info("Creating baseline version %q for schema %q", baselineVersion, m.schema)
+
+	// Delegate to state to create the actual baseline migration record
+	return m.state.CreateBaseline(ctx, m.schema, baselineVersion)
+}

--- a/pkg/roll/baseline_test.go
+++ b/pkg/roll/baseline_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package roll_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xataio/pgroll/internal/testutils"
+	"github.com/xataio/pgroll/pkg/roll"
+	"github.com/xataio/pgroll/pkg/schema"
+	"github.com/xataio/pgroll/pkg/state"
+)
+
+func TestBaseline(t *testing.T) {
+	t.Parallel()
+
+	t.Run("baseline migration captures the current schema", func(t *testing.T) {
+		testutils.WithMigratorAndStateAndConnectionToContainerWithOptions(t, nil, func(roll *roll.Roll, st *state.State, db *sql.DB) {
+			ctx := context.Background()
+
+			// Create a table in the database to simulate an existing schema
+			_, err := db.ExecContext(ctx, "CREATE TABLE users (id int)")
+			require.NoError(t, err)
+
+			// Create a baseline migration
+			err = roll.CreateBaseline(ctx, "01_initial_version")
+			require.NoError(t, err)
+
+			// Get the captured database schema after the baseline migration was applied
+			sc, err := st.SchemaAfterMigration(ctx, "public", "01_initial_version")
+			require.NoError(t, err)
+
+			// Define the expected schema
+			wantSchema := &schema.Schema{
+				Name: "public",
+				Tables: map[string]*schema.Table{
+					"users": {
+						Name: "users",
+						Columns: map[string]*schema.Column{
+							"id": {
+								Name:         "id",
+								Type:         "integer",
+								Nullable:     true,
+								PostgresType: "base",
+							},
+						},
+						PrimaryKey:         []string{},
+						Indexes:            map[string]*schema.Index{},
+						ForeignKeys:        map[string]*schema.ForeignKey{},
+						CheckConstraints:   map[string]*schema.CheckConstraint{},
+						UniqueConstraints:  map[string]*schema.UniqueConstraint{},
+						ExcludeConstraints: map[string]*schema.ExcludeConstraint{},
+					},
+				},
+			}
+
+			// Clear OIDs from the schema to avoid comparison issues
+			clearOIDS(sc)
+
+			// Assert the the schema matches the expected schema
+			require.Equal(t, wantSchema, sc)
+		})
+	})
+}
+
+func clearOIDS(s *schema.Schema) {
+	for k := range s.Tables {
+		c := s.Tables[k]
+		c.OID = ""
+		s.Tables[k] = c
+	}
+}

--- a/pkg/roll/execute_test.go
+++ b/pkg/roll/execute_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	schema = "public"
+	cSchema = "public"
 )
 
 func TestMain(m *testing.M) {
@@ -41,7 +41,7 @@ func TestSchemaIsCreatedAfterMigrationStart(t *testing.T) {
 		//
 		// Check that the schema exists
 		//
-		if !schemaExists(t, db, roll.VersionedSchemaName(schema, version)) {
+		if !schemaExists(t, db, roll.VersionedSchemaName(cSchema, version)) {
 			t.Errorf("Expected schema %q to exist", version)
 		}
 	})
@@ -61,7 +61,7 @@ func TestDisabledSchemaManagement(t *testing.T) {
 		//
 		// Check that the schema doesn't get created
 		//
-		if schemaExists(t, db, roll.VersionedSchemaName(schema, version)) {
+		if schemaExists(t, db, roll.VersionedSchemaName(cSchema, version)) {
 			t.Errorf("Expected schema %q to not exist", version)
 		}
 
@@ -78,7 +78,7 @@ func TestDisabledSchemaManagement(t *testing.T) {
 			t.Fatalf("Failed to complete migration: %v", err)
 		}
 
-		if schemaExists(t, db, roll.VersionedSchemaName(schema, version)) {
+		if schemaExists(t, db, roll.VersionedSchemaName(cSchema, version)) {
 			t.Errorf("Expected schema %q to not exist", version)
 		}
 	})
@@ -111,7 +111,7 @@ func TestPreviousVersionIsDroppedAfterMigrationCompletion(t *testing.T) {
 			//
 			// Check that the schema for the first version has been dropped
 			//
-			if schemaExists(t, db, roll.VersionedSchemaName(schema, firstVersion)) {
+			if schemaExists(t, db, roll.VersionedSchemaName(cSchema, firstVersion)) {
 				t.Errorf("Expected schema %q to not exist", firstVersion)
 			}
 		})
@@ -150,7 +150,7 @@ func TestPreviousVersionIsDroppedAfterMigrationCompletion(t *testing.T) {
 			//
 			// Check that the schema for the first version has been dropped
 			//
-			if schemaExists(t, db, roll.VersionedSchemaName(schema, firstVersion)) {
+			if schemaExists(t, db, roll.VersionedSchemaName(cSchema, firstVersion)) {
 				t.Errorf("Expected schema %q to not exist", firstVersion)
 			}
 		})
@@ -198,7 +198,7 @@ func TestNoVersionSchemaForRawSQLMigrationsOptionIsRespected(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, prevVersion)
 		assert.Equal(t, "02_create_table", *prevVersion)
-		assert.False(t, schemaExists(t, db, roll.VersionedSchemaName(schema, "02_create_table")))
+		assert.False(t, schemaExists(t, db, roll.VersionedSchemaName(cSchema, "02_create_table")))
 
 		// Complete the third migration
 		err = mig.Complete(ctx)
@@ -229,7 +229,7 @@ func TestSchemaIsDroppedAfterMigrationRollback(t *testing.T) {
 		//
 		// Check that the schema has been dropped
 		//
-		if schemaExists(t, db, roll.VersionedSchemaName(schema, version)) {
+		if schemaExists(t, db, roll.VersionedSchemaName(cSchema, version)) {
 			t.Errorf("Expected schema %q to not exist", version)
 		}
 	})

--- a/pkg/state/init.sql
+++ b/pkg/state/init.sql
@@ -31,6 +31,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS history_is_linear ON placeholder.migrations (s
 ALTER TABLE placeholder.migrations
     ADD COLUMN IF NOT EXISTS migration_type varchar(32) DEFAULT 'pgroll' CONSTRAINT migration_type_check CHECK (migration_type IN ('pgroll', 'inferred'));
 
+-- Update the `migration_type` column to also allow a `baseline` migration type.
+ALTER TABLE placeholder.migrations
+    DROP CONSTRAINT migration_type_check;
+
+ALTER TABLE placeholder.migrations
+    ADD CONSTRAINT migration_type_check CHECK (migration_type IN ('pgroll', 'inferred', 'baseline'));
+
 -- Change timestamp columns to use timestamptz
 ALTER TABLE placeholder.migrations
     ALTER COLUMN created_at SET DATA TYPE timestamptz USING created_at AT TIME ZONE 'UTC',


### PR DESCRIPTION
Add a new `pgroll baseline` command to `pgroll` that allows users to establish a baseline migration from an existing database schema.

### Usage

Run:

```bash
$ pgroll baseline 01_initial_version migrations/
```

This does two things:
* Creates a new entry in `pgroll.migrations` with a new migration type of `baseline`. The migration JSON is empty and the `resulting_schema` field contains the schema at the time the command was run.
* Creates a placeholder `migrations/01_initial_version.yaml` file for the user to populate (likely with the use of `pg_dump`).

### Features

  - New `pgroll baseline <version> <target directory>` command (currently hidden)
  - Creates a `baseline` migration in the `pgroll.migrations` table that captures the current schema state without applying changes.
  - Validation to prevent baseline creation during active migrations
  - Adds test coverage for baseline functionality

### Implementation Details

  - Added `Roll.CreateBaseline` method and corresponding tests
  - Added `State.CreateBaseline` method for writing `baseline` migrations to `pgroll.migrations`
  - Extended migration type definition to include 'baseline' type

The `pgroll baseline` command is currently hidden. Un-hiding the command will happen when the `pull` and `migrate` commands are made baseline-aware.

This is the first part of #364 
