### PR TITLE
Remove redundant check from `MissingMigrations` method

### DIFF
--- a/pkg/roll/missing.go
+++ b/pkg/roll/missing.go
@@ -14,17 +14,6 @@ import (
 // the target database but are missing from the local migrations directory
 // `dir`.
 func (m *Roll) MissingMigrations(ctx context.Context, dir fs.FS) ([]*migrations.RawMigration, error) {
-	// Determine the latest version of the database
-	latestVersion, err := m.State().LatestVersion(ctx, m.Schema())
-	if err != nil {
-		return nil, fmt.Errorf("determining latest version: %w", err)
-	}
-
-	// If no migrations are applied, return a nil slice
-	if latestVersion == nil {
-		return nil, nil
-	}
-
 	// Collect all migration files from the directory
 	files, err := migrations.CollectFilesFromDir(dir)
 	if err != nil {


### PR DESCRIPTION
There is no need for this check, as the method will anyway return an empty slice if the schema history is empty.

There is a test for this case here:

https://github.com/xataio/pgroll/blob/68fc1f6c93a0879d62fbd43caa7818faa3ad44d4/pkg/roll/missing_test.go?plain=1#L169-L185

Related to #872 