### PR TITLE
Add test coverage `ReadMigration`

### DIFF
--- a/pkg/migrations/op_common.go
+++ b/pkg/migrations/op_common.go
@@ -118,7 +118,7 @@ func ReadRawMigration(dir fs.FS, filename string) (*RawMigration, error) {
 		return nil, fmt.Errorf("reading migration file: %w", err)
 	}
 
-	// Extract base filename wiahout extension as the migration name
+	// Extract base filename without extension as the migration name
 	mig.Name = strings.TrimSuffix(filepath.Base(filename), filepath.Ext(filename))
 
 	return &mig, nil


### PR DESCRIPTION
Add testcases to ensure that migration names are set correctly from the filename from which they are read.