### PR TITLE
Update error type returned when `Roll.LatestVersionRemote` finds no version schema

### DIFF
--- a/pkg/roll/latest.go
+++ b/pkg/roll/latest.go
@@ -13,6 +13,7 @@ import (
 var (
 	ErrNoMigrationFiles   = fmt.Errorf("no migration files found")
 	ErrNoMigrationApplied = fmt.Errorf("no migrations applied")
+	ErrNoVersionSchema    = fmt.Errorf("no version schemas found")
 )
 
 // LatestVersionLocal returns the version schema name of the last migration in
@@ -46,7 +47,7 @@ func (m *Roll) LatestVersionRemote(ctx context.Context) (string, error) {
 	}
 
 	if latestVersion == nil {
-		return "", ErrNoMigrationApplied
+		return "", ErrNoVersionSchema
 	}
 
 	return *latestVersion, nil


### PR DESCRIPTION
Ensure  that the error returned by `Roll.LatestVersionRemote` when there are no version schema in the target database makes it clear that there are no **version schema** rather than no **migrations**.

When using `Roll.WithVersionSchema(false)` it's easy to have a situation where there are migrations applied but no version schema; in that case `Roll.LatestVersionRemote` should return an appropriate error rather than one that says no migrations have been applied.