### PR TITLE
Rename `WithDisableViewsManagement` roll option

### DIFF
--- a/pkg/roll/options.go
+++ b/pkg/roll/options.go
@@ -52,11 +52,11 @@ func WithRole(role string) Option {
 	}
 }
 
-// WithDisableViewsManagement disables pgroll version schemas management
-// when passed, pgroll will not create or drop version schemas
-func WithDisableViewsManagement() Option {
+// WithVersionSchema enables or disables the creation of version schema for
+// migrations.
+func WithVersionSchema(enabled bool) Option {
 	return func(o *options) {
-		o.disableVersionSchemas = true
+		o.disableVersionSchemas = !enabled
 	}
 }
 


### PR DESCRIPTION
Rename the `WithDisableViewsManagement` option to `WithVersionSchema` to better reflect its purpose.

Update the test that runs a migration with the option set to include a rollback.

Part of #872 