### PR TITLE
Ignore all DDL executed by `pgroll`

### DIFF
--- a/pkg/roll/roll.go
+++ b/pkg/roll/roll.go
@@ -105,6 +105,11 @@ func setupConn(ctx context.Context, pgURL, schema string, options options) (*sql
 		return nil, err
 	}
 
+	_, err = conn.ExecContext(ctx, "SET pgroll.internal TO 'TRUE'")
+	if err != nil {
+		return nil, fmt.Errorf("unable to set pgroll.internal to true: %w", err)
+	}
+
 	if options.lockTimeoutMs > 0 {
 		_, err = conn.ExecContext(ctx, fmt.Sprintf("SET lock_timeout to '%dms'", options.lockTimeoutMs))
 		if err != nil {

--- a/pkg/state/init.sql
+++ b/pkg/state/init.sql
@@ -331,6 +331,10 @@ DECLARE
     schemaname text;
     migration_id text;
 BEGIN
+    -- Ignore schema changes made by pgroll
+    IF (pg_catalog.current_setting('pgroll.internal', TRUE) = 'TRUE') THEN
+        RETURN;
+    END IF;
     IF tg_event = 'sql_drop' AND tg_tag = 'DROP SCHEMA' THEN
         -- Take the schema name from the drop schema command
         SELECT

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -47,6 +47,11 @@ func New(ctx context.Context, pgURL, stateSchema string, opts ...StateOpt) (*Sta
 		return nil, err
 	}
 
+	_, err = conn.ExecContext(ctx, "SET pgroll.internal TO 'TRUE'")
+	if err != nil {
+		return nil, fmt.Errorf("unable to set pgroll.internal to true: %w", err)
+	}
+
 	st := &State{
 		pgConn:        conn,
 		pgrollVersion: "development",


### PR DESCRIPTION
Set a session-level setting `pgroll.internal` to `TRUE` on connections used by `pgroll` (`pgroll` uses two connections, one to execute migrations and one for its internal state).

Use the `pgroll.internal` setting to prevent schema changes made by `pgroll` itself being captured by the `raw_migration()` event trigger function.

DDL changes made in schema `s` are already ignored by `raw_migration()` if there is an active migration period in progress for schema `s`. The change in this commit ensures that *all* DDL changes in *all* schema at *all* times made by `pgroll` are ignored by `raw_migration()`, including version schema creation and the creation of views within those schema.

This reverts PR https://github.com/xataio/pgroll/pull/823 which removed a `pgroll.internal` setting that was set using `SET LOCAL` outside a transaction block. That PR assumed that setting `pgroll.internal` with `SET LOCAL` outside a transaction had no effect, but it did have an effect (the setting was set to an empty string, which was sufficient given how it was used in`raw_migration()`). This PR uses the same setting but sets it with `SET` (instead of `SET LOCAL`) to make it more obvious what is happening.

Add a test to verify that version schema creation does not create inferred migrations.