### PR TITLE
Remove `Ensure JSON examples are formatted` CI step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,15 +94,6 @@ jobs:
         # The location of the configuration file can be changed by using `--config=`
         args: --timeout=30m --out-format=colored-line-number --config=.golangci.yml
 
-    - name: Ensure JSON examples are formatted
-      run: |
-        for file in ./examples/*.json; do
-          if ! diff <(cat $file | jq) <(cat $file); then
-            echo "$file is not formatted: run 'cat $file | jq' to fix";
-            exit 1;
-          fi
-        done
-
   format:
     name: format
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Examples are in YAML now so this step does nothing.