### PR TITLE
Update docs with `backfill-batch-delay` and `backfill-batch-size` options

### DIFF
--- a/docs/cli/migrate.mdx
+++ b/docs/cli/migrate.mdx
@@ -17,6 +17,19 @@ If the `--complete` flag is passed to `pgroll migrate` the final migration to be
 
 If any of the migration files are incompatible with your `pgroll` version, the command will report the errors and exit before running any migrations.
 
+## Backfill Configuration
+
+When migrations involve backfilling data (such as adding a `NOT NULL` constraint to an existing column), the backfill process can be controlled using these flags:
+
+- `--backfill-batch-size`: Number of rows backfilled in each batch (default: 1000)
+- `--backfill-batch-delay`: Duration of delay between each batch, e.g., "1s", "1000ms" (default: 0s)
+
+```
+$ pgroll migrate examples/ --backfill-batch-size 500 --backfill-batch-delay 100ms
+```
+
+These options help manage the performance impact of large backfill operations by processing data in smaller batches with optional delays between batches.
+
 ## Existing Database Schema
 
 If you attempt to run `pgroll migrate` against a database that has existing tables but no migration history, the command will fail with an error message. In this case, you should first run `pgroll baseline` to establish a baseline migration that captures the current schema state before applying any new migrations.

--- a/docs/cli/start.mdx
+++ b/docs/cli/start.mdx
@@ -30,6 +30,19 @@ This is equivalent to running `pgroll start` immediately followed by `pgroll com
   before running `pgroll complete` as a separate step.
 </Warning>
 
+## Backfill Configuration
+
+When migrations involve backfilling data (such as adding a `NOT NULL` constraint to an existing column), the backfill process can be controlled using these flags:
+
+- `--backfill-batch-size`: Number of rows backfilled in each batch (default: 1000)
+- `--backfill-batch-delay`: Duration of delay between each batch, e.g., "1s", "1000ms" (default: 0s)
+
+```
+$ pgroll migrate examples/ --backfill-batch-size 500 --backfill-batch-delay 100ms
+```
+
+These options help manage the performance impact of large backfill operations by processing data in smaller batches with optional delays between batches.
+
 ## Existing Database Schema
 
 If you attempt to run `pgroll start` against a database that has existing tables but no migration history, the command will fail with an error message. In this case, you should first run `pgroll baseline` to establish a baseline migration that captures the current schema state before starting any new migrations.


### PR DESCRIPTION
Add documentation for backfill configuration options in the `start` and `migrate` commands.