### PR TITLE
Make `pgroll latest schema` ignore migrations for which no version schema exists

### DIFF
--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -175,7 +175,7 @@ func (m *Roll) Complete(ctx context.Context) error {
 
 	// Drop the old schema
 	if !m.disableVersionSchemas {
-		prevVersion, err := m.state.PreviousVersion(ctx, m.schema, false)
+		prevVersion, err := m.state.PreviousVersion(ctx, m.schema)
 		if err != nil {
 			return fmt.Errorf("unable to get name of previous version: %w", err)
 		}

--- a/pkg/state/latest.go
+++ b/pkg/state/latest.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lib/pq"
+)
+
+// LatestVersion returns the name of the latest version schema, or nil if there
+// is none.
+func (s *State) LatestVersion(ctx context.Context, schema string) (*string, error) {
+	var version *string
+	err := s.pgConn.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT %s.latest_version($1)", pq.QuoteIdentifier(s.schema)),
+		schema).Scan(&version)
+	if err != nil {
+		return nil, err
+	}
+
+	return version, nil
+}
+
+// PreviousVersion returns the name of the previous version schema
+func (s *State) PreviousVersion(ctx context.Context, schema string) (*string, error) {
+	var parent *string
+	err := s.pgConn.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT %s.previous_version($1)", pq.QuoteIdentifier(s.schema)),
+		schema).Scan(&parent)
+	if err != nil {
+		return nil, err
+	}
+
+	return parent, nil
+}
+
+// LatestMigration returns the name of the latest migration, or nil if there
+// is none.
+func (s *State) LatestMigration(ctx context.Context, schema string) (*string, error) {
+	var migration *string
+	err := s.pgConn.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT %s.latest_migration($1)", pq.QuoteIdentifier(s.schema)),
+		schema).Scan(&migration)
+	if err != nil {
+		return nil, err
+	}
+
+	return migration, nil
+}
+
+// PreviousMigration returns the name of the previous migration, or nil if
+// there is none.
+func (s *State) PreviousMigration(ctx context.Context, schema string) (*string, error) {
+	var parent *string
+	err := s.pgConn.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT %s.previous_migration($1)", pq.QuoteIdentifier(s.schema)),
+		schema).Scan(&parent)
+	if err != nil {
+		return nil, err
+	}
+
+	return parent, nil
+}

