### PR TITLE
Remove `State.LastSchema` method

### DIFF
--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -19,7 +19,7 @@ func (m *Roll) Validate(ctx context.Context, migration *migrations.Migration) er
 	if m.skipValidation {
 		return nil
 	}
-	lastSchema, err := m.state.LastSchema(ctx, m.schema)
+	lastSchema, err := m.state.ReadSchema(ctx, m.schema)
 	if err != nil {
 		return err
 	}

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -38,7 +38,7 @@ func TestSchemaOptionIsRespected(t *testing.T) {
 		}
 
 		// check that we can retrieve the already existing table
-		currentSchema, err := state.LastSchema(ctx, "public")
+		currentSchema, err := state.ReadSchema(ctx, "public")
 		assert.NoError(t, err)
 
 		assert.Equal(t, 1, len(currentSchema.Tables))


### PR DESCRIPTION
Remove the `State.LastSchema` method and replace its usages with `state.ReadSchema` instead.

For validating migrations, we always want to validate against the current state of the db schema.