### PR TITLE
Add new `DBAction`: `RenameDuplicatedColumnAction`

### DIFF
--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -134,7 +134,7 @@ func (o *OpAlterColumn) Complete(ctx context.Context, l Logger, conn db.DB, s *s
 	if column == nil {
 		return ColumnDoesNotExistError{Table: o.Table, Name: o.Column}
 	}
-	if err := RenameDuplicatedColumn(ctx, conn, table, column); err != nil {
+	if err := NewRenameDuplicatedColumnAction(conn, table, column.Name).Execute(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/migrations/op_create_constraint.go
+++ b/pkg/migrations/op_create_constraint.go
@@ -168,7 +168,7 @@ func (o *OpCreateConstraint) Complete(ctx context.Context, l Logger, conn db.DB,
 		if column == nil {
 			return ColumnDoesNotExistError{Table: o.Table, Name: col}
 		}
-		if err := RenameDuplicatedColumn(ctx, conn, table, column); err != nil {
+		if err := NewRenameDuplicatedColumnAction(conn, table, column.Name).Execute(ctx); err != nil {
 			return err
 		}
 	}

--- a/pkg/migrations/op_drop_constraint.go
+++ b/pkg/migrations/op_drop_constraint.go
@@ -111,7 +111,7 @@ func (o *OpDropConstraint) Complete(ctx context.Context, l Logger, conn db.DB, s
 	}
 
 	// Rename the new column to the old column name
-	if err := RenameDuplicatedColumn(ctx, conn, table, column); err != nil {
+	if err := NewRenameDuplicatedColumnAction(conn, table, column.Name).Execute(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/migrations/op_drop_multicolumn_constraint.go
+++ b/pkg/migrations/op_drop_multicolumn_constraint.go
@@ -127,7 +127,7 @@ func (o *OpDropMultiColumnConstraint) Complete(ctx context.Context, l Logger, co
 
 		// Rename the new column to the old column name
 		column := table.GetColumn(columnName)
-		if err := RenameDuplicatedColumn(ctx, conn, table, column); err != nil {
+		if err := NewRenameDuplicatedColumnAction(conn, table, column.Name).Execute(ctx); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR transforms `RenameDuplicatedColumn` to a `DBAction`. It consists of multiple `DBAction`s. It might be
more elegant if it returned a list of `DBActions` instead. But for now, it is good enough for the upcoming extraction
of the cleanup phase from complete and rollback.

Related to #742