--- a/pkg/state/latest_test.go
+++ b/pkg/state/latest_test.go
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package state_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xataio/pgroll/internal/testutils"
+	"github.com/xataio/pgroll/pkg/backfill"
+	"github.com/xataio/pgroll/pkg/migrations"
+	"github.com/xataio/pgroll/pkg/roll"
+)
+
+func TestLatestAndPreviousMigrationMethods(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no migrations applied", func(t *testing.T) {
+		testutils.WithMigratorAndConnectionToContainer(t, func(m *roll.Roll, db *sql.DB) {
+			ctx := context.Background()
+
+			// Get the latest migration name
+			latest, err := m.State().LatestMigration(ctx, "public")
+			require.NoError(t, err)
+
+			// Get the previous migration name
+			previous, err := m.State().PreviousMigration(ctx, "public")
+			require.NoError(t, err)
+
+			// Assert that both latest and previous are nil as no migrations have
+			// been applied
+			require.Nil(t, latest)
+			require.Nil(t, previous)
+		})
+	})
+
+	t.Run("one pgroll migration applied", func(t *testing.T) {
+		testutils.WithMigratorAndConnectionToContainer(t, func(m *roll.Roll, db *sql.DB) {
+			ctx := context.Background()
+
+			// Apply a pgroll migration
+			err := m.Start(ctx, &migrations.Migration{
+				Name:       "01_initial_migration",
+				Operations: migrations.Operations{&migrations.OpRawSQL{Up: "SELECT 1"}},
+			}, backfill.NewConfig())
+			require.NoError(t, err)
+			err = m.Complete(ctx)
+			require.NoError(t, err)
+
+			// Get the latest migration name
+			latest, err := m.State().LatestMigration(ctx, "public")
+			require.NoError(t, err)
+
+			// Get the previous migration name
+			previous, err := m.State().PreviousMigration(ctx, "public")
+			require.NoError(t, err)
+
+			// We have a latest migration name but no previous migration name
+			require.NotNil(t, latest)
+			require.Equal(t, "01_initial_migration", *latest)
+			require.Nil(t, previous)
+		})
+	})
+
+	t.Run("two pgroll migrations applied", func(t *testing.T) {
+		testutils.WithMigratorAndConnectionToContainer(t, func(m *roll.Roll, db *sql.DB) {
+			ctx := context.Background()
+
+			// Apply a pgroll migration
+			err := m.Start(ctx, &migrations.Migration{
+				Name:       "01_initial_migration",
+				Operations: migrations.Operations{&migrations.OpRawSQL{Up: "SELECT 1"}},
+			}, backfill.NewConfig())
+			require.NoError(t, err)
+			err = m.Complete(ctx)
+			require.NoError(t, err)
+
+			// Apply another pgroll migration
+			err = m.Start(ctx, &migrations.Migration{
+				Name:       "02_another_migration",
+				Operations: migrations.Operations{&migrations.OpRawSQL{Up: "SELECT 1"}},
+			}, backfill.NewConfig())
+			require.NoError(t, err)
+			err = m.Complete(ctx)
+			require.NoError(t, err)
+
+			// Get the latest migration name
+			latest, err := m.State().LatestMigration(ctx, "public")
+			require.NoError(t, err)
+
+			// Get the previous migration name
+			previous, err := m.State().PreviousMigration(ctx, "public")
+			require.NoError(t, err)
+
+			// We have latest and previous migration names
+			require.NotNil(t, latest)
+			require.Equal(t, "02_another_migration", *latest)
+			require.NotNil(t, previous)
+			require.Equal(t, "01_initial_migration", *previous)
+		})
+	})
+
+	t.Run("one pgroll then one inferred migration", func(t *testing.T) {
+		testutils.WithMigratorAndConnectionToContainer(t, func(m *roll.Roll, db *sql.DB) {
+			ctx := context.Background()
+
+			// Apply a pgroll migration
+			err := m.Start(ctx, &migrations.Migration{
+				Name:       "01_initial_migration",
+				Operations: migrations.Operations{&migrations.OpRawSQL{Up: "SELECT 1"}},
+			}, backfill.NewConfig())
+			require.NoError(t, err)
+			err = m.Complete(ctx)
+			require.NoError(t, err)
+
+			// Execute a SQL DDL statement to generate an inferred migration
+			_, err = db.ExecContext(ctx, "CREATE TABLE table1(id int)")
+			require.NoError(t, err)
+
+			// Get the latest migration name
+			latest, err := m.State().LatestMigration(ctx, "public")
+			require.NoError(t, err)
+
+			// Get the previous migration name
+			previous, err := m.State().PreviousMigration(ctx, "public")
+			require.NoError(t, err)
+
+			// We have latest and previous migration names
+			require.NotNil(t, latest)
+			require.Regexp(t, `01_initial_migration_\d{20}$`, *latest)
+			require.NotNil(t, previous)
+			require.Equal(t, "01_initial_migration", *previous)
+		})
+	})
+}
+
+func TestLatestAndPreviousVersionMethods(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no migrations applied", func(t *testing.T) {
+		testutils.WithMigratorAndConnectionToContainer(t, func(m *roll.Roll, db *sql.DB) {
+			ctx := context.Background()
+
+			// Get the latest version schema name
+			latest, err := m.State().LatestVersion(ctx, "public")
+			require.NoError(t, err)
+
+			// Get the previous version schema name
+			previous, err := m.State().PreviousVersion(ctx, "public")
+			require.NoError(t, err)
+
+			// Assert that both latest and previous are nil as no migrations have
+			// been applied
+			require.Nil(t, latest)
+			require.Nil(t, previous)
+		})
+	})
+
+	t.Run("one inferred migration applied", func(t *testing.T) {
+		testutils.WithMigratorAndConnectionToContainer(t, func(m *roll.Roll, db *sql.DB) {
+			ctx := context.Background()
+
+			// Apply an inferred migration
+			_, err := db.ExecContext(ctx, "CREATE TABLE apples(id int)")
+			require.NoError(t, err)
+
+			// Get the latest version schema name
+			latest, err := m.State().LatestVersion(ctx, "public")
+			require.NoError(t, err)
+
+			// Get the previous version schema name
+			previous, err := m.State().PreviousVersion(ctx, "public")
+			require.NoError(t, err)
+
+			// Assert that both latest and previous are nil as the inferred migration
+			// did not create a version schema
+			require.Nil(t, latest)
+			require.Nil(t, previous)
+		})
+	})
+
+	t.Run("one pgroll migration applied", func(t *testing.T) {
+		testutils.WithMigratorAndConnectionToContainer(t, func(m *roll.Roll, db *sql.DB) {
+			ctx := context.Background()
+
+			// Apply a pgroll migration
+			err := m.Start(ctx, &migrations.Migration{
+				Name:          "01_initial_migration",
+				VersionSchema: "initial_migration",
+				Operations:    migrations.Operations{&migrations.OpRawSQL{Up: "SELECT 1"}},
+			}, backfill.NewConfig())
+			require.NoError(t, err)
+			err = m.Complete(ctx)
+			require.NoError(t, err)
+
+			// Get the latest version schema name
+			latest, err := m.State().LatestVersion(ctx, "public")
+			require.NoError(t, err)
+
+			// Get the previous version schema name
+			previous, err := m.State().PreviousVersion(ctx, "public")
+			require.NoError(t, err)
+
+			// We have a latest version schema name but no previous one
+			require.NotNil(t, latest)
+			require.Equal(t, "initial_migration", *latest)
+			require.Nil(t, previous)
+		})
+	})
+
+	t.Run("one pgroll migration applied, another active", func(t *testing.T) {
+		testutils.WithMigratorAndConnectionToContainer(t, func(m *roll.Roll, db *sql.DB) {
+			ctx := context.Background()
+
+			// Apply a pgroll migration
+			err := m.Start(ctx, &migrations.Migration{
+				Name:          "01_initial_migration",
+				VersionSchema: "initial_migration",
+				Operations:    migrations.Operations{&migrations.OpRawSQL{Up: "SELECT 1"}},
+			}, backfill.NewConfig())
+			require.NoError(t, err)
+			err = m.Complete(ctx)
+			require.NoError(t, err)
+
+			// Start but don't complete another pgroll migration.
+			err = m.Start(ctx, &migrations.Migration{
+				Name:          "02_another_migration",
+				VersionSchema: "another_migration",
+				Operations:    migrations.Operations{&migrations.OpRawSQL{Up: "SELECT 1"}},
+			}, backfill.NewConfig())
+			require.NoError(t, err)
+
+			// Get the latest version schema name
+			latest, err := m.State().LatestVersion(ctx, "public")
+			require.NoError(t, err)
+
+			// Get the previous version schema name
+			previous, err := m.State().PreviousVersion(ctx, "public")
+			require.NoError(t, err)
+
+			// We have latest and previous version schema names
+			require.NotNil(t, latest)
+			require.Equal(t, "another_migration", *latest)
+			require.NotNil(t, previous)
+			require.Equal(t, "initial_migration", *previous)
+		})
+	})
+
+	t.Run("two pgroll migrations applied", func(t *testing.T) {
+		testutils.WithMigratorAndConnectionToContainer(t, func(m *roll.Roll, db *sql.DB) {
+			ctx := context.Background()
+
+			// Apply a pgroll migration
+			err := m.Start(ctx, &migrations.Migration{
+				Name:          "01_initial_migration",
+				VersionSchema: "initial_migration",
+				Operations:    migrations.Operations{&migrations.OpRawSQL{Up: "SELECT 1"}},
+			}, backfill.NewConfig())
+			require.NoError(t, err)
+			err = m.Complete(ctx)
+			require.NoError(t, err)
+
+			// Apply another pgroll migration
+			err = m.Start(ctx, &migrations.Migration{
+				Name:          "02_another_migration",
+				VersionSchema: "another_migration",
+				Operations:    migrations.Operations{&migrations.OpRawSQL{Up: "SELECT 1"}},
+			}, backfill.NewConfig())
+			require.NoError(t, err)
+			err = m.Complete(ctx)
+			require.NoError(t, err)
+
+			// Get the latest version schema name
+			latest, err := m.State().LatestVersion(ctx, "public")
+			require.NoError(t, err)
+
+			// Get the previous version schema name
+			previous, err := m.State().PreviousVersion(ctx, "public")
+			require.NoError(t, err)
+
+			// We have only a latest version schema name because the previous version
+			// schema was removed when the second migration was completed
+			require.NotNil(t, latest)
+			require.Equal(t, "another_migration", *latest)
+			require.Nil(t, previous)
+		})
+	})
+
+	t.Run("one pgroll then one inferred migration", func(t *testing.T) {
+		testutils.WithMigratorAndConnectionToContainer(t, func(m *roll.Roll, db *sql.DB) {
+			ctx := context.Background()
+
+			// Apply a pgroll migration
+			err := m.Start(ctx, &migrations.Migration{
+				Name:          "01_initial_migration",
+				VersionSchema: "initial_migration",
+				Operations:    migrations.Operations{&migrations.OpRawSQL{Up: "SELECT 1"}},
+			}, backfill.NewConfig())
+			require.NoError(t, err)
+			err = m.Complete(ctx)
+			require.NoError(t, err)
+
+			// Execute a SQL DDL statement to generate an inferred migration
+			_, err = db.ExecContext(ctx, "CREATE TABLE table1(id int)")
+			require.NoError(t, err)
+
+			// Get the latest version schema name
+			latest, err := m.State().LatestVersion(ctx, "public")
+			require.NoError(t, err)
+
+			// Get the previous version schema name
+			previous, err := m.State().PreviousVersion(ctx, "public")
+			require.NoError(t, err)
+
+			// We have a latest version schema name that corresponds to the most
+			// recent `pgroll` migration. There is no previous version schema name.
+			require.NotNil(t, latest)
+			require.Equal(t, "initial_migration", *latest)
+			require.Nil(t, previous)
+		})
+	})
+
+	t.Run("one pgroll, one inferred migration, then another pgroll migration", func(t *testing.T) {
+		testutils.WithMigratorAndConnectionToContainer(t, func(m *roll.Roll, db *sql.DB) {
+			ctx := context.Background()
+
+			// Apply a pgroll migration
+			err := m.Start(ctx, &migrations.Migration{
+				Name:          "01_initial_migration",
+				VersionSchema: "initial_migration",
+				Operations:    migrations.Operations{&migrations.OpRawSQL{Up: "SELECT 1"}},
+			}, backfill.NewConfig())
+			require.NoError(t, err)
+			err = m.Complete(ctx)
+			require.NoError(t, err)
+
+			// Execute a SQL DDL statement to generate an inferred migration
+			_, err = db.ExecContext(ctx, "CREATE TABLE table1(id int)")
+			require.NoError(t, err)
+
+			// Start but do not complete a pgroll migration
+			err = m.Start(ctx, &migrations.Migration{
+				Name:       "02_another_migration",
+				Operations: migrations.Operations{&migrations.OpRawSQL{Up: "SELECT 1"}},
+			}, backfill.NewConfig())
+			require.NoError(t, err)
+
+			// Get the latest version schema name
+			latest, err := m.State().LatestVersion(ctx, "public")
+			require.NoError(t, err)
+
+			// Get the previous version schema name
+			previous, err := m.State().PreviousVersion(ctx, "public")
+			require.NoError(t, err)
+
+			// We have a latest and a previous version schema name. The inferred
+			// migation that was created after the first pgroll migration is ignored.
+			require.NotNil(t, latest)
+			require.Equal(t, "02_another_migration", *latest)
+			require.NotNil(t, previous)
+			require.Equal(t, "initial_migration", *previous)
+		})
+	})
+}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -224,60 +224,6 @@ func (s *State) GetActiveMigration(ctx context.Context, schema string) (*migrati
 	return &migration, nil
 }
 
-// LatestVersion returns the name of the latest version schema, or nil if there
-// is none.
-func (s *State) LatestVersion(ctx context.Context, schema string) (*string, error) {
-	var version *string
-	err := s.pgConn.QueryRowContext(ctx,
-		fmt.Sprintf("SELECT %s.latest_version($1)", pq.QuoteIdentifier(s.schema)),
-		schema).Scan(&version)
-	if err != nil {
-		return nil, err
-	}
-
-	return version, nil
-}
-
-// LatestMigration returns the name of the latest migration, or nil if there
-// is none.
-func (s *State) LatestMigration(ctx context.Context, schema string) (*string, error) {
-	var migration *string
-	err := s.pgConn.QueryRowContext(ctx,
-		fmt.Sprintf("SELECT %s.latest_migration($1)", pq.QuoteIdentifier(s.schema)),
-		schema).Scan(&migration)
-	if err != nil {
-		return nil, err
-	}
-
-	return migration, nil
-}
-
-// PreviousVersion returns the name of the previous version schema
-func (s *State) PreviousVersion(ctx context.Context, schema string) (*string, error) {
-	var parent *string
-	err := s.pgConn.QueryRowContext(ctx,
-		fmt.Sprintf("SELECT %s.previous_version($1)", pq.QuoteIdentifier(s.schema)),
-		schema).Scan(&parent)
-	if err != nil {
-		return nil, err
-	}
-
-	return parent, nil
-}
-
-// PreviousMigration returns the name of the previous migration
-func (s *State) PreviousMigration(ctx context.Context, schema string) (*string, error) {
-	var parent *string
-	err := s.pgConn.QueryRowContext(ctx,
-		fmt.Sprintf("SELECT %s.previous_migration($1)", pq.QuoteIdentifier(s.schema)),
-		schema).Scan(&parent)
-	if err != nil {
-		return nil, err
-	}
-
-	return parent, nil
-}
-
 // Status returns the current migration status of the specified schema
 func (s *State) Status(ctx context.Context, schema string) (*Status, error) {
 	latestVersion, err := s.LatestVersion(ctx, schema)

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -253,11 +253,11 @@ func (s *State) LatestMigration(ctx context.Context, schema string) (*string, er
 }
 
 // PreviousVersion returns the name of the previous version schema
-func (s *State) PreviousVersion(ctx context.Context, schema string, includeInferred bool) (*string, error) {
+func (s *State) PreviousVersion(ctx context.Context, schema string) (*string, error) {
 	var parent *string
 	err := s.pgConn.QueryRowContext(ctx,
-		fmt.Sprintf("SELECT %s.previous_version($1, $2)", pq.QuoteIdentifier(s.schema)),
-		schema, includeInferred).Scan(&parent)
+		fmt.Sprintf("SELECT %s.previous_version($1)", pq.QuoteIdentifier(s.schema)),
+		schema).Scan(&parent)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix the problem described in #915 where `pgroll latest schema` will return version schema names for which no version schema exists in the database, such as for `inferred` migrations.

---

1. Apply a migration
```
pgroll  start examples/01_create_tables.yaml --complete
```

2. Create an inferred migration
```
CREATE TABLE foo(id int PRIMARY KEY)
```

3. Run `pgroll latest schema`

Before this PR the output would be incorrect:

```
public_sql_fca0901e
```

The most recent migration (inferred from the `CREATE TABLE`) did not create a version schema - the most recent schema version is still `public_01_create_tables`.

This PR corrects the behaviour of `pgroll latest schema` to consider only migrations for which a version schema exists. So the output is:

```
public_01_create_tables
```

as expected.

---


Fixes #915 

Related to #872 
