### PR TITLE
Simplify `previous_migration` function

### DIFF
--- a/pkg/state/init.sql
+++ b/pkg/state/init.sql
@@ -98,42 +98,15 @@ STABLE;
 CREATE OR REPLACE FUNCTION placeholder.previous_migration (schemaname name)
     RETURNS text
     AS $$
-    WITH RECURSIVE ancestors AS (
-        SELECT
-            name,
-            schema,
-            parent,
-            migration_type,
-            0 AS depth
-        FROM
-            placeholder.migrations
-        WHERE
-            name = placeholder.latest_migration (schemaname)
-            AND SCHEMA = schemaname
-        UNION ALL
-        SELECT
-            m.name,
-            m.schema,
-            m.parent,
-            m.migration_type,
-            a.depth + 1
-        FROM
-            placeholder.migrations m
-            JOIN ancestors a ON m.name = a.parent
-                AND m.schema = a.schema
-)
-        SELECT
-            a.name
-        FROM
-            ancestors a
+    SELECT
+        parent
+    FROM
+        placeholder.migrations
     WHERE
-        a.depth > 0
-    ORDER BY
-        a.depth ASC
-    LIMIT 1;
+        SCHEMA = schemaname
+        AND name = placeholder.latest_migration (schemaname);
 $$
-LANGUAGE SQL
-STABLE;
+LANGUAGE SQL;
 
 -- find_version_schema finds a recent version schema for a given schema name.
 -- How recent is determined by the minDepth parameter: for a minDepth of 0, it


### PR DESCRIPTION
Get rid of the recursive CTE in the `previous_migration` function - we only need to find the parent of the latest migration, which can be done with a simple query.

The need for recursion was removed because this function used to find the previous migration with an existent version schema, but that functionality is now in the `previous_version` function, allowing `previous_migration` to be simplified.