### PR TITLE
Add new subcommand to update migrations that contain breaking changes

### DIFF
--- a/cli-definition.json
+++ b/cli-definition.json
@@ -241,6 +241,30 @@
       "args": []
     },
     {
+      "name": "update",
+      "short": "update outdated migrations in a directory",
+      "use": "update <directory>",
+      "example": "update ./migrations",
+      "flags": [
+        {
+          "name": "json",
+          "shorthand": "j",
+          "description": "Output migration file in JSON format instead of YAML",
+          "default": "false"
+        },
+        {
+          "name": "local",
+          "shorthand": "l",
+          "description": "Update all local migration files",
+          "default": "false"
+        }
+      ],
+      "subcommands": [],
+      "args": [
+        "directory"
+      ]
+    },
+    {
       "name": "validate",
       "short": "Validate a migration file",
       "use": "validate <file>",

--- a/cli-definition.json
+++ b/cli-definition.json
@@ -242,7 +242,7 @@
     },
     {
       "name": "update",
-      "short": "update outdated migrations in a directory",
+      "short": "Update outdated migrations in a directory",
       "use": "update <directory>",
       "example": "update ./migrations",
       "flags": [
@@ -250,12 +250,6 @@
           "name": "json",
           "shorthand": "j",
           "description": "Output migration file in JSON format instead of YAML",
-          "default": "false"
-        },
-        {
-          "name": "local",
-          "shorthand": "l",
-          "description": "Update all local migration files",
           "default": "false"
         }
       ],

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -101,6 +101,7 @@ func Prepare() *cobra.Command {
 	rootCmd.AddCommand(analyzeCmd)
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(statusCmd)
+	rootCmd.AddCommand(updateCmd())
 	rootCmd.AddCommand(createCmd())
 	rootCmd.AddCommand(migrateCmd())
 	rootCmd.AddCommand(pullCmd())

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/xataio/pgroll/pkg/migrations"
+	"github.com/xataio/pgroll/pkg/roll"
+)
+
+func updateCmd() *cobra.Command {
+	var useJSON bool
+	var local bool
+
+	updateCmd := &cobra.Command{
+		Use:       "update <directory>",
+		Short:     "update outdated migrations in a directory",
+		Example:   "update ./migrations",
+		Args:      cobra.ExactArgs(1),
+		ValidArgs: []string{"directory"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			migrationsDir := args[0]
+
+			// Create a roll instance and check if pgroll is initialized
+			m, err := NewRollWithInitCheck(ctx)
+			if err != nil {
+				return err
+			}
+			defer m.Close()
+
+			info, err := os.Stat(migrationsDir)
+			if err != nil {
+				return fmt.Errorf("failed to stat directory: %w", err)
+			}
+			if !info.IsDir() {
+				return fmt.Errorf("migrations directory %q is not a directory", migrationsDir)
+			}
+
+			migs, err := getMigrationsToUpdate(ctx, m, os.DirFS(migrationsDir), local)
+			if err != nil {
+				return err
+			}
+
+			if len(migs) == 0 {
+				fmt.Println("database is up to date; no migrations to apply")
+				return nil
+			}
+
+			for _, mig := range migs {
+				if _, err := migrations.ParseMigration(mig); err == nil {
+					continue
+				}
+
+				updater := migrations.NewFileUpdater()
+				updatedMigration, err := updater.Update(mig)
+				if err != nil {
+					return err
+				}
+
+				format := migrations.NewMigrationFormat(useJSON)
+				migrationFileName := fmt.Sprintf("%s.%s", mig.Name, format.Extension())
+				file, err := os.Create(filepath.Join(migrationsDir, migrationFileName))
+				if err != nil {
+					return fmt.Errorf("failed to update migration file: %w", err)
+				}
+				err = migrations.NewWriter(file, format).Write(updatedMigration)
+				if err != nil {
+					file.Close()
+					return fmt.Errorf("failed to write migration file: %w", err)
+				}
+				file.Close()
+			}
+
+			return nil
+		},
+	}
+
+	updateCmd.Flags().BoolVarP(&useJSON, "json", "j", false, "Output migration file in JSON format instead of YAML")
+	updateCmd.Flags().BoolVarP(&local, "local", "l", false, "Update all local migration files")
+
+	return updateCmd
+}
+
+func getMigrationsToUpdate(ctx context.Context, m *roll.Roll, migrationsDir fs.FS, local bool) ([]*migrations.RawMigration, error) {
+	if !local {
+		migs, err := m.UnappliedMigrations(ctx, migrationsDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get migrations to apply: %w", err)
+		}
+		return migs, nil
+	}
+	files, err := migrations.CollectFilesFromDir(migrationsDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading migration files: %w", err)
+	}
+	migs := make([]*migrations.RawMigration, 0, len(files))
+	for _, f := range files {
+		m, err := migrations.ReadRawMigration(migrationsDir, f)
+		if err != nil {
+			return nil, err
+		}
+		migs = append(migs, m)
+	}
+	return migs, nil
+}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -49,7 +49,7 @@ func updateCmd() *cobra.Command {
 			}
 
 			if len(migs) == 0 {
-				fmt.Println("database is up to date; no migrations to apply")
+				fmt.Println("nothing to do; all migration files are up to date")
 				return nil
 			}
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -41,7 +41,7 @@ func updateCmd() *cobra.Command {
 
 			files, err := migrations.CollectFilesFromDir(os.DirFS(migrationsDir))
 			if err != nil {
-				return fmt.Errorf("failed to reading migration files from directory: %w", err)
+				return fmt.Errorf("failed to read migration files from directory: %w", err)
 			}
 
 			for _, f := range files {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -53,8 +53,7 @@ func updateCmd() *cobra.Command {
 					continue
 				}
 
-				updater := newFileUpdater()
-				updatedMigration, err := updater.Update(mig)
+				updatedMigration, err := newFileUpdater().Update(mig)
 				if err != nil {
 					return fmt.Errorf("failed to update migration file: %w", err)
 				}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -20,7 +20,7 @@ func updateCmd() *cobra.Command {
 
 	updateCmd := &cobra.Command{
 		Use:       "update <directory>",
-		Short:     "update outdated migrations in a directory",
+		Short:     "Update outdated migrations in a directory",
 		Example:   "update ./migrations",
 		Args:      cobra.ExactArgs(1),
 		ValidArgs: []string{"directory"},

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -53,7 +53,7 @@ func updateCmd() *cobra.Command {
 					continue
 				}
 
-				updater := migrations.NewFileUpdater()
+				updater := newFileUpdater()
 				updatedMigration, err := updater.Update(mig)
 				if err != nil {
 					return fmt.Errorf("failed to update migration file: %w", err)
@@ -80,4 +80,12 @@ func updateCmd() *cobra.Command {
 	updateCmd.Flags().BoolVarP(&useJSON, "json", "j", false, "Output migration file in JSON format instead of YAML")
 
 	return updateCmd
+}
+
+func newFileUpdater() *migrations.FileUpdater {
+	return migrations.NewFileUpdater(map[string][]migrations.UpdaterFn{
+		string(migrations.OpNameCreateIndex): {
+			migrations.UpdateCreateIndexColumnsList,
+		},
+	})
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -3,20 +3,16 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/xataio/pgroll/pkg/migrations"
-	"github.com/xataio/pgroll/pkg/roll"
 )
 
 func updateCmd() *cobra.Command {
 	var useJSON bool
-	var local bool
 
 	updateCmd := &cobra.Command{
 		Use:       "update <directory>",
@@ -43,17 +39,16 @@ func updateCmd() *cobra.Command {
 				return fmt.Errorf("migrations directory %q is not a directory", migrationsDir)
 			}
 
-			migs, err := getMigrationsToUpdate(ctx, m, os.DirFS(migrationsDir), local)
+			files, err := migrations.CollectFilesFromDir(os.DirFS(migrationsDir))
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to reading migration files from directory: %w", err)
 			}
 
-			if len(migs) == 0 {
-				fmt.Println("nothing to do; all migration files are up to date")
-				return nil
-			}
-
-			for _, mig := range migs {
+			for _, f := range files {
+				mig, err := migrations.ReadRawMigration(os.DirFS(migrationsDir), f)
+				if err != nil {
+					return fmt.Errorf("failed to read migration file: %w", err)
+				}
 				if _, err := migrations.ParseMigration(mig); err == nil {
 					continue
 				}
@@ -61,7 +56,7 @@ func updateCmd() *cobra.Command {
 				updater := migrations.NewFileUpdater()
 				updatedMigration, err := updater.Update(mig)
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to update migration file: %w", err)
 				}
 
 				format := migrations.NewMigrationFormat(useJSON)
@@ -83,30 +78,6 @@ func updateCmd() *cobra.Command {
 	}
 
 	updateCmd.Flags().BoolVarP(&useJSON, "json", "j", false, "Output migration file in JSON format instead of YAML")
-	updateCmd.Flags().BoolVarP(&local, "local", "l", false, "Update all local migration files")
 
 	return updateCmd
-}
-
-func getMigrationsToUpdate(ctx context.Context, m *roll.Roll, migrationsDir fs.FS, local bool) ([]*migrations.RawMigration, error) {
-	if !local {
-		migs, err := m.UnappliedMigrations(ctx, migrationsDir)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get migrations to apply: %w", err)
-		}
-		return migs, nil
-	}
-	files, err := migrations.CollectFilesFromDir(migrationsDir)
-	if err != nil {
-		return nil, fmt.Errorf("reading migration files: %w", err)
-	}
-	migs := make([]*migrations.RawMigration, 0, len(files))
-	for _, f := range files {
-		m, err := migrations.ReadRawMigration(migrationsDir, f)
-		if err != nil {
-			return nil, err
-		}
-		migs = append(migs, m)
-	}
-	return migs, nil
 }

--- a/docs/cli/update.mdx
+++ b/docs/cli/update.mdx
@@ -1,0 +1,14 @@
+---
+title: Update
+description: Update migration files that contain breaking changes
+---
+
+## Command
+
+```
+$ pgroll update migrations
+```
+
+TODO
+
+The optional `--json` flag can be used to write migration files in JSON.

--- a/docs/cli/update.mdx
+++ b/docs/cli/update.mdx
@@ -6,9 +6,15 @@ description: Update migration files that contain breaking changes
 ## Command
 
 ```
-$ pgroll update migrations
+$ pgroll update {migrations-folder}
 ```
 
 This command updates all outdated migration files in the selected migrations folder.
 
 The optional `--json` flag can be used to write migration files in JSON.
+
+### Example for updating migrations in the folder `migrations`
+
+```
+$ pgroll update migrations
+```

--- a/docs/cli/update.mdx
+++ b/docs/cli/update.mdx
@@ -9,6 +9,6 @@ description: Update migration files that contain breaking changes
 $ pgroll update migrations
 ```
 
-TODO
+This command updates all outdated migration files in the selected migrations folder.
 
 The optional `--json` flag can be used to write migration files in JSON.

--- a/docs/config.json
+++ b/docs/config.json
@@ -113,6 +113,11 @@
           "title": "Baseline",
           "href": "/cli/baseline",
           "file": "docs/cli/baseline.mdx"
+        },
+        {
+          "title": "Update",
+          "href": "/cli/update",
+          "file": "docs/cli/update.mdx"
         }
       ]
     },

--- a/pkg/migrations/updater.go
+++ b/pkg/migrations/updater.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package migrations
+
+import "encoding/json"
+
+type updaterFn func(operation map[string]any) (map[string]any, error)
+
+// FileUpdater updates raw migration files if they contain any breaking
+// changes that have proper updater functions registered.
+type FileUpdater struct {
+	updaterFns map[string][]updaterFn
+}
+
+func (u *FileUpdater) registerFn(op string, fn updaterFn) {
+	u.updaterFns[op] = append(u.updaterFns[op], fn)
+}
+
+func NewFileUpdater() *FileUpdater {
+	updater := &FileUpdater{updaterFns: make(map[string][]updaterFn)}
+
+	// register updater functions
+	updater.registerFn("create_index", updateCreateIndexColumnsList)
+
+	return updater
+}
+
+func (u *FileUpdater) Update(rawMigration *RawMigration) (*Migration, error) {
+	var ops []map[string]any
+	if err := json.Unmarshal(rawMigration.Operations, &ops); err != nil {
+		return nil, err
+	}
+	var err error
+	for _, op := range ops {
+		for opName, fns := range u.updaterFns {
+			// if the operation does not have registered updater function, do nothing
+			if _, ok := op[opName]; !ok {
+				continue
+			}
+			// run all registered updater functions on operation
+			for _, fn := range fns {
+				op, err = fn(op)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	rawMigration.Operations, err = json.Marshal(ops)
+	if err != nil {
+		return nil, err
+	}
+	return ParseMigration(rawMigration)
+}
+
+// updateCreateIndexColumnsList transforms the columns attribute from a list into a map
+// columns: [name] -> columns: name: {}
+// breaking change was released in v0.10.0
+// PR: https://github.com/xataio/pgroll/pull/697
+func updateCreateIndexColumnsList(op map[string]any) (map[string]any, error) {
+	body, err := json.Marshal(op)
+	if err != nil {
+		return nil, err
+	}
+	var createIndexOp struct {
+		CreateIndex struct {
+			Columns []string `json:"columns"`
+		} `json:"create_index"`
+	}
+	if err := json.Unmarshal(body, &createIndexOp); err == nil {
+		if createIndexOper, ok := op["create_index"].(map[string]any); ok {
+			delete(createIndexOper, "columns")
+			columnsList := make(map[string]any, len(createIndexOp.CreateIndex.Columns))
+			for _, col := range createIndexOp.CreateIndex.Columns {
+				columnsList[col] = map[string]any{}
+			}
+			createIndexOper["columns"] = columnsList
+		}
+	}
+
+	return op, nil
+}

--- a/pkg/migrations/updater.go
+++ b/pkg/migrations/updater.go
@@ -53,7 +53,7 @@ func (u *FileUpdater) Update(rawMigration *RawMigration) (*Migration, error) {
 	return ParseMigration(rawMigration)
 }
 
-// updateCreateIndexColumnsList transforms the columns attribute from a list into a map
+// updateCreateIndexColumnsList transforms create_index's columns attribute from a list into a map
 // columns: [name] -> columns: name: {}
 // breaking change was released in v0.10.0
 // PR: https://github.com/xataio/pgroll/pull/697

--- a/pkg/migrations/updater.go
+++ b/pkg/migrations/updater.go
@@ -12,10 +12,6 @@ type FileUpdater struct {
 	updaterFns map[string][]UpdaterFn
 }
 
-func (u *FileUpdater) RegisterFn(op string, fn UpdaterFn) {
-	u.updaterFns[op] = append(u.updaterFns[op], fn)
-}
-
 func NewFileUpdater(updaters map[string][]UpdaterFn) *FileUpdater {
 	return &FileUpdater{
 		updaterFns: updaters,

--- a/pkg/migrations/updater.go
+++ b/pkg/migrations/updater.go
@@ -67,6 +67,9 @@ func updateCreateIndexColumnsList(op map[string]any) (map[string]any, error) {
 			Columns []string `json:"columns"`
 		} `json:"create_index"`
 	}
+
+	// error is ignored here, because it can only happend if the create_index
+	// operation does not contain the expected, outdated structure
 	if err := json.Unmarshal(body, &createIndexOp); err == nil {
 		if createIndexOper, ok := op["create_index"].(map[string]any); ok {
 			delete(createIndexOper, "columns")

--- a/pkg/migrations/updater.go
+++ b/pkg/migrations/updater.go
@@ -68,7 +68,7 @@ func updateCreateIndexColumnsList(op map[string]any) (map[string]any, error) {
 		} `json:"create_index"`
 	}
 
-	// error is ignored here, because it can only happend if the create_index
+	// error is ignored here, because it can only happened if the create_index
 	// operation does not contain the expected, outdated structure
 	if err := json.Unmarshal(body, &createIndexOp); err == nil {
 		if createIndexOper, ok := op["create_index"].(map[string]any); ok {

--- a/pkg/migrations/updater.go
+++ b/pkg/migrations/updater.go
@@ -20,7 +20,7 @@ func NewFileUpdater() *FileUpdater {
 	updater := &FileUpdater{updaterFns: make(map[string][]updaterFn)}
 
 	// register updater functions
-	updater.registerFn("create_index", updateCreateIndexColumnsList)
+	updater.registerFn(string(OpNameCreateIndex), updateCreateIndexColumnsList)
 
 	return updater
 }

--- a/pkg/migrations/updater_test.go
+++ b/pkg/migrations/updater_test.go
@@ -54,7 +54,7 @@ func TestFileUpdater(t *testing.T) {
 			t.Fatal("expected columns to be a map, got nil")
 		}
 
-		var expectedColumns = migrations.OpCreateIndexColumns{
+		expectedColumns := migrations.OpCreateIndexColumns{
 			"col1": migrations.IndexField{},
 			"col2": migrations.IndexField{},
 		}
@@ -132,7 +132,7 @@ func TestFileUpdater(t *testing.T) {
 			t.Fatal("expected columns to be a map, got nil")
 		}
 
-		var expectedColumns = migrations.OpCreateIndexColumns{
+		expectedColumns := migrations.OpCreateIndexColumns{
 			"col1": migrations.IndexField{},
 			"col2": migrations.IndexField{},
 		}

--- a/pkg/migrations/updater_test.go
+++ b/pkg/migrations/updater_test.go
@@ -5,137 +5,113 @@ package migrations_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/xataio/pgroll/pkg/migrations"
 )
 
 func TestFileUpdater(t *testing.T) {
-	updater := migrations.NewFileUpdater()
+	t.Run("create_index", func(t *testing.T) {
+		updater := createIndexUpdater()
 
-	t.Run("update with no operations", func(t *testing.T) {
-		rawMigration := &migrations.RawMigration{Operations: []byte("[]")}
-		migration, err := updater.Update(rawMigration)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
-		if len(migration.Operations) != 0 {
-			t.Fatalf("expected no operations, got %d", len(migration.Operations))
-		}
-	})
+		t.Run("update with no operations", func(t *testing.T) {
+			rawMigration := &migrations.RawMigration{Operations: []byte("[]")}
+			migration, err := updater.Update(rawMigration)
+			require.NoError(t, err, "expected no error for empty operations")
+			require.Equal(t, 0, len(migration.Operations), "expected no operations in migration")
+		})
 
-	t.Run("update with malformed operations", func(t *testing.T) {
-		rawMigration := &migrations.RawMigration{
-			Operations: []byte(`[{"create_index": {"name": "idx_test", "columns": "col1, col2"}}]`),
-		}
-		_, err := updater.Update(rawMigration)
-		if err == nil {
-			t.Fatal("expected error for malformed operations, got nil")
-		}
-	})
+		t.Run("update with malformed operations", func(t *testing.T) {
+			rawMigration := &migrations.RawMigration{
+				Operations: []byte(`[{"create_index": {"name": "idx_test", "columns": "col1, col2"}}]`),
+			}
+			_, err := updater.Update(rawMigration)
+			require.Error(t, err, "expected error for malformed operations")
+		})
 
-	t.Run("update with create_index operation", func(t *testing.T) {
-		rawMigration := &migrations.RawMigration{
-			Operations: []byte(`[{"create_index": {"name": "idx_test", "columns": ["col1", "col2"]}}]`),
-		}
-		migration, err := updater.Update(rawMigration)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
-		if len(migration.Operations) != 1 {
-			t.Fatalf("expected 1 operation, got %d", len(migration.Operations))
-		}
-		op := migration.Operations[0]
-		createIndexOp, ok := op.(*migrations.OpCreateIndex)
-		if !ok {
-			t.Fatal("expected create_index operation to be present")
-		}
+		t.Run("update with create_index operation", func(t *testing.T) {
+			rawMigration := &migrations.RawMigration{
+				Operations: []byte(`[{"create_index": {"name": "idx_test", "columns": ["col1", "col2"]}}]`),
+			}
+			migration, err := updater.Update(rawMigration)
+			require.NoError(t, err, "expected no error for valid create_index operation")
+			require.Equal(t, 1, len(migration.Operations), "expected 1 operation in migration")
 
-		if createIndexOp.Columns == nil {
-			t.Fatal("expected columns to be a map, got nil")
-		}
+			op := migration.Operations[0]
+			createIndexOp, ok := op.(*migrations.OpCreateIndex)
+			require.True(t, ok, "expected create_index operation to be present")
+			require.NotNil(t, createIndexOp.Columns, "expected columns to be present")
 
-		expectedColumns := migrations.OpCreateIndexColumns{
-			"col1": migrations.IndexField{},
-			"col2": migrations.IndexField{},
-		}
-		assert.Equal(t, expectedColumns, createIndexOp.Columns, "columns should be transformed to a map")
-	})
+			expectedColumns := migrations.OpCreateIndexColumns{
+				"col1": migrations.IndexField{},
+				"col2": migrations.IndexField{},
+			}
+			require.Equal(t, expectedColumns, createIndexOp.Columns, "columns should be transformed to a map")
+		})
 
-	t.Run("update with no create_index operation", func(t *testing.T) {
-		rawMigration := &migrations.RawMigration{
-			Operations: []byte(`[{"create_table": {"name": "test_table"}}]`),
-		}
-		migration, err := updater.Update(rawMigration)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
-		if len(migration.Operations) != 1 {
-			t.Fatalf("expected 1 operation, got %d", len(migration.Operations))
-		}
-		op := migration.Operations[0]
-		if _, ok := op.(*migrations.OpCreateTable); !ok {
-			t.Fatal("expected create_table operation to be present")
-		}
-	})
+		t.Run("update with no create_index operation", func(t *testing.T) {
+			rawMigration := &migrations.RawMigration{
+				Operations: []byte(`[{"create_table": {"name": "test_table"}}]`),
+			}
+			migration, err := updater.Update(rawMigration)
+			require.NoError(t, err, "expected no error for valid create_table operation")
+			require.Equal(t, 1, len(migration.Operations), "expected 1 operation in migration")
 
-	t.Run("update with multiple operations", func(t *testing.T) {
-		rawMigration := &migrations.RawMigration{
-			Operations: []byte(`[
+			op := migration.Operations[0]
+			_, ok := op.(*migrations.OpCreateTable)
+			require.True(t, ok, "expected create_table operation to be present")
+		})
+
+		t.Run("update with multiple operations", func(t *testing.T) {
+			rawMigration := &migrations.RawMigration{
+				Operations: []byte(`[
 				{"create_index": {"name": "idx_test1", "columns": ["col1"]}},
 				{"create_index": {"name": "idx_test2", "columns": ["col2"]}}
 			]`),
-		}
-		migration, err := updater.Update(rawMigration)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
-		if len(migration.Operations) != 2 {
-			t.Fatalf("expected 2 operations, got %d", len(migration.Operations))
-		}
-		for i, op := range migration.Operations {
-			createIndexOp, ok := op.(*migrations.OpCreateIndex)
-			if !ok {
-				t.Fatalf("expected create_index operation at index %d to be present", i)
 			}
-			if createIndexOp.Columns == nil {
-				t.Fatal("expected columns to be a map, got nil")
-			}
-		}
-	})
+			migration, err := updater.Update(rawMigration)
+			require.NoError(t, err, "expected no error for multiple create_index operations")
+			require.Equal(t, 2, len(migration.Operations), "expected 2 operations in migration")
 
-	t.Run("update with multiple operations and one create_index", func(t *testing.T) {
-		rawMigration := &migrations.RawMigration{
-			Operations: []byte(`[
+			for i, op := range migration.Operations {
+				createIndexOp, ok := op.(*migrations.OpCreateIndex)
+				require.True(t, ok, "expected create_index operation at index %d to be present", i)
+				require.NotNil(t, createIndexOp.Columns, "expected columns to be a map for create_index operation at index %d", i)
+			}
+		})
+
+		t.Run("update with multiple operations and one create_index", func(t *testing.T) {
+			rawMigration := &migrations.RawMigration{
+				Operations: []byte(`[
 				{"create_table": {"name": "test_table"}},
 				{"create_index": {"name": "idx_test", "columns": ["col1", "col2"]}}
 			]`),
-		}
-		migration, err := updater.Update(rawMigration)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
-		if len(migration.Operations) != 2 {
-			t.Fatalf("expected 2 operations, got %d", len(migration.Operations))
-		}
-		op := migration.Operations[0]
-		if _, ok := op.(*migrations.OpCreateTable); !ok {
-			t.Fatal("expected create_table operation to be present")
-		}
+			}
+			migration, err := updater.Update(rawMigration)
+			require.NoError(t, err, "expected no error for mixed operations")
+			require.Equal(t, 2, len(migration.Operations), "expected 2 operations in migration")
 
-		op = migration.Operations[1]
-		createIndexOp, ok := op.(*migrations.OpCreateIndex)
-		if !ok {
-			t.Fatal("expected create_index operation to be present")
-		}
+			op := migration.Operations[0]
+			_, ok := op.(*migrations.OpCreateTable)
+			require.True(t, ok, "expected create_table operation to be present")
 
-		if createIndexOp.Columns == nil {
-			t.Fatal("expected columns to be a map, got nil")
-		}
+			op = migration.Operations[1]
+			createIndexOp, ok := op.(*migrations.OpCreateIndex)
+			require.True(t, ok, "expected create_index operation to be present")
+			require.NotNil(t, createIndexOp.Columns, "expected columns to be a map for create_index operation")
 
-		expectedColumns := migrations.OpCreateIndexColumns{
-			"col1": migrations.IndexField{},
-			"col2": migrations.IndexField{},
-		}
-		assert.Equal(t, expectedColumns, createIndexOp.Columns, "columns should be transformed to a map")
+			expectedColumns := migrations.OpCreateIndexColumns{
+				"col1": migrations.IndexField{},
+				"col2": migrations.IndexField{},
+			}
+			require.Equal(t, expectedColumns, createIndexOp.Columns, "columns should be transformed to a map")
+		})
+	})
+}
+
+func createIndexUpdater() *migrations.FileUpdater {
+	return migrations.NewFileUpdater(map[string][]migrations.UpdaterFn{
+		string(migrations.OpNameCreateIndex): {
+			migrations.UpdateCreateIndexColumnsList,
+		},
 	})
 }

--- a/pkg/migrations/updater_test.go
+++ b/pkg/migrations/updater_test.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package migrations_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xataio/pgroll/pkg/migrations"
+)
+
+func TestFileUpdater(t *testing.T) {
+	updater := migrations.NewFileUpdater()
+
+	t.Run("update with no operations", func(t *testing.T) {
+		rawMigration := &migrations.RawMigration{Operations: []byte("[]")}
+		migration, err := updater.Update(rawMigration)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(migration.Operations) != 0 {
+			t.Fatalf("expected no operations, got %d", len(migration.Operations))
+		}
+	})
+
+	t.Run("update with malformed operations", func(t *testing.T) {
+		rawMigration := &migrations.RawMigration{
+			Operations: []byte(`[{"create_index": {"name": "idx_test", "columns": "col1, col2"}}]`),
+		}
+		_, err := updater.Update(rawMigration)
+		if err == nil {
+			t.Fatal("expected error for malformed operations, got nil")
+		}
+	})
+
+	t.Run("update with create_index operation", func(t *testing.T) {
+		rawMigration := &migrations.RawMigration{
+			Operations: []byte(`[{"create_index": {"name": "idx_test", "columns": ["col1", "col2"]}}]`),
+		}
+		migration, err := updater.Update(rawMigration)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(migration.Operations) != 1 {
+			t.Fatalf("expected 1 operation, got %d", len(migration.Operations))
+		}
+		op := migration.Operations[0]
+		createIndexOp, ok := op.(*migrations.OpCreateIndex)
+		if !ok {
+			t.Fatal("expected create_index operation to be present")
+		}
+
+		if createIndexOp.Columns == nil {
+			t.Fatal("expected columns to be a map, got nil")
+		}
+
+		var expectedColumns = migrations.OpCreateIndexColumns{
+			"col1": migrations.IndexField{},
+			"col2": migrations.IndexField{},
+		}
+		assert.Equal(t, expectedColumns, createIndexOp.Columns, "columns should be transformed to a map")
+	})
+
+	t.Run("update with no create_index operation", func(t *testing.T) {
+		rawMigration := &migrations.RawMigration{
+			Operations: []byte(`[{"create_table": {"name": "test_table"}}]`),
+		}
+		migration, err := updater.Update(rawMigration)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(migration.Operations) != 1 {
+			t.Fatalf("expected 1 operation, got %d", len(migration.Operations))
+		}
+		op := migration.Operations[0]
+		if _, ok := op.(*migrations.OpCreateTable); !ok {
+			t.Fatal("expected create_table operation to be present")
+		}
+	})
+
+	t.Run("update with multiple operations", func(t *testing.T) {
+		rawMigration := &migrations.RawMigration{
+			Operations: []byte(`[
+				{"create_index": {"name": "idx_test1", "columns": ["col1"]}},
+				{"create_index": {"name": "idx_test2", "columns": ["col2"]}}
+			]`),
+		}
+		migration, err := updater.Update(rawMigration)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(migration.Operations) != 2 {
+			t.Fatalf("expected 2 operations, got %d", len(migration.Operations))
+		}
+		for i, op := range migration.Operations {
+			createIndexOp, ok := op.(*migrations.OpCreateIndex)
+			if !ok {
+				t.Fatalf("expected create_index operation at index %d to be present", i)
+			}
+			if createIndexOp.Columns == nil {
+				t.Fatal("expected columns to be a map, got nil")
+			}
+		}
+	})
+
+	t.Run("update with multiple operations and one create_index", func(t *testing.T) {
+		rawMigration := &migrations.RawMigration{
+			Operations: []byte(`[
+				{"create_table": {"name": "test_table"}},
+				{"create_index": {"name": "idx_test", "columns": ["col1", "col2"]}}
+			]`),
+		}
+		migration, err := updater.Update(rawMigration)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(migration.Operations) != 2 {
+			t.Fatalf("expected 2 operations, got %d", len(migration.Operations))
+		}
+		op := migration.Operations[0]
+		if _, ok := op.(*migrations.OpCreateTable); !ok {
+			t.Fatal("expected create_table operation to be present")
+		}
+
+		op = migration.Operations[1]
+		createIndexOp, ok := op.(*migrations.OpCreateIndex)
+		if !ok {
+			t.Fatal("expected create_index operation to be present")
+		}
+
+		if createIndexOp.Columns == nil {
+			t.Fatal("expected columns to be a map, got nil")
+		}
+
+		var expectedColumns = migrations.OpCreateIndexColumns{
+			"col1": migrations.IndexField{},
+			"col2": migrations.IndexField{},
+		}
+		assert.Equal(t, expectedColumns, createIndexOp.Columns, "columns should be transformed to a map")
+	})
+}


### PR DESCRIPTION
This PR adds a new subcommand called `update`. It updates migrations that contain breaking changes in the selected folder.

```
Usage:
  pgroll update <directory> [flags]

Examples:
update ./migrations

Flags:
  -h, --help    help for update
  -j, --json    Output migration file in JSON format instead of YAML
```

### Dev notes

The new `migrations.FileUpdater` follows the chain of responsibility design pattern. In the `FileUpdater` you can register new updater functions (`migrations.updaterFn`) for any pgroll migration. The file updater iterates over all operations in a migration and run the registered updater functions in order.

The ordering of the updater functions is important. Please always add a new updater function to the end of the list.

Closes #770
