### PR TITLE
Return `DBActions` from `Complete`

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -25,7 +25,7 @@ type Operation interface {
 	// Complete will update the database schema to match the current version
 	// after calling Start.
 	// This method should be called once the previous version is no longer used.
-	Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error
+	Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error)
 
 	// Rollback will revert the changes made by Start. It is not possible to
 	// rollback a completed migration.

--- a/pkg/migrations/op_change_type.go
+++ b/pkg/migrations/op_change_type.go
@@ -31,10 +31,10 @@ func (o *OpChangeType) Start(ctx context.Context, l Logger, conn db.DB, latestSc
 	return backfill.NewTask(table), nil
 }
 
-func (o *OpChangeType) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+func (o *OpChangeType) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {
 	l.LogOperationComplete(o)
 
-	return nil
+	return []DBAction{}, nil
 }
 
 func (o *OpChangeType) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_create_index.go
+++ b/pkg/migrations/op_create_index.go
@@ -79,11 +79,11 @@ func (o *OpCreateIndex) Start(ctx context.Context, l Logger, conn db.DB, latestS
 	return nil, err
 }
 
-func (o *OpCreateIndex) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+func (o *OpCreateIndex) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {
 	l.LogOperationComplete(o)
 
 	// No-op
-	return nil
+	return []DBAction{}, nil
 }
 
 func (o *OpCreateIndex) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -61,11 +61,11 @@ func (o *OpCreateTable) Start(ctx context.Context, l Logger, conn db.DB, latestS
 	return nil, nil
 }
 
-func (o *OpCreateTable) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+func (o *OpCreateTable) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {
 	l.LogOperationComplete(o)
 
 	// No-op
-	return nil
+	return []DBAction{}, nil
 }
 
 func (o *OpCreateTable) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_drop_index.go
+++ b/pkg/migrations/op_drop_index.go
@@ -22,10 +22,12 @@ func (o *OpDropIndex) Start(ctx context.Context, l Logger, conn db.DB, latestSch
 	return nil, nil
 }
 
-func (o *OpDropIndex) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+func (o *OpDropIndex) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {
 	l.LogOperationComplete(o)
 
-	return NewDropIndexAction(conn, o.Name).Execute(ctx)
+	return []DBAction{
+		NewDropIndexAction(conn, o.Name),
+	}, nil
 }
 
 func (o *OpDropIndex) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_drop_not_null.go
+++ b/pkg/migrations/op_drop_not_null.go
@@ -31,9 +31,9 @@ func (o *OpDropNotNull) Start(ctx context.Context, l Logger, conn db.DB, latestS
 	return backfill.NewTask(table), nil
 }
 
-func (o *OpDropNotNull) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+func (o *OpDropNotNull) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {
 	l.LogOperationComplete(o)
-	return nil
+	return []DBAction{}, nil
 }
 
 func (o *OpDropNotNull) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_drop_table.go
+++ b/pkg/migrations/op_drop_table.go
@@ -35,13 +35,13 @@ func (o *OpDropTable) Start(ctx context.Context, l Logger, conn db.DB, latestSch
 	return nil, nil
 }
 
-func (o *OpDropTable) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+func (o *OpDropTable) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {
 	l.LogOperationComplete(o)
 
-	deletionName := DeletionName(o.Name)
-
-	// Perform the actual deletion of the soft-deleted table
-	return NewDropTableAction(conn, deletionName).Execute(ctx)
+	return []DBAction{
+		// Perform the actual deletion of the soft-deleted table
+		NewDropTableAction(conn, DeletionName(o.Name)),
+	}, nil
 }
 
 func (o *OpDropTable) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_raw_sql.go
+++ b/pkg/migrations/op_raw_sql.go
@@ -25,14 +25,14 @@ func (o *OpRawSQL) Start(ctx context.Context, l Logger, conn db.DB, latestSchema
 	return nil, NewRawSQLAction(conn, o.Up).Execute(ctx)
 }
 
-func (o *OpRawSQL) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+func (o *OpRawSQL) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {
 	l.LogOperationComplete(o)
 
 	if !o.OnComplete {
-		return nil
+		return []DBAction{}, nil
 	}
 
-	return NewRawSQLAction(conn, o.Up).Execute(ctx)
+	return []DBAction{NewRawSQLAction(conn, o.Up)}, nil
 }
 
 func (o *OpRawSQL) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_rename_column.go
+++ b/pkg/migrations/op_rename_column.go
@@ -33,9 +33,12 @@ func (o *OpRenameColumn) Start(ctx context.Context, l Logger, conn db.DB, latest
 	return nil, nil
 }
 
-func (o *OpRenameColumn) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+func (o *OpRenameColumn) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {
 	l.LogOperationComplete(o)
-	return NewRenameColumnAction(conn, o.Table, o.From, o.To).Execute(ctx)
+
+	return []DBAction{
+		NewRenameColumnAction(conn, o.Table, o.From, o.To),
+	}, nil
 }
 
 func (o *OpRenameColumn) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_rename_constraint.go
+++ b/pkg/migrations/op_rename_constraint.go
@@ -19,11 +19,13 @@ func (o *OpRenameConstraint) Start(ctx context.Context, l Logger, conn db.DB, la
 	return nil, nil
 }
 
