### PR TITLE
Add `VersionSchema` field to operation integration tests

### DIFF
--- a/pkg/migrations/op_add_column_test.go
+++ b/pkg/migrations/op_add_column_test.go
@@ -21,7 +21,8 @@ func TestAddColumn(t *testing.T) {
 			name: "add column",
 			migrations: []migrations.Migration{
 				{
-					Name: "01_add_table",
+					Name:          "01_add_table",
+					VersionSchema: "add_table",
 					Operations: migrations.Operations{
 						&migrations.OpCreateTable{
 							Name: "users",
@@ -41,7 +42,8 @@ func TestAddColumn(t *testing.T) {
 					},
 				},
 				{
-					Name: "02_add_column",
+					Name:          "02_add_column",
+					VersionSchema: "add_column",
 					Operations: migrations.Operations{
 						&migrations.OpAddColumn{
 							Table: "users",
@@ -58,25 +60,25 @@ func TestAddColumn(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// old and new views of the table should exist
-				ViewMustExist(t, db, schema, "01_add_table", "users")
-				ViewMustExist(t, db, schema, "02_add_column", "users")
+				ViewMustExist(t, db, schema, "add_table", "users")
+				ViewMustExist(t, db, schema, "add_column", "users")
 
 				// inserting via both the old and the new views works
-				MustInsert(t, db, schema, "01_add_table", "users", map[string]string{
+				MustInsert(t, db, schema, "add_table", "users", map[string]string{
 					"name": "Alice",
 				})
-				MustInsert(t, db, schema, "02_add_column", "users", map[string]string{
+				MustInsert(t, db, schema, "add_column", "users", map[string]string{
 					"name": "Bob",
 					"age":  "21",
 				})
 
 				// selecting from both the old and the new views works
-				resOld := MustSelect(t, db, schema, "01_add_table", "users")
+				resOld := MustSelect(t, db, schema, "add_table", "users")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "name": "Alice"},
 					{"id": 2, "name": "Bob"},
 				}, resOld)
-				resNew := MustSelect(t, db, schema, "02_add_column", "users")
+				resNew := MustSelect(t, db, schema, "add_column", "users")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "name": "Alice", "age": 0},
 					{"id": 2, "name": "Bob", "age": 21},
@@ -92,16 +94,16 @@ func TestAddColumn(t *testing.T) {
 			},
 			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The new view still exists
-				ViewMustExist(t, db, schema, "02_add_column", "users")
+				ViewMustExist(t, db, schema, "add_column", "users")
 
 				// Inserting into the new view still works
-				MustInsert(t, db, schema, "02_add_column", "users", map[string]string{
+				MustInsert(t, db, schema, "add_column", "users", map[string]string{
 					"name": "Carl",
 					"age":  "31",
 				})
 
 				// Selecting from the new view still works
-				res := MustSelect(t, db, schema, "02_add_column", "users")
+				res := MustSelect(t, db, schema, "add_column", "users")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "name": "Alice", "age": 0},
 					{"id": 2, "name": "Bob", "age": 0},

--- a/pkg/migrations/op_create_constraint_test.go
+++ b/pkg/migrations/op_create_constraint_test.go
@@ -21,7 +21,8 @@ func TestCreateConstraint(t *testing.T) {
 			name: "create unique constraint on single column",
 			migrations: []migrations.Migration{
 				{
-					Name: "01_add_table",
+					Name:          "01_add_table",
+					VersionSchema: "add_table",
 					Operations: migrations.Operations{
 						&migrations.OpCreateTable{
 							Name: "users",
@@ -41,7 +42,8 @@ func TestCreateConstraint(t *testing.T) {
 					},
 				},
 				{
-					Name: "02_create_constraint",
+					Name:          "02_create_constraint",
+					VersionSchema: "create_constraint",
 					Operations: migrations.Operations{
 						&migrations.OpCreateConstraint{
 							Name:    "unique_name",
@@ -63,18 +65,18 @@ func TestCreateConstraint(t *testing.T) {
 				IndexMustExist(t, db, schema, "users", "unique_name")
 
 				// Inserting values into the old schema that violate uniqueness should succeed.
-				MustInsert(t, db, schema, "01_add_table", "users", map[string]string{
+				MustInsert(t, db, schema, "add_table", "users", map[string]string{
 					"name": "alice",
 				})
-				MustInsert(t, db, schema, "01_add_table", "users", map[string]string{
+				MustInsert(t, db, schema, "add_table", "users", map[string]string{
 					"name": "alice",
 				})
 
 				// Inserting values into the new schema that violate uniqueness should fail.
-				MustInsert(t, db, schema, "02_create_constraint", "users", map[string]string{
+				MustInsert(t, db, schema, "create_constraint", "users", map[string]string{
 					"name": "bob",
 				})
-				MustNotInsert(t, db, schema, "02_create_constraint", "users", map[string]string{
+				MustNotInsert(t, db, schema, "create_constraint", "users", map[string]string{
 					"name": "bob",
 				}, testutils.UniqueViolationErrorCode)
 			},
@@ -90,10 +92,10 @@ func TestCreateConstraint(t *testing.T) {
 				TableMustBeCleanedUp(t, db, schema, "users", "name")
 
 				// Inserting values into the new schema that violate uniqueness should fail.
-				MustInsert(t, db, schema, "02_create_constraint", "users", map[string]string{
+				MustInsert(t, db, schema, "create_constraint", "users", map[string]string{
 					"name": "carol",
 				})
-				MustNotInsert(t, db, schema, "02_create_constraint", "users", map[string]string{
+				MustNotInsert(t, db, schema, "create_constraint", "users", map[string]string{
 					"name": "carol",
 				}, testutils.UniqueViolationErrorCode)
 			},

--- a/pkg/migrations/op_create_index_test.go
+++ b/pkg/migrations/op_create_index_test.go
@@ -20,7 +20,8 @@ func TestCreateIndex(t *testing.T) {
 			name: "create index",
 			migrations: []migrations.Migration{
 				{
-					Name: "01_add_table",
+					Name:          "01_add_table",
+					VersionSchema: "add_table",
 					Operations: migrations.Operations{
 						&migrations.OpCreateTable{
 							Name: "users",
@@ -40,7 +41,8 @@ func TestCreateIndex(t *testing.T) {
 					},
 				},
 				{
-					Name: "02_create_index",
+					Name:          "02_create_index",
+					VersionSchema: "create_index",
 					Operations: migrations.Operations{
 						&migrations.OpCreateIndex{
 							Name:    "idx_users_name",

--- a/pkg/migrations/op_create_table_test.go
+++ b/pkg/migrations/op_create_table_test.go
@@ -22,7 +22,8 @@ func TestCreateTable(t *testing.T) {
 			name: "create table",
 			migrations: []migrations.Migration{
 				{
-					Name: "01_create_table",
+					Name:          "01_create_table",
+					VersionSchema: "create_table",
 					Operations: migrations.Operations{
 						&migrations.OpCreateTable{
 							Name: "users",
@@ -44,15 +45,15 @@ func TestCreateTable(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The new view exists in the new version schema.
-				ViewMustExist(t, db, schema, "01_create_table", "users")
+				ViewMustExist(t, db, schema, "create_table", "users")
 
 				// Data can be inserted into the new view.
-				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
+				MustInsert(t, db, schema, "create_table", "users", map[string]string{
 					"name": "Alice",
 				})
 
 				// Data can be retrieved from the new view.
-				rows := MustSelect(t, db, schema, "01_create_table", "users")
+				rows := MustSelect(t, db, schema, "create_table", "users")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "name": "Alice"},
 				}, rows)
@@ -63,15 +64,15 @@ func TestCreateTable(t *testing.T) {
 			},
 			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// The view still exists
-				ViewMustExist(t, db, schema, "01_create_table", "users")
+				ViewMustExist(t, db, schema, "create_table", "users")
 
 				// Data can be inserted into the new view.
-				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
+				MustInsert(t, db, schema, "create_table", "users", map[string]string{
 					"name": "Alice",
 				})
 
 				// Data can be retrieved from the new view.
-				rows := MustSelect(t, db, schema, "01_create_table", "users")
+				rows := MustSelect(t, db, schema, "create_table", "users")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "name": "Alice"},
 				}, rows)

--- a/pkg/migrations/op_drop_column_test.go
+++ b/pkg/migrations/op_drop_column_test.go
@@ -20,7 +20,8 @@ func TestDropColumnWithDownSQL(t *testing.T) {
 			name: "drop column",
 			migrations: []migrations.Migration{
 				{
-					Name: "01_add_table",
+					Name:          "01_add_table",
+					VersionSchema: "add_table",
 					Operations: migrations.Operations{
 						&migrations.OpCreateTable{
 							Name: "users",
@@ -45,7 +46,8 @@ func TestDropColumnWithDownSQL(t *testing.T) {
 					},
 				},
 				{
-					Name: "02_drop_column",
+					Name:          "02_drop_column",
+					VersionSchema: "drop_column",
 					Operations: migrations.Operations{
 						&migrations.OpDropColumn{
 							Table:  "users",
@@ -57,19 +59,19 @@ func TestDropColumnWithDownSQL(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The deleted column is not present on the view in the new version schema.
-				versionSchema := roll.VersionedSchemaName(schema, "02_drop_column")
+				versionSchema := roll.VersionedSchemaName(schema, "drop_column")
 				ColumnMustNotExist(t, db, versionSchema, "users", "name")
 
 				// But the column is still present on the underlying table.
 				ColumnMustExist(t, db, schema, "users", "name")
 
 				// Inserting into the view in the new version schema should succeed.
-				MustInsert(t, db, schema, "02_drop_column", "users", map[string]string{
+				MustInsert(t, db, schema, "drop_column", "users", map[string]string{
 					"email": "foo@example.com",
 				})
 
 				// The "down" SQL has populated the removed column ("name")
-				results := MustSelect(t, db, schema, "01_add_table", "users")
+				results := MustSelect(t, db, schema, "add_table", "users")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "name": "FOO@EXAMPLE.COM", "email": "foo@example.com"},
 				}, results)
@@ -96,10 +98,10 @@ func TestDropColumnWithDownSQL(t *testing.T) {
 				TriggerMustNotExist(t, db, schema, "users", triggerName)
 
 				// Inserting into the view in the new version schema should succeed.
-				MustInsert(t, db, schema, "02_drop_column", "users", map[string]string{
+				MustInsert(t, db, schema, "drop_column", "users", map[string]string{
 					"email": "bar@example.com",
 				})
-				results := MustSelect(t, db, schema, "02_drop_column", "users")
+				results := MustSelect(t, db, schema, "drop_column", "users")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "email": "foo@example.com"},
 					{"id": 2, "email": "bar@example.com"},

--- a/pkg/migrations/op_drop_index_test.go
+++ b/pkg/migrations/op_drop_index_test.go
@@ -17,7 +17,8 @@ func TestDropIndex(t *testing.T) {
 			name: "drop index",
 			migrations: []migrations.Migration{
 				{
-					Name: "01_add_table",
+					Name:          "01_add_table",
+					VersionSchema: "add_table",
 					Operations: migrations.Operations{
 						&migrations.OpCreateTable{
 							Name: "users",
@@ -37,7 +38,8 @@ func TestDropIndex(t *testing.T) {
 					},
 				},
 				{
-					Name: "02_create_index",
+					Name:          "02_create_index",
+					VersionSchema: "create_index",
 					Operations: migrations.Operations{
 						&migrations.OpCreateIndex{
 							Name:    "idx_users_name",
@@ -47,7 +49,8 @@ func TestDropIndex(t *testing.T) {
 					},
 				},
 				{
-					Name: "03_drop_index",
+					Name:          "03_drop_index",
+					VersionSchema: "drop_index",
 					Operations: migrations.Operations{
 						&migrations.OpDropIndex{
 							Name: "idx_users_name",

--- a/pkg/migrations/op_drop_table_test.go
+++ b/pkg/migrations/op_drop_table_test.go
@@ -18,7 +18,8 @@ func TestDropTable(t *testing.T) {
 			name: "drop table",
 			migrations: []migrations.Migration{
 				{
-					Name: "01_create_table",
+					Name:          "01_create_table",
+					VersionSchema: "create_table",
 					Operations: migrations.Operations{
 						&migrations.OpCreateTable{
 							Name: "users",
@@ -38,7 +39,8 @@ func TestDropTable(t *testing.T) {
 					},
 				},
 				{
-					Name: "02_drop_table",
+					Name:          "02_drop_table",
+					VersionSchema: "drop_table",
 					Operations: migrations.Operations{
 						&migrations.OpDropTable{
 							Name: "users",
@@ -48,7 +50,7 @@ func TestDropTable(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// The view for the deleted table does not exist in the new version schema.
-				ViewMustNotExist(t, db, schema, "02_drop_table", "users")
+				ViewMustNotExist(t, db, schema, "drop_table", "users")
 
 				// The underlying table has been soft-deleted (renamed).
 				TableMustExist(t, db, schema, migrations.DeletionName("users"))

--- a/pkg/migrations/op_raw_sql_test.go
+++ b/pkg/migrations/op_raw_sql_test.go
@@ -17,7 +17,8 @@ func TestRawSQL(t *testing.T) {
 			name: "raw SQL",
 			migrations: []migrations.Migration{
 				{
-					Name: "01_create_table",
+					Name:          "01_create_table",
+					VersionSchema: "create_table",
 					Operations: migrations.Operations{
 						&migrations.OpRawSQL{
 							Up: `
@@ -35,10 +36,10 @@ func TestRawSQL(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// table can be accessed after start
-				ViewMustExist(t, db, schema, "01_create_table", "test_table")
+				ViewMustExist(t, db, schema, "create_table", "test_table")
 
 				// inserts work
-				MustInsert(t, db, schema, "01_create_table", "test_table", map[string]string{
+				MustInsert(t, db, schema, "create_table", "test_table", map[string]string{
 					"name": "foo",
 				})
 			},
@@ -48,7 +49,7 @@ func TestRawSQL(t *testing.T) {
 			},
 			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// inserts still work after complete
-				MustInsert(t, db, schema, "01_create_table", "test_table", map[string]string{
+				MustInsert(t, db, schema, "create_table", "test_table", map[string]string{
 					"name": "foo",
 				})
 			},

--- a/pkg/migrations/op_rename_column_test.go
+++ b/pkg/migrations/op_rename_column_test.go
@@ -19,7 +19,8 @@ func TestOpRenameColumn(t *testing.T) {
 			name: "rename column",
 			migrations: []migrations.Migration{
 				{
-					Name: "01_create_table",
+					Name:          "01_create_table",
+					VersionSchema: "create_table",
 					Operations: migrations.Operations{
 						&migrations.OpCreateTable{
 							Name: "users",
@@ -39,7 +40,8 @@ func TestOpRenameColumn(t *testing.T) {
 					},
 				},
 				{
-					Name: "02_rename_column",
+					Name:          "02_rename_column",
+					VersionSchema: "rename_column",
 					Operations: migrations.Operations{
 						&migrations.OpRenameColumn{
 							Table: "users",
@@ -54,17 +56,17 @@ func TestOpRenameColumn(t *testing.T) {
 				ColumnMustExist(t, db, schema, "users", "username")
 
 				// Insertions to the new column name in the new version schema should work.
-				MustInsert(t, db, schema, "02_rename_column", "users", map[string]string{
+				MustInsert(t, db, schema, "rename_column", "users", map[string]string{
 					"name": "alice",
 				})
 
 				// Insertions to the old column name in the old version schema should work.
-				MustInsert(t, db, schema, "01_create_table", "users", map[string]string{
+				MustInsert(t, db, schema, "create_table", "users", map[string]string{
 					"username": "bob",
 				})
 
 				// Data can be read from the view in the new version schema.
-				rows := MustSelect(t, db, schema, "02_rename_column", "users")
+				rows := MustSelect(t, db, schema, "rename_column", "users")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "name": "alice"},
 					{"id": 2, "name": "bob"},
@@ -78,7 +80,7 @@ func TestOpRenameColumn(t *testing.T) {
 				ColumnMustExist(t, db, schema, "users", "name")
 
 				// Data can be read from the view in the new version schema.
-				rows := MustSelect(t, db, schema, "02_rename_column", "users")
+				rows := MustSelect(t, db, schema, "rename_column", "users")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "name": "alice"},
 					{"id": 2, "name": "bob"},

--- a/pkg/migrations/op_rename_constraint_test.go
+++ b/pkg/migrations/op_rename_constraint_test.go
@@ -15,7 +15,8 @@ func TestRenameConstraint(t *testing.T) {
 	t.Parallel()
 
 	addTableMigration := migrations.Migration{
-		Name: "01_add_table",
+		Name:          "01_add_table",
+		VersionSchema: "add_table",
 		Operations: migrations.Operations{
 			&migrations.OpCreateTable{
 				Name: "users",
@@ -41,7 +42,8 @@ func TestRenameConstraint(t *testing.T) {
 		migrations: []migrations.Migration{
 			addTableMigration,
 			{
-				Name: "02_rename_constraint",
+				Name:          "02_rename_constraint",
+				VersionSchema: "rename_constraint",
 				Operations: migrations.Operations{
 					&migrations.OpRenameConstraint{
 						Table: "users",
@@ -59,7 +61,7 @@ func TestRenameConstraint(t *testing.T) {
 			CheckConstraintMustNotExist(t, db, schema, "users", "users_check_username_length")
 
 			// Inserting a row that violates the check constraint should fail.
-			MustNotInsert(t, db, schema, "02_rename_constraint", "users", map[string]string{
+			MustNotInsert(t, db, schema, "rename_constraint", "users", map[string]string{
 				"username": "a",
 			}, testutils.CheckViolationErrorCode)
 		},
@@ -75,7 +77,7 @@ func TestRenameConstraint(t *testing.T) {
 			CheckConstraintMustNotExist(t, db, schema, "users", "users_check")
 
 			// Inserting a row that violates the check constraint should fail.
-			MustNotInsert(t, db, schema, "02_rename_constraint", "users", map[string]string{
+			MustNotInsert(t, db, schema, "rename_constraint", "users", map[string]string{
 				"username": "a",
 			}, testutils.CheckViolationErrorCode)
 		},

--- a/pkg/migrations/op_rename_table_test.go
+++ b/pkg/migrations/op_rename_table_test.go
@@ -21,7 +21,8 @@ func TestRenameTable(t *testing.T) {
 			name: "rename table",
 			migrations: []migrations.Migration{
 				{
-					Name: "01_create_table",
+					Name:          "01_create_table",
+					VersionSchema: "create_table",
 					Operations: migrations.Operations{
 						&migrations.OpCreateTable{
 							Name: "test_table",
@@ -39,7 +40,8 @@ func TestRenameTable(t *testing.T) {
 					},
 				},
 				{
-					Name: "02_rename_table",
+					Name:          "02_rename_table",
+					VersionSchema: "rename_table",
 					Operations: migrations.Operations{
 						&migrations.OpRenameTable{
 							From: "test_table",
@@ -50,20 +52,20 @@ func TestRenameTable(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// check that the table with the new name can be accessed
-				ViewMustExist(t, db, schema, "01_create_table", "test_table")
-				ViewMustExist(t, db, schema, "02_rename_table", "renamed_table")
+				ViewMustExist(t, db, schema, "create_table", "test_table")
+				ViewMustExist(t, db, schema, "rename_table", "renamed_table")
 
 				// inserts work
-				MustInsert(t, db, schema, "01_create_table", "test_table", map[string]string{
+				MustInsert(t, db, schema, "create_table", "test_table", map[string]string{
 					"name": "foo",
 				})
-				MustInsert(t, db, schema, "02_rename_table", "renamed_table", map[string]string{
+				MustInsert(t, db, schema, "rename_table", "renamed_table", map[string]string{
 					"name": "bar",
 				})
 
 				// selects work in both versions
-				resNew := MustSelect(t, db, schema, "01_create_table", "test_table")
-				resOld := MustSelect(t, db, schema, "02_rename_table", "renamed_table")
+				resNew := MustSelect(t, db, schema, "create_table", "test_table")
+				resOld := MustSelect(t, db, schema, "rename_table", "renamed_table")
 
 				assert.Equal(t, resOld, resNew)
 				assert.Equal(t, []map[string]any{
@@ -79,14 +81,14 @@ func TestRenameTable(t *testing.T) {
 			},
 			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
 				// the table still exists with the new name
-				ViewMustNotExist(t, db, schema, "02_rename_table", "testTable")
-				ViewMustExist(t, db, schema, "02_rename_table", "renamed_table")
+				ViewMustNotExist(t, db, schema, "rename_table", "testTable")
+				ViewMustExist(t, db, schema, "rename_table", "renamed_table")
 
 				// inserts & select work
-				MustInsert(t, db, schema, "02_rename_table", "renamed_table", map[string]string{
+				MustInsert(t, db, schema, "rename_table", "renamed_table", map[string]string{
 					"name": "baz",
 				})
-				res := MustSelect(t, db, schema, "02_rename_table", "renamed_table")
+				res := MustSelect(t, db, schema, "rename_table", "renamed_table")
 				assert.Equal(t, []map[string]any{
 					{
 						"id":   1,

--- a/pkg/migrations/op_set_comment_test.go
+++ b/pkg/migrations/op_set_comment_test.go
@@ -20,7 +20,8 @@ func TestSetComment(t *testing.T) {
 			name: "set column comment with default up and down SQL",
 			migrations: []migrations.Migration{
 				{
-					Name: "01_add_table",
+					Name:          "01_add_table",
+					VersionSchema: "add_table",
 					Operations: migrations.Operations{
 						&migrations.OpCreateTable{
 							Name: "users",
@@ -40,7 +41,8 @@ func TestSetComment(t *testing.T) {
 					},
 				},
 				{
-					Name: "02_set_comment",
+					Name:          "02_set_comment",
+					VersionSchema: "set_comment",
 					Operations: migrations.Operations{
 						&migrations.OpAlterColumn{
 							Table:   "users",
@@ -52,12 +54,12 @@ func TestSetComment(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// Inserting a row into the new schema succeeds
-				MustInsert(t, db, schema, "02_set_comment", "users", map[string]string{
+				MustInsert(t, db, schema, "set_comment", "users", map[string]string{
 					"name": "alice",
 				})
 
 				// Inserting a row into the old schema succeeds
-				MustInsert(t, db, schema, "01_add_table", "users", map[string]string{
+				MustInsert(t, db, schema, "add_table", "users", map[string]string{
 					"name": "bob",
 				})
 
@@ -68,14 +70,14 @@ func TestSetComment(t *testing.T) {
 				ColumnMustHaveComment(t, db, schema, "users", migrations.TemporaryName("name"), "name of the user")
 
 				// The old schema view has the expected rows
-				rows := MustSelect(t, db, schema, "01_add_table", "users")
+				rows := MustSelect(t, db, schema, "add_table", "users")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "name": "alice"},
 					{"id": 2, "name": "bob"},
 				}, rows)
 
 				// The new schema view has the expected rows
-				rows = MustSelect(t, db, schema, "02_set_comment", "users")
+				rows = MustSelect(t, db, schema, "set_comment", "users")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "name": "alice"},
 					{"id": 2, "name": "bob"},
@@ -90,7 +92,7 @@ func TestSetComment(t *testing.T) {
 				ColumnMustHaveComment(t, db, schema, "users", "name", "name of the user")
 
 				// The new schema view has the expected rows
-				rows := MustSelect(t, db, schema, "02_set_comment", "users")
+				rows := MustSelect(t, db, schema, "set_comment", "users")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "name": "alice"},
 					{"id": 2, "name": "bob"},

--- a/pkg/migrations/op_set_fk_test.go
+++ b/pkg/migrations/op_set_fk_test.go
@@ -20,7 +20,8 @@ func TestSetForeignKey(t *testing.T) {
 			name: "add foreign key constraint",
 			migrations: []migrations.Migration{
 				{
-					Name: "01_add_tables",
+					Name:          "01_add_tables",
+					VersionSchema: "add_tables",
 					Operations: migrations.Operations{
 						&migrations.OpCreateTable{
 							Name: "users",
@@ -58,7 +59,8 @@ func TestSetForeignKey(t *testing.T) {
 					},
 				},
 				{
-					Name: "02_add_fk_constraint",
+					Name:          "02_add_fk_constraint",
+					VersionSchema: "add_fk_constraint",
 					Operations: migrations.Operations{
 						&migrations.OpAlterColumn{
 							Table:  "posts",
@@ -82,46 +84,46 @@ func TestSetForeignKey(t *testing.T) {
 				NotValidatedForeignKeyMustExist(t, db, schema, "posts", "fk_users_id")
 
 				// Inserting some data into the `users` table works.
-				MustInsert(t, db, schema, "02_add_fk_constraint", "users", map[string]string{
+				MustInsert(t, db, schema, "add_fk_constraint", "users", map[string]string{
 					"name": "alice",
 				})
-				MustInsert(t, db, schema, "02_add_fk_constraint", "users", map[string]string{
+				MustInsert(t, db, schema, "add_fk_constraint", "users", map[string]string{
 					"name": "bob",
 				})
 
 				// Inserting data into the new `posts` view with a valid user reference works.
-				MustInsert(t, db, schema, "02_add_fk_constraint", "posts", map[string]string{
+				MustInsert(t, db, schema, "add_fk_constraint", "posts", map[string]string{
 					"title":   "post by alice",
 					"user_id": "1",
 				})
 
 				// Inserting data into the new `posts` view with an invalid user reference fails.
-				MustNotInsert(t, db, schema, "02_add_fk_constraint", "posts", map[string]string{
+				MustNotInsert(t, db, schema, "add_fk_constraint", "posts", map[string]string{
 					"title":   "post by unknown user",
 					"user_id": "3",
 				}, testutils.FKViolationErrorCode)
 
 				// The post that was inserted successfully has been backfilled into the old view.
-				rows := MustSelect(t, db, schema, "01_add_tables", "posts")
+				rows := MustSelect(t, db, schema, "add_tables", "posts")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "title": "post by alice", "user_id": 1},
 				}, rows)
 
 				// Inserting data into the old `posts` view with a valid user reference works.
-				MustInsert(t, db, schema, "01_add_tables", "posts", map[string]string{
+				MustInsert(t, db, schema, "add_tables", "posts", map[string]string{
 					"title":   "post by bob",
 					"user_id": "2",
 				})
 
 				// Inserting data into the old `posts` view with an invalid user reference also works.
-				MustInsert(t, db, schema, "01_add_tables", "posts", map[string]string{
+				MustInsert(t, db, schema, "add_tables", "posts", map[string]string{
 					"title":   "post by unknown user",
 					"user_id": "3",
 				})
 
 				// The post that was inserted successfully has been backfilled into the new view.
 				// The post by an unknown user has been backfilled with a NULL user_id.
-				rows = MustSelect(t, db, schema, "02_add_fk_constraint", "posts")
+				rows = MustSelect(t, db, schema, "add_fk_constraint", "posts")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "title": "post by alice", "user_id": 1},
 					{"id": 3, "title": "post by bob", "user_id": 2},
@@ -140,19 +142,19 @@ func TestSetForeignKey(t *testing.T) {
 				ValidatedForeignKeyMustExist(t, db, schema, "posts", "fk_users_id")
 
 				// Inserting data into the new `posts` view with a valid user reference works.
-				MustInsert(t, db, schema, "02_add_fk_constraint", "posts", map[string]string{
+				MustInsert(t, db, schema, "add_fk_constraint", "posts", map[string]string{
 					"title":   "another post by alice",
 					"user_id": "1",
 				})
 
 				// Inserting data into the new `posts` view with an invalid user reference fails.
-				MustNotInsert(t, db, schema, "02_add_fk_constraint", "posts", map[string]string{
+				MustNotInsert(t, db, schema, "add_fk_constraint", "posts", map[string]string{
 					"title":   "post by unknown user",
 					"user_id": "3",
 				}, testutils.FKViolationErrorCode)
 
 				// The data in the new `posts` view is as expected.
-				rows := MustSelect(t, db, schema, "02_add_fk_constraint", "posts")
+				rows := MustSelect(t, db, schema, "add_fk_constraint", "posts")
 				assert.Equal(t, []map[string]any{
 					{"id": 1, "title": "post by alice", "user_id": 1},
 					{"id": 3, "title": "post by bob", "user_id": 2},

--- a/pkg/migrations/op_set_unique_test.go
+++ b/pkg/migrations/op_set_unique_test.go
@@ -20,7 +20,8 @@ func TestSetColumnUnique(t *testing.T) {
 			name: "set unique with default down sql",
 			migrations: []migrations.Migration{
 				{
-					Name: "01_add_table",
+					Name:          "01_add_table",
+					VersionSchema: "add_table",
 					Operations: migrations.Operations{
 						&migrations.OpCreateTable{
 							Name: "reviews",
@@ -50,7 +51,8 @@ func TestSetColumnUnique(t *testing.T) {
 					},
 				},
 				{
-					Name: "02_set_unique",
+					Name:          "02_set_unique",
+					VersionSchema: "set_unique",
 					Operations: migrations.Operations{
 						&migrations.OpAlterColumn{
 							Table:  "reviews",
@@ -65,18 +67,18 @@ func TestSetColumnUnique(t *testing.T) {
 			},
 			afterStart: func(t *testing.T, db *sql.DB, schema string) {
 				// Inserting values into the old schema that violate uniqueness should succeed.
-				MustInsert(t, db, schema, "01_add_table", "reviews", map[string]string{
+				MustInsert(t, db, schema, "add_table", "reviews", map[string]string{
 					"username": "alice", "product": "apple", "review": "good",
 				})
-				MustInsert(t, db, schema, "01_add_table", "reviews", map[string]string{
+				MustInsert(t, db, schema, "add_table", "reviews", map[string]string{
 					"username": "bob", "product": "banana", "review": "good",
 				})
 
 				// Inserting values into the new schema that violate uniqueness should fail.
-				MustInsert(t, db, schema, "02_set_unique", "reviews", map[string]string{
+				MustInsert(t, db, schema, "set_unique", "reviews", map[string]string{
 					"username": "carl", "product": "carrot", "review": "bad",
 				})
-				MustNotInsert(t, db, schema, "02_set_unique", "reviews", map[string]string{
+				MustNotInsert(t, db, schema, "set_unique", "reviews", map[string]string{
 					"username": "dana", "product": "durian", "review": "bad",
 				}, testutils.UniqueViolationErrorCode)
 			},
@@ -89,10 +91,10 @@ func TestSetColumnUnique(t *testing.T) {
 				TableMustBeCleanedUp(t, db, schema, "reviews", "review")
 
 				// Inserting values into the new schema that violate uniqueness should fail.
-				MustInsert(t, db, schema, "02_set_unique", "reviews", map[string]string{
+				MustInsert(t, db, schema, "set_unique", "reviews", map[string]string{
 					"username": "earl", "product": "elderberry", "review": "ok",
 				})
-				MustNotInsert(t, db, schema, "02_set_unique", "reviews", map[string]string{
+				MustNotInsert(t, db, schema, "set_unique", "reviews", map[string]string{
 					"username": "flora", "product": "fig", "review": "ok",
 				}, testutils.UniqueViolationErrorCode)
 			},


### PR DESCRIPTION
Ensure that at least one test for every operation type sets a `VersionSchema` for the the migration.

This PR adds a `VersionSchema` field to one test for every operation type.

--- 

This PR is part of a stack:
* https://github.com/xataio/pgroll/pull/884
* https://github.com/xataio/pgroll/pull/886 (this PR)
* https://github.com/xataio/pgroll/pull/887