### PR TITLE
Mark hidden commands in `build-cli-definition` tool

### DIFF
--- a/cli-definition.json
+++ b/cli-definition.json
@@ -5,6 +5,7 @@
       "name": "analyze",
       "short": "Analyze the SQL schema of the target database",
       "use": "analyze",
+      "hidden": true,
       "example": "",
       "flags": [],
       "subcommands": [],
@@ -14,6 +15,7 @@
       "name": "baseline",
       "short": "Create a baseline migration for an existing database schema",
       "use": "baseline <version> <target directory>",
+      "hidden": true,
       "example": "",
       "flags": [
         {

--- a/tools/build-cli-definition.go
+++ b/tools/build-cli-definition.go
@@ -23,6 +23,7 @@ type Command struct {
 	Name        string    `json:"name"`
 	Short       string    `json:"short"`
 	Use         string    `json:"use"`
+	Hidden      bool      `json:"hidden,omitempty"`
 	Example     string    `json:"example"`
 	Flags       []Flag    `json:"flags"`
 	Subcommands []Command `json:"subcommands"`
@@ -71,6 +72,7 @@ func processCommand(cmd *cobra.Command) Command {
 		Name:        cmd.Name(),
 		Short:       cmd.Short,
 		Use:         cmd.Use,
+		Hidden:      cmd.Hidden,
 		Example:     cmd.Example,
 		Args:        validateArgs(cmd),
 		Flags:       extractFlags(cmd.Flags()),


### PR DESCRIPTION
~~Make the `build-cli-definition` tool not include hidden commands in the generated CLI definition JSON file.~~

~~Hidden commands are either internal (like `anaylze`) or work in progress (like `baseline`) and shouldn't be included in the generated CLI definition.~~

Updated based on https://github.com/xataio/pgroll/pull/847#pullrequestreview-2853771576.

Make the `build-cli-definition` tool mark hidden commands in the generated JSON output.