### PR TITLE
Add new subcommand to validate migration files

### DIFF
--- a/cli-definition.json
+++ b/cli-definition.json
@@ -219,6 +219,17 @@
       "flags": [],
       "subcommands": [],
       "args": []
+    },
+    {
+      "name": "validate",
+      "short": "Validate a migration file",
+      "use": "validate <file>",
+      "example": "validate migrations/03_my_migration.yaml",
+      "flags": [],
+      "subcommands": [],
+      "args": [
+        "file"
+      ]
     }
   ],
   "flags": [

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -107,6 +107,7 @@ func Prepare() *cobra.Command {
 	rootCmd.AddCommand(latestCmd())
 	rootCmd.AddCommand(convertCmd())
 	rootCmd.AddCommand(baselineCmd())
+	rootCmd.AddCommand(validateCmd)
 
 	return rootCmd
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -92,7 +92,13 @@ func runMigration(ctx context.Context, m *roll.Roll, migration *migrations.Migra
 		}
 	})
 
-	err := m.Start(ctx, migration, c)
+	err := m.Validate(ctx, migration)
+	if err != nil {
+		sp.Fail(fmt.Sprintf("Failed to start migration: %s", err))
+		return err
+	}
+
+	err = m.Start(ctx, migration, c)
 	if err != nil {
 		sp.Fail(fmt.Sprintf("Failed to start migration: %s", err))
 		return err

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/xataio/pgroll/pkg/migrations"
+)
+
+var validateCmd = &cobra.Command{
+	Use:       "validate <file>",
+	Short:     "Validate a migration file",
+	Example:   "validate migrations/03_my_migration.yaml",
+	Args:      cobra.ExactArgs(1),
+	ValidArgs: []string{"file"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		fileName := args[0]
+
+		m, err := NewRollWithInitCheck(ctx)
+		if err != nil {
+			return err
+		}
+		defer m.Close()
+
+		migration, err := migrations.ReadMigration(os.DirFS(filepath.Dir(fileName)), filepath.Base(fileName))
+		if err != nil {
+			return err
+		}
+		err = m.Validate(ctx, migration)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+}

--- a/docs/cli/validate.mdx
+++ b/docs/cli/validate.mdx
@@ -1,0 +1,18 @@
+---
+title: Validate
+description: Validate a pgroll migration
+---
+
+## Command
+
+```
+$ pgroll validate sql/03_add_column.yaml
+```
+
+This validates the migration defined in the `sql/03_add_column.yaml` file.
+
+The command can detect the following errors:
+
+* syntax error in pgroll migration format
+* unknown/invalid configuration options and settings in the migration file
+* reference to unknown database objects

--- a/docs/config.json
+++ b/docs/config.json
@@ -75,6 +75,11 @@
           "file": "docs/cli/rollback.mdx"
         },
         {
+          "title": "Validate",
+          "href": "/cli/validate",
+          "file": "docs/cli/validate.mdx"
+        },
+        {
           "title": "Create",
           "href": "/cli/create",
           "file": "docs/cli/create.mdx"

--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -15,7 +15,23 @@ import (
 	"github.com/xataio/pgroll/pkg/schema"
 )
 
+func (m *Roll) Validate(ctx context.Context, migration *migrations.Migration) error {
+	if m.skipValidation {
+		return nil
+	}
+	lastSchema, err := m.state.LastSchema(ctx, m.schema)
+	if err != nil {
+		return err
+	}
+	err = migration.Validate(ctx, lastSchema)
+	if err != nil {
+		return fmt.Errorf("migration '%s' is invalid: %w", migration.Name, err)
+	}
+	return nil
+}
+
 // Start will apply the required changes to enable supporting the new schema version
+// Migrations must be validated before running Start.
 func (m *Roll) Start(ctx context.Context, migration *migrations.Migration, cfg *backfill.Config) error {
 	// Fail early if we have existing schema without migration history
 	hasExistingSchema, err := m.state.HasExistingSchemaWithoutHistory(ctx, m.schema)
@@ -50,20 +66,8 @@ func (m *Roll) StartDDLOperations(ctx context.Context, migration *migrations.Mig
 	}
 
 	// create a new active migration (guaranteed to be unique by constraints)
-	newSchema, err := m.state.Start(ctx, m.schema, migration)
-	if err != nil {
+	if err = m.state.Start(ctx, m.schema, migration); err != nil {
 		return nil, fmt.Errorf("unable to start migration: %w", err)
-	}
-
-	// validate migration
-	if !m.skipValidation {
-		err = migration.Validate(ctx, newSchema)
-		if err != nil {
-			if err := m.state.Rollback(ctx, m.schema, migration.Name); err != nil {
-				fmt.Printf("failed to rollback migration: %s\n", err)
-			}
-			return nil, fmt.Errorf("migration is invalid: %w", err)
-		}
 	}
 
 	// run any BeforeStartDDL hooks
@@ -89,7 +93,7 @@ func (m *Roll) StartDDLOperations(ctx context.Context, migration *migrations.Mig
 
 	// Reread the latest schema as validation may have updated the schema object
 	// in memory.
-	newSchema, err = m.state.ReadSchema(ctx, m.schema)
+	newSchema, err := m.state.ReadSchema(ctx, m.schema)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read schema: %w", err)
 	}

--- a/pkg/state/history_test.go
+++ b/pkg/state/history_test.go
@@ -55,7 +55,7 @@ func TestSchemaHistoryReturnsFullSchemaHistory(t *testing.T) {
 
 		// Start and complete both migrations
 		for _, mig := range migs {
-			_, err := state.Start(ctx, "public", &mig)
+			err := state.Start(ctx, "public", &mig)
 			require.NoError(t, err)
 			err = state.Complete(ctx, "public", mig.Name)
 			require.NoError(t, err)

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -35,8 +35,15 @@ func TestSchemaOptionIsRespected(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// check that starting a new migration returns the already existing table
-		currentSchema, err := state.Start(ctx, "public", &migrations.Migration{
+		// check that we can retrieve the already existing table
+		currentSchema, err := state.LastSchema(ctx, "public")
+		assert.NoError(t, err)
+
+		assert.Equal(t, 1, len(currentSchema.Tables))
+		assert.Equal(t, "public", currentSchema.Name)
+
+		// check that we can start the migration
+		err = state.Start(ctx, "public", &migrations.Migration{
 			Name: "1_add_column",
 			Operations: migrations.Operations{
 				&migrations.OpAddColumn{
@@ -49,9 +56,6 @@ func TestSchemaOptionIsRespected(t *testing.T) {
 			},
 		})
 		assert.NoError(t, err)
-
-		assert.Equal(t, 1, len(currentSchema.Tables))
-		assert.Equal(t, "public", currentSchema.Name)
 	})
 }
 


### PR DESCRIPTION
This PR adds a new subcommand to validate migration files.

```
```

It is first step towards providing a way to validate migration files before running them. At the moment it can validate a single migration file against the latest schema in the database. This can be added to your local workflow, or a linter to make sure that the newly added migration file is correct.

Future improvements can be
* validating multiple migrations
* validating all unapplied migrations in a folder
* verifying `up` migrations on a subset of the table

The PR contains some minor changes to the migration phase `Start`. Now migration validation is decoupled from it. It must be called explicitly before running `Start`.

Closes #370