-func (o *OpRenameConstraint) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+func (o *OpRenameConstraint) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {
 	l.LogOperationComplete(o)
 
-	// rename the constraint in the underlying table
-	return NewRenameConstraintAction(conn, o.Table, o.From, o.To).Execute(ctx)
+	return []DBAction{
+		// rename the constraint in the underlying table
+		NewRenameConstraintAction(conn, o.Table, o.From, o.To),
+	}, nil
 }
 
 func (o *OpRenameConstraint) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_rename_table.go
+++ b/pkg/migrations/op_rename_table.go
@@ -18,10 +18,10 @@ func (o *OpRenameTable) Start(ctx context.Context, l Logger, conn db.DB, latestS
 	return nil, s.RenameTable(o.From, o.To)
 }
 
-func (o *OpRenameTable) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+func (o *OpRenameTable) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {
 	l.LogOperationComplete(o)
 
-	return NewRenameTableAction(conn, o.From, o.To).Execute(ctx)
+	return []DBAction{NewRenameTableAction(conn, o.From, o.To)}, nil
 }
 
 func (o *OpRenameTable) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_set_check.go
+++ b/pkg/migrations/op_set_check.go
@@ -37,16 +37,13 @@ func (o *OpSetCheckConstraint) Start(ctx context.Context, l Logger, conn db.DB, 
 	return backfill.NewTask(table), nil
 }
 
-func (o *OpSetCheckConstraint) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+func (o *OpSetCheckConstraint) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {
 	l.LogOperationComplete(o)
 
-	// Validate the check constraint
-	err := NewValidateConstraintAction(conn, o.Table, o.Check.Name).Execute(ctx)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return []DBAction{
+		// Validate the check constraint
+		NewValidateConstraintAction(conn, o.Table, o.Check.Name),
+	}, nil
 }
 
 func (o *OpSetCheckConstraint) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_set_comment.go
+++ b/pkg/migrations/op_set_comment.go
@@ -32,10 +32,12 @@ func (o *OpSetComment) Start(ctx context.Context, l Logger, conn db.DB, latestSc
 	return backfill.NewTask(tbl), NewCommentColumnAction(conn, o.Table, TemporaryName(o.Column), o.Comment).Execute(ctx)
 }
 
-func (o *OpSetComment) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+func (o *OpSetComment) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {
 	l.LogOperationComplete(o)
 
-	return NewCommentColumnAction(conn, o.Table, o.Column, o.Comment).Execute(ctx)
+	return []DBAction{
+		NewCommentColumnAction(conn, o.Table, o.Column, o.Comment),
+	}, nil
 }
 
 func (o *OpSetComment) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_set_default.go
+++ b/pkg/migrations/op_set_default.go
@@ -47,10 +47,10 @@ func (o *OpSetDefault) Start(ctx context.Context, l Logger, conn db.DB, latestSc
 	return backfill.NewTask(table), nil
 }
 
-func (o *OpSetDefault) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+func (o *OpSetDefault) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {
 	l.LogOperationComplete(o)
 
-	return nil
+	return []DBAction{}, nil
 }
 
 func (o *OpSetDefault) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_set_fk.go
+++ b/pkg/migrations/op_set_fk.go
@@ -64,16 +64,13 @@ func (o *OpSetForeignKey) Start(ctx context.Context, l Logger, conn db.DB, lates
 	return backfill.NewTask(table), nil
 }
 
-func (o *OpSetForeignKey) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+func (o *OpSetForeignKey) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {
 	l.LogOperationComplete(o)
 
-	// Validate the foreign key constraint
-	err := NewValidateConstraintAction(conn, o.Table, o.References.Name).Execute(ctx)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return []DBAction{
+		// Validate the foreign key constraint
+		NewValidateConstraintAction(conn, o.Table, o.References.Name),
+	}, nil
 }
 
 func (o *OpSetForeignKey) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_set_replica_identity.go
+++ b/pkg/migrations/op_set_replica_identity.go
@@ -33,11 +33,11 @@ func (o *OpSetReplicaIdentity) Start(ctx context.Context, l Logger, conn db.DB, 
 	return nil, err
 }
 
-func (o *OpSetReplicaIdentity) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+func (o *OpSetReplicaIdentity) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {
 	l.LogOperationComplete(o)
 
 	// No-op
-	return nil
+	return []DBAction{}, nil
 }
 
 func (o *OpSetReplicaIdentity) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_set_unique.go
+++ b/pkg/migrations/op_set_unique.go
@@ -35,11 +35,11 @@ func (o *OpSetUnique) Start(ctx context.Context, l Logger, conn db.DB, latestSch
 	return backfill.NewTask(table), NewCreateUniqueIndexConcurrentlyAction(conn, s.Name, o.Name, table.Name, column.Name).Execute(ctx)
 }
 
-func (o *OpSetUnique) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {
+func (o *OpSetUnique) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {
 	l.LogOperationComplete(o)
 
 	// Create a unique constraint using the unique index
-	return NewAddConstraintUsingUniqueIndex(conn, o.Table, o.Name, o.Name).Execute(ctx)
+	return []DBAction{NewAddConstraintUsingUniqueIndex(conn, o.Table, o.Name, o.Name)}, nil
 }
 
 func (o *OpSetUnique) Rollback(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {


### PR DESCRIPTION
This PR changes the signature of `Complete`. From now on, it returns a list of `DBActions`.

I am transforming `Rollback` and `Start` calls in upcoming PRs. Once all the migration phases are refactored, I am adding coordination between the operations to eliminate unnecessary steps and invalid actions sequences (like trying to rename a duplicated column multiple times).