### PR TITLE
Allow migration files to specify a `versionSchema` field

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -36,7 +36,7 @@ func migrateCmd() *cobra.Command {
 			}
 			defer m.Close()
 
-			latestVersion, err := m.State().LatestVersion(ctx, m.Schema())
+			latestMigration, err := m.State().LatestMigration(ctx, m.Schema())
 			if err != nil {
 				return fmt.Errorf("unable to determine latest version: %w", err)
 			}
@@ -46,7 +46,7 @@ func migrateCmd() *cobra.Command {
 				return fmt.Errorf("unable to determine active migration period: %w", err)
 			}
 			if active {
-				fmt.Printf("migration %q is active\n", *latestVersion)
+				fmt.Printf("migration %q is active\n", *latestMigration)
 				return nil
 			}
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -105,8 +105,7 @@ func runMigration(ctx context.Context, m *roll.Roll, migration *migrations.Migra
 		}
 	}
 
-	version := migration.Name
-	viewName := roll.VersionedSchemaName(flags.Schema(), version)
+	viewName := roll.VersionedSchemaName(flags.Schema(), migration.VersionSchemaName())
 	msg := fmt.Sprintf("New version of the schema available under the postgres %q schema", viewName)
 	sp.Success(msg)
 

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -68,14 +68,25 @@ type RequiresSchemaRefreshOperation interface {
 type (
 	Operations []Operation
 	Migration  struct {
-		Name       string     `json:"-"`
-		Operations Operations `json:"operations"`
+		Name          string     `json:"-"`
+		VersionSchema string     `json:"versionSchema,omitempty"`
+		Operations    Operations `json:"operations"`
 	}
 	RawMigration struct {
-		Name       string          `json:"-"`
-		Operations json.RawMessage `json:"operations"`
+		Name          string          `json:"-"`
+		VersionSchema string          `json:"versionSchema,omitempty"`
+		Operations    json.RawMessage `json:"operations"`
 	}
 )
+
+// VersionSchemaName returns the version schema name for the migration.
+// It defaults to the migration name if no version schema is set.
+func (m *Migration) VersionSchemaName() string {
+	if m.VersionSchema != "" {
+		return m.VersionSchema
+	}
+	return m.Name
+}
 
 // Validate will check that the migration can be applied to the given schema
 // returns a descriptive error if the migration is invalid

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -69,12 +69,12 @@ type (
 	Operations []Operation
 	Migration  struct {
 		Name          string     `json:"-"`
-		VersionSchema string     `json:"versionSchema,omitempty"`
+		VersionSchema string     `json:"version_schema,omitempty"`
 		Operations    Operations `json:"operations"`
 	}
 	RawMigration struct {
 		Name          string          `json:"-"`
-		VersionSchema string          `json:"versionSchema,omitempty"`
+		VersionSchema string          `json:"version_schema,omitempty"`
 		Operations    json.RawMessage `json:"operations"`
 	}
 )

--- a/pkg/migrations/op_common.go
+++ b/pkg/migrations/op_common.go
@@ -132,8 +132,9 @@ func ParseMigration(raw *RawMigration) (*Migration, error) {
 	}
 
 	return &Migration{
-		Name:       raw.Name,
-		Operations: ops,
+		Name:          raw.Name,
+		VersionSchema: raw.VersionSchema,
+		Operations:    ops,
 	}, nil
 }
 

--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -275,15 +275,15 @@ func (m *Roll) Rollback(ctx context.Context) error {
 	}
 
 	// get the name of the previous version of the schema
-	previousVersion, err := m.state.PreviousVersion(ctx, m.schema, true)
+	previousMigration, err := m.state.PreviousMigration(ctx, m.schema, true)
 	if err != nil {
 		return fmt.Errorf("unable to get name of previous version: %w", err)
 	}
 
 	// get the schema after the previous migration was applied
 	schema := schema.New()
-	if previousVersion != nil {
-		schema, err = m.state.SchemaAfterMigration(ctx, m.schema, *previousVersion)
+	if previousMigration != nil {
+		schema, err = m.state.SchemaAfterMigration(ctx, m.schema, *previousMigration)
 		if err != nil {
 			return fmt.Errorf("unable to read schema: %w", err)
 		}

--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -136,16 +136,15 @@ func (m *Roll) StartDDLOperations(ctx context.Context, migration *migrations.Mig
 	}
 
 	// create views for the new version
-	if err := m.ensureViews(ctx, newSchema, migration.Name); err != nil {
+	if err := m.ensureViews(ctx, newSchema, migration); err != nil {
 		return nil, err
 	}
 
 	return tablesToBackfill, nil
 }
 
-func (m *Roll) ensureViews(ctx context.Context, schema *schema.Schema, version string) error {
-	// create schema for the new version
-	versionSchema := VersionedSchemaName(m.schema, version)
+func (m *Roll) ensureViews(ctx context.Context, schema *schema.Schema, mig *migrations.Migration) error {
+	versionSchema := VersionedSchemaName(m.schema, mig.VersionSchemaName())
 	_, err := m.pgConn.ExecContext(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(versionSchema)))
 	if err != nil {
 		return err
@@ -156,13 +155,13 @@ func (m *Roll) ensureViews(ctx context.Context, schema *schema.Schema, version s
 		if table.Deleted {
 			continue
 		}
-		err = m.ensureView(ctx, version, name, table)
+		err = m.ensureView(ctx, mig.VersionSchemaName(), name, table)
 		if err != nil {
 			return fmt.Errorf("unable to create view: %w", err)
 		}
 	}
 
-	m.logger.LogSchemaCreation(version, versionSchema)
+	m.logger.LogSchemaCreation(mig.VersionSchemaName(), versionSchema)
 
 	return nil
 }
@@ -237,7 +236,7 @@ func (m *Roll) Complete(ctx context.Context) error {
 			return fmt.Errorf("unable to read schema: %w", err)
 		}
 
-		err = m.ensureViews(ctx, currentSchema, migration.Name)
+		err = m.ensureViews(ctx, currentSchema, migration)
 		if err != nil {
 			return err
 		}

--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -265,7 +265,7 @@ func (m *Roll) Rollback(ctx context.Context) error {
 
 	if !m.disableVersionSchemas {
 		// delete the schema and view for the new version
-		versionSchema := VersionedSchemaName(m.schema, migration.Name)
+		versionSchema := VersionedSchemaName(m.schema, migration.VersionSchemaName())
 		_, err = m.pgConn.ExecContext(ctx, fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", pq.QuoteIdentifier(versionSchema)))
 		if err != nil {
 			return err

--- a/pkg/roll/execute_test.go
+++ b/pkg/roll/execute_test.go
@@ -258,23 +258,48 @@ func TestNoVersionSchemaForRawSQLMigrationsOptionIsRespected(t *testing.T) {
 func TestSchemaIsDroppedAfterMigrationRollback(t *testing.T) {
 	t.Parallel()
 
-	testutils.WithMigratorAndConnectionToContainer(t, func(mig *roll.Roll, db *sql.DB) {
-		ctx := context.Background()
-		version := "1_create_table"
+	t.Run("when the migration does not set an explicit version schema name ", func(t *testing.T) {
+		testutils.WithMigratorAndConnectionToContainer(t, func(mig *roll.Roll, db *sql.DB) {
+			ctx := context.Background()
+			version := "1_create_table"
 
-		if err := mig.Start(ctx, &migrations.Migration{Name: version, Operations: migrations.Operations{createTableOp("table1")}}, backfill.NewConfig()); err != nil {
-			t.Fatalf("Failed to start migration: %v", err)
-		}
-		if err := mig.Rollback(ctx); err != nil {
-			t.Fatalf("Failed to rollback migration: %v", err)
-		}
+			if err := mig.Start(ctx, &migrations.Migration{
+				Name:       version,
+				Operations: migrations.Operations{createTableOp("table1")},
+			}, backfill.NewConfig()); err != nil {
+				t.Fatalf("Failed to start migration: %v", err)
+			}
+			if err := mig.Rollback(ctx); err != nil {
+				t.Fatalf("Failed to rollback migration: %v", err)
+			}
 
-		//
-		// Check that the schema has been dropped
-		//
-		if schemaExists(t, db, roll.VersionedSchemaName(cSchema, version)) {
-			t.Errorf("Expected schema %q to not exist", version)
-		}
+			// Check that the schema has been dropped
+			if schemaExists(t, db, roll.VersionedSchemaName(cSchema, version)) {
+				t.Errorf("Expected schema %q to not exist", version)
+			}
+		})
+	})
+
+	t.Run("when the migration does set an explicit version schema name ", func(t *testing.T) {
+		testutils.WithMigratorAndConnectionToContainer(t, func(mig *roll.Roll, db *sql.DB) {
+			ctx := context.Background()
+
+			if err := mig.Start(ctx, &migrations.Migration{
+				Name:          "1_create_table",
+				VersionSchema: "1_foo",
+				Operations:    migrations.Operations{createTableOp("table1")},
+			}, backfill.NewConfig()); err != nil {
+				t.Fatalf("Failed to start migration: %v", err)
+			}
+			if err := mig.Rollback(ctx); err != nil {
+				t.Fatalf("Failed to rollback migration: %v", err)
+			}
+
+			// Check that the schema has been dropped
+			if schemaExists(t, db, roll.VersionedSchemaName(cSchema, "1_foo")) {
+				t.Errorf("Expected schema %q to not exist", "1_foo")
+			}
+		})
 	})
 }
 

--- a/pkg/state/init.sql
+++ b/pkg/state/init.sql
@@ -61,14 +61,14 @@ $$
 LANGUAGE SQL
 STABLE;
 
--- Get the latest version name (this is the one with child migrations)
+-- Get the latest version schema name
 CREATE OR REPLACE FUNCTION placeholder.latest_version (schemaname name)
     RETURNS text
     SECURITY DEFINER
     SET search_path = placeholder, pg_catalog, pg_temp
     AS $$
     SELECT
-        p.name
+        COALESCE(p.migration ->> 'versionSchema', p.name)
     FROM
         placeholder.migrations p
     WHERE

--- a/pkg/state/init.sql
+++ b/pkg/state/init.sql
@@ -68,7 +68,7 @@ CREATE OR REPLACE FUNCTION placeholder.latest_version (schemaname name)
     SET search_path = placeholder, pg_catalog, pg_temp
     AS $$
     SELECT
-        COALESCE(p.migration ->> 'versionSchema', p.name)
+        COALESCE(p.migration ->> 'version_schema', p.name)
     FROM
         placeholder.migrations p
     WHERE
@@ -120,7 +120,7 @@ CREATE OR REPLACE FUNCTION placeholder.previous_version (schemaname name, includ
     WITH RECURSIVE ancestors AS (
         SELECT
             name,
-            migration ->> 'versionSchema' AS versionSchema,
+            migration ->> 'version_schema' AS versionSchema,
             schema,
             parent,
             migration_type,
@@ -133,7 +133,7 @@ CREATE OR REPLACE FUNCTION placeholder.previous_version (schemaname name, includ
         UNION ALL
         SELECT
             m.name,
-            m.migration ->> 'versionSchema' AS versionSchema,
+            m.migration ->> 'version_schema' AS versionSchema,
             m.schema,
             m.parent,
             m.migration_type,

--- a/pkg/state/init.sql
+++ b/pkg/state/init.sql
@@ -120,6 +120,7 @@ CREATE OR REPLACE FUNCTION placeholder.previous_version (schemaname name, includ
     WITH RECURSIVE ancestors AS (
         SELECT
             name,
+            migration ->> 'versionSchema' AS versionSchema,
             schema,
             parent,
             migration_type,
@@ -132,6 +133,7 @@ CREATE OR REPLACE FUNCTION placeholder.previous_version (schemaname name, includ
         UNION ALL
         SELECT
             m.name,
+            m.migration ->> 'versionSchema' AS versionSchema,
             m.schema,
             m.parent,
             m.migration_type,
@@ -142,7 +144,7 @@ CREATE OR REPLACE FUNCTION placeholder.previous_version (schemaname name, includ
                 AND m.schema = a.schema
 )
         SELECT
-            a.name
+            COALESCE(a.versionSchema, a.name)
         FROM
             ancestors a
     WHERE
@@ -155,7 +157,7 @@ CREATE OR REPLACE FUNCTION placeholder.previous_version (schemaname name, includ
                     FROM
                         information_schema.schemata s
                     WHERE
-                        s.schema_name = schemaname || '_' || a.name)))
+                        s.schema_name = schemaname || '_' || COALESCE(a.versionSchema, a.name))))
     ORDER BY
         a.depth ASC
     LIMIT 1;

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -214,6 +214,19 @@ func (s *State) PreviousVersion(ctx context.Context, schema string, includeInfer
 	return parent, nil
 }
 
+// PreviousMigration returns the name of the previous migration
+func (s *State) PreviousMigration(ctx context.Context, schema string, includeInferred bool) (*string, error) {
+	var parent *string
+	err := s.pgConn.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT %s.previous_migration($1, $2)", pq.QuoteIdentifier(s.schema)),
+		schema, includeInferred).Scan(&parent)
+	if err != nil {
+		return nil, err
+	}
+
+	return parent, nil
+}
+
 // Status returns the current migration status of the specified schema
 func (s *State) Status(ctx context.Context, schema string) (*Status, error) {
 	latestVersion, err := s.LatestVersion(ctx, schema)

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -174,8 +174,7 @@ func (s *State) GetActiveMigration(ctx context.Context, schema string) (*migrati
 }
 
 // LatestVersion returns the name of the latest version schema, or nil if there
-// is none. No active version occurs after initialization, but before the first
-// migration is started.
+// is none.
 func (s *State) LatestVersion(ctx context.Context, schema string) (*string, error) {
 	var version *string
 	err := s.pgConn.QueryRowContext(ctx,
@@ -186,6 +185,20 @@ func (s *State) LatestVersion(ctx context.Context, schema string) (*string, erro
 	}
 
 	return version, nil
+}
+
+// LatestMigration returns the name of the latest migration, or nil if there
+// is none.
+func (s *State) LatestMigration(ctx context.Context, schema string) (*string, error) {
+	var migration *string
+	err := s.pgConn.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT %s.latest_migration($1)", pq.QuoteIdentifier(s.schema)),
+		schema).Scan(&migration)
+	if err != nil {
+		return nil, err
+	}
+
+	return migration, nil
 }
 
 // PreviousVersion returns the name of the previous version schema

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -244,7 +244,7 @@ func (s *State) Start(ctx context.Context, schemaname string, migration *migrati
 
 	// create a new migration object and return the previous known schema
 	// if there is no previous migration, read the schema from postgres
-	stmt := fmt.Sprintf(`INSERT INTO %[1]s.migrations (schema, name, parent, migration) VALUES ($1, $2, %[1]s.latest_version($1), $3)`,
+	stmt := fmt.Sprintf(`INSERT INTO %[1]s.migrations (schema, name, parent, migration) VALUES ($1, $2, %[1]s.latest_migration($1), $3)`,
 		pq.QuoteIdentifier(s.schema))
 
 	_, err = s.pgConn.ExecContext(ctx, stmt, schemaname, migration.Name, rawMigration)
@@ -386,7 +386,7 @@ func (s *State) CreateBaseline(ctx context.Context, schemaName, baselineVersion 
 	stmt := fmt.Sprintf(`
 		INSERT INTO %[1]s.migrations 
 		(schema, name, migration, resulting_schema, done, parent, migration_type, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, TRUE,  %[1]s.latest_version($1), 'baseline', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+		VALUES ($1, $2, $3, $4, TRUE,  %[1]s.latest_migration($1), 'baseline', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
 		pq.QuoteIdentifier(s.schema))
 
 	_, err = s.pgConn.ExecContext(ctx, stmt, schemaName, baselineVersion, rawMigration, rawSchema)


### PR DESCRIPTION
#852 removed support for specifying a migration name via the `name` field in a migration file. While having an unambiguous source of truth for the migration name (the filename) is good, it is still often desirable to decouple the filename from the name of the version schema that the migration will create when applied because filenames:

* can be longer than the limit Postgres imposes on schema names
* can contain characters that are not legal in Postgres schema names
* must be named so that migration files are ordered lexicographically on disk 

This PR adds support for a new `version_schema` field in migration files that allows the migration author to specify the name of the version schema that the migration will create.

## Example

```yaml
# migration files can now specify the version schema 
# name to be created by the migration
version_schema: my_version_schema
operations:
  - create_table:
      name: items
      columns:
        - name: id
          type: serial
          pk: true
        - name: name
          type: varchar(255)
```

Running this migration:

```
$ pgroll start migrations/01_create_table.yaml --complete
```

Creates this version schema:

```
+-----------------------+-------------------+
| Name                  | Owner             |
|-----------------------+-------------------|
...
| public_my_version_schema | postgres       |
+-----------------------+-------------------+
```

Had the `version_schema` field not been specified in the migration file the version schema would have been:

```
+-----------------------+-------------------+
| Name                  | Owner             |
|-----------------------+-------------------|
...
| public_01_create_table | postgres         |
+-----------------------+-------------------+
```

---

This PR is part of a stack:
* https://github.com/xataio/pgroll/pull/884 (this PR)
* https://github.com/xataio/pgroll/pull/886
* https://github.com/xataio/pgroll/pull/887

Part of #882 