### PR TITLE
New `DBAction`: `ValidateConstraintAction`

### DIFF
--- a/pkg/migrations/dbactions.go
+++ b/pkg/migrations/dbactions.go
@@ -372,3 +372,25 @@ func (a *DropTableAction) Execute(ctx context.Context) error {
 		pq.QuoteIdentifier(a.table)))
 	return err
 }
+
+// validateConstraintAction is a DBAction that validates a constraint in a table.
+type validateConstraintAction struct {
+	conn       db.DB
+	table      string
+	constraint string
+}
+
+func NewValidateConstraintAction(conn db.DB, table, constraint string) *validateConstraintAction {
+	return &validateConstraintAction{
+		conn:       conn,
+		table:      table,
+		constraint: constraint,
+	}
+}
+
+func (a *validateConstraintAction) Execute(ctx context.Context) error {
+	_, err := a.conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s VALIDATE CONSTRAINT %s",
+		pq.QuoteIdentifier(a.table),
+		pq.QuoteIdentifier(a.constraint)))
+	return err
+}

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -152,9 +152,7 @@ func (o *OpAddColumn) Complete(ctx context.Context, l Logger, conn db.DB, s *sch
 	}
 
 	if o.Column.Check != nil {
-		_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s VALIDATE CONSTRAINT %s",
-			pq.QuoteIdentifier(o.Table),
-			pq.QuoteIdentifier(o.Column.Check.Name)))
+		err = NewValidateConstraintAction(conn, o.Table, o.Column.Check.Name).Execute(ctx)
 		if err != nil {
 			return err
 		}
@@ -348,9 +346,7 @@ func addColumn(ctx context.Context, conn db.DB, o OpAddColumn, t *schema.Table, 
 // constraint to a NOT NULL column attribute. The constraint is removed after
 // the column attribute is added.
 func upgradeNotNullConstraintToNotNullAttribute(ctx context.Context, conn db.DB, tableName, columnName string) error {
-	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s VALIDATE CONSTRAINT %s",
-		pq.QuoteIdentifier(tableName),
-		pq.QuoteIdentifier(NotNullConstraintName(columnName))))
+	err := NewValidateConstraintAction(conn, tableName, NotNullConstraintName(columnName)).Execute(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/migrations/op_set_check.go
+++ b/pkg/migrations/op_set_check.go
@@ -43,9 +43,7 @@ func (o *OpSetCheckConstraint) Complete(ctx context.Context, l Logger, conn db.D
 	l.LogOperationComplete(o)
 
 	// Validate the check constraint
-	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s VALIDATE CONSTRAINT %s",
-		pq.QuoteIdentifier(o.Table),
-		pq.QuoteIdentifier(o.Check.Name)))
+	err := NewValidateConstraintAction(conn, o.Table, o.Check.Name).Execute(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/migrations/op_set_fk.go
+++ b/pkg/migrations/op_set_fk.go
@@ -39,9 +39,7 @@ func (o *OpSetForeignKey) Complete(ctx context.Context, l Logger, conn db.DB, s 
 	l.LogOperationComplete(o)
 
 	// Validate the foreign key constraint
-	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s VALIDATE CONSTRAINT %s",
-		pq.QuoteIdentifier(o.Table),
-		pq.QuoteIdentifier(o.References.Name)))
+	err := NewValidateConstraintAction(conn, o.Table, o.References.Name).Execute(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/migrations/op_set_notnull.go
+++ b/pkg/migrations/op_set_notnull.go
@@ -48,9 +48,7 @@ func (o *OpSetNotNull) Complete(ctx context.Context, l Logger, conn db.DB, s *sc
 	// The constraint must be valid because:
 	// * Existing NULL values in the old column were rewritten using the `up` SQL during backfill.
 	// * New NULL values written to the old column during the migration period were also rewritten using `up` SQL.
-	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE IF EXISTS %s VALIDATE CONSTRAINT %s",
-		pq.QuoteIdentifier(o.Table),
-		pq.QuoteIdentifier(NotNullConstraintName(o.Column))))
+	err := NewValidateConstraintAction(conn, o.Table, NotNullConstraintName(o.Column)).Execute(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds a new `DBAction` to validate constraints on tables.
The new action is used in:
* `op_add_column`
* `op_set_fk`
* `op_set_not_null`
* `op_set_check`
* `rename`
