### PR TITLE
Return `backfill.Task` from `Start` phase operations

### DIFF
--- a/pkg/backfill/backfill.go
+++ b/pkg/backfill/backfill.go
@@ -21,8 +21,8 @@ const CNeedsBackfillColumn = "_pgroll_needs_backfill"
 
 // Task represents a backfill task for a specific table from an operation.
 type Task struct {
-	Table    *schema.Table
-	Triggers []TriggerConfig
+	table    *schema.Table
+	triggers []TriggerConfig
 }
 
 // Job is a collection of all tables that need to be backfilled and their associated triggers.
@@ -38,9 +38,16 @@ type Backfill struct {
 
 type CallbackFn func(done int64, total int64)
 
+func NewTask(table *schema.Table, triggers ...TriggerConfig) *Task {
+	return &Task{
+		table:    table,
+		triggers: triggers,
+	}
+}
+
 func (j *Job) AddTask(t *Task) {
-	j.Tables = append(j.Tables, t.Table)
-	j.triggers = append(j.triggers, t.Triggers...)
+	j.Tables = append(j.Tables, t.table)
+	j.triggers = append(j.triggers, t.triggers...)
 }
 
 // New creates a new backfill operation with the given options. The backfill is
@@ -54,8 +61,8 @@ func New(conn db.DB, c *Config) *Backfill {
 	return b
 }
 
-// LoadTriggers loads the triggers for the tables before starting the backfill.
-func (bf *Backfill) LoadTriggers(ctx context.Context, j *Job) error {
+// CreateTriggers creates the triggers for the tables before starting the backfill.
+func (bf *Backfill) CreateTriggers(ctx context.Context, j *Job) error {
 	// Not yet implemented, triggers are loaded during the Start method.
 	return nil
 }

--- a/pkg/backfill/backfill.go
+++ b/pkg/backfill/backfill.go
@@ -19,12 +19,29 @@ import (
 // by pgroll to mark rows that must be backfilled
 const CNeedsBackfillColumn = "_pgroll_needs_backfill"
 
+// Task represents a backfill task for a specific table from an operation.
+type Task struct {
+	Table    *schema.Table
+	Triggers []TriggerConfig
+}
+
+// Job is a collection of all tables that need to be backfilled and their associated triggers.
+type Job struct {
+	Tables   []*schema.Table
+	triggers []TriggerConfig
+}
+
 type Backfill struct {
 	conn db.DB
 	*Config
 }
 
 type CallbackFn func(done int64, total int64)
+
+func (j *Job) AddTask(t *Task) {
+	j.Tables = append(j.Tables, t.Table)
+	j.triggers = append(j.triggers, t.Triggers...)
+}
 
 // New creates a new backfill operation with the given options. The backfill is
 // not started until `Start` is invoked.
@@ -35,6 +52,12 @@ func New(conn db.DB, c *Config) *Backfill {
 	}
 
 	return b
+}
+
+// LoadTriggers loads the triggers for the tables before starting the backfill.
+func (bf *Backfill) LoadTriggers(ctx context.Context, j *Job) error {
+	// Not yet implemented, triggers are loaded during the Start method.
+	return nil
 }
 
 // Start updates all rows in the given table, in batches, using the

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -9,6 +9,7 @@ import (
 
 	_ "github.com/lib/pq"
 
+	"github.com/xataio/pgroll/pkg/backfill"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
@@ -19,7 +20,7 @@ type Operation interface {
 	// version in the database (through a view)
 	// update the given views to expose the new schema version
 	// Returns the table that requires backfilling, if any.
-	Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error)
+	Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error)
 
 	// Complete will update the database schema to match the current version
 	// after calling Start.

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -117,9 +117,7 @@ func (o *OpAddColumn) Start(ctx context.Context, l Logger, conn db.DB, latestSch
 		if err != nil {
 			return nil, fmt.Errorf("failed to create trigger: %w", err)
 		}
-		task = &backfill.Task{
-			Table: table,
-		}
+		task = backfill.NewTask(table)
 	}
 
 	tmpColumn := toSchemaColumn(o.Column)

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -19,7 +19,7 @@ var (
 	_ Createable = (*OpAddColumn)(nil)
 )
 
-func (o *OpAddColumn) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpAddColumn) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
@@ -100,7 +100,7 @@ func (o *OpAddColumn) Start(ctx context.Context, l Logger, conn db.DB, latestSch
 		}
 	}
 
-	var tableToBackfill *schema.Table
+	var task *backfill.Task
 	if o.Up != "" {
 		err := NewCreateTriggerAction(conn,
 			backfill.TriggerConfig{
@@ -117,14 +117,16 @@ func (o *OpAddColumn) Start(ctx context.Context, l Logger, conn db.DB, latestSch
 		if err != nil {
 			return nil, fmt.Errorf("failed to create trigger: %w", err)
 		}
-		tableToBackfill = table
+		task = &backfill.Task{
+			Table: table,
+		}
 	}
 
 	tmpColumn := toSchemaColumn(o.Column)
 	tmpColumn.Name = TemporaryName(o.Column.Name)
 	table.AddColumn(o.Column.Name, tmpColumn)
 
-	return tableToBackfill, nil
+	return task, nil
 }
 
 func toSchemaColumn(c Column) *schema.Column {

--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -88,9 +88,7 @@ func (o *OpAlterColumn) Start(ctx context.Context, l Logger, conn db.DB, latestS
 		}
 	}
 
-	return &backfill.Task{
-		Table: table,
-	}, nil
+	return backfill.NewTask(table), nil
 }
 
 func (o *OpAlterColumn) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -18,7 +18,7 @@ var (
 	_ Createable = (*OpAlterColumn)(nil)
 )
 
-func (o *OpAlterColumn) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpAlterColumn) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
@@ -88,7 +88,9 @@ func (o *OpAlterColumn) Start(ctx context.Context, l Logger, conn db.DB, latestS
 		}
 	}
 
-	return table, nil
+	return &backfill.Task{
+		Table: table,
+	}, nil
 }
 
 func (o *OpAlterColumn) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_change_type.go
+++ b/pkg/migrations/op_change_type.go
@@ -28,9 +28,7 @@ func (o *OpChangeType) Start(ctx context.Context, l Logger, conn db.DB, latestSc
 		return nil, TableDoesNotExistError{Name: o.Table}
 	}
 
-	return &backfill.Task{
-		Table: table,
-	}, nil
+	return backfill.NewTask(table), nil
 }
 
 func (o *OpChangeType) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_change_type.go
+++ b/pkg/migrations/op_change_type.go
@@ -5,6 +5,7 @@ package migrations
 import (
 	"context"
 
+	"github.com/xataio/pgroll/pkg/backfill"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
@@ -19,7 +20,7 @@ type OpChangeType struct {
 
 var _ Operation = (*OpChangeType)(nil)
 
-func (o *OpChangeType) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpChangeType) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
@@ -27,7 +28,9 @@ func (o *OpChangeType) Start(ctx context.Context, l Logger, conn db.DB, latestSc
 		return nil, TableDoesNotExistError{Name: o.Table}
 	}
 
-	return table, nil
+	return &backfill.Task{
+		Table: table,
+	}, nil
 }
 
 func (o *OpChangeType) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_create_constraint.go
+++ b/pkg/migrations/op_create_constraint.go
@@ -87,9 +87,7 @@ func (o *OpCreateConstraint) Start(ctx context.Context, l Logger, conn db.DB, la
 		}
 	}
 
-	task := &backfill.Task{
-		Table: table,
-	}
+	task := backfill.NewTask(table)
 
 	switch o.Type {
 	case OpCreateConstraintTypeUnique, OpCreateConstraintTypePrimaryKey:

--- a/pkg/migrations/op_create_constraint.go
+++ b/pkg/migrations/op_create_constraint.go
@@ -16,7 +16,7 @@ var (
 	_ Createable = (*OpCreateConstraint)(nil)
 )
 
-func (o *OpCreateConstraint) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpCreateConstraint) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
@@ -87,16 +87,20 @@ func (o *OpCreateConstraint) Start(ctx context.Context, l Logger, conn db.DB, la
 		}
 	}
 
-	switch o.Type {
-	case OpCreateConstraintTypeUnique, OpCreateConstraintTypePrimaryKey:
-		return table, NewCreateUniqueIndexConcurrentlyAction(conn, s.Name, o.Name, table.Name, temporaryNames(o.Columns)...).Execute(ctx)
-	case OpCreateConstraintTypeCheck:
-		return table, NewCreateCheckConstraintAction(conn, table.Name, o.Name, *o.Check, o.Columns, o.NoInherit, true).Execute(ctx)
-	case OpCreateConstraintTypeForeignKey:
-		return table, NewCreateFKConstraintAction(conn, table.Name, o.Name, temporaryNames(o.Columns), o.References, false, false, true).Execute(ctx)
+	task := &backfill.Task{
+		Table: table,
 	}
 
-	return table, nil
+	switch o.Type {
+	case OpCreateConstraintTypeUnique, OpCreateConstraintTypePrimaryKey:
+		return task, NewCreateUniqueIndexConcurrentlyAction(conn, s.Name, o.Name, table.Name, temporaryNames(o.Columns)...).Execute(ctx)
+	case OpCreateConstraintTypeCheck:
+		return task, NewCreateCheckConstraintAction(conn, table.Name, o.Name, *o.Check, o.Columns, o.NoInherit, true).Execute(ctx)
+	case OpCreateConstraintTypeForeignKey:
+		return task, NewCreateFKConstraintAction(conn, table.Name, o.Name, temporaryNames(o.Columns), o.References, false, false, true).Execute(ctx)
+	}
+
+	return task, nil
 }
 
 func (o *OpCreateConstraint) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_create_index.go
+++ b/pkg/migrations/op_create_index.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lib/pq"
 
+	"github.com/xataio/pgroll/pkg/backfill"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
@@ -18,7 +19,7 @@ var (
 	_ Createable = (*OpCreateIndex)(nil)
 )
 
-func (o *OpCreateIndex) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpCreateIndex) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/xataio/pgroll/pkg/backfill"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
@@ -17,7 +18,7 @@ var (
 	_ Createable = (*OpCreateTable)(nil)
 )
 
-func (o *OpCreateTable) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpCreateTable) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	// Generate SQL for the columns in the table

--- a/pkg/migrations/op_drop_column.go
+++ b/pkg/migrations/op_drop_column.go
@@ -15,7 +15,7 @@ var (
 	_ Createable = (*OpDropColumn)(nil)
 )
 
-func (o *OpDropColumn) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpDropColumn) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	if o.Down != "" {

--- a/pkg/migrations/op_drop_constraint.go
+++ b/pkg/migrations/op_drop_constraint.go
@@ -76,9 +76,7 @@ func (o *OpDropConstraint) Start(ctx context.Context, l Logger, conn db.DB, late
 	if err != nil {
 		return nil, fmt.Errorf("failed to create down trigger: %w", err)
 	}
-	return &backfill.Task{
-		Table: table,
-	}, nil
+	return backfill.NewTask(table), nil
 }
 
 func (o *OpDropConstraint) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_drop_constraint.go
+++ b/pkg/migrations/op_drop_constraint.go
@@ -15,7 +15,7 @@ import (
 
 var _ Operation = (*OpDropConstraint)(nil)
 
-func (o *OpDropConstraint) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpDropConstraint) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
@@ -76,7 +76,9 @@ func (o *OpDropConstraint) Start(ctx context.Context, l Logger, conn db.DB, late
 	if err != nil {
 		return nil, fmt.Errorf("failed to create down trigger: %w", err)
 	}
-	return table, nil
+	return &backfill.Task{
+		Table: table,
+	}, nil
 }
 
 func (o *OpDropConstraint) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_drop_index.go
+++ b/pkg/migrations/op_drop_index.go
@@ -5,6 +5,7 @@ package migrations
 import (
 	"context"
 
+	"github.com/xataio/pgroll/pkg/backfill"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
@@ -14,7 +15,7 @@ var (
 	_ Createable = (*OpDropIndex)(nil)
 )
 
-func (o *OpDropIndex) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpDropIndex) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	// no-op

--- a/pkg/migrations/op_drop_multicolumn_constraint.go
+++ b/pkg/migrations/op_drop_multicolumn_constraint.go
@@ -94,9 +94,7 @@ func (o *OpDropMultiColumnConstraint) Start(ctx context.Context, l Logger, conn 
 		}
 	}
 
-	return &backfill.Task{
-		Table: table,
-	}, nil
+	return backfill.NewTask(table), nil
 }
 
 func (o *OpDropMultiColumnConstraint) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_drop_multicolumn_constraint.go
+++ b/pkg/migrations/op_drop_multicolumn_constraint.go
@@ -19,7 +19,7 @@ var (
 	_ Createable = (*OpDropMultiColumnConstraint)(nil)
 )
 
-func (o *OpDropMultiColumnConstraint) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpDropMultiColumnConstraint) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
@@ -94,7 +94,9 @@ func (o *OpDropMultiColumnConstraint) Start(ctx context.Context, l Logger, conn 
 		}
 	}
 
-	return table, nil
+	return &backfill.Task{
+		Table: table,
+	}, nil
 }
 
 func (o *OpDropMultiColumnConstraint) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_drop_not_null.go
+++ b/pkg/migrations/op_drop_not_null.go
@@ -5,6 +5,7 @@ package migrations
 import (
 	"context"
 
+	"github.com/xataio/pgroll/pkg/backfill"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
@@ -19,7 +20,7 @@ type OpDropNotNull struct {
 
 var _ Operation = (*OpDropNotNull)(nil)
 
-func (o *OpDropNotNull) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpDropNotNull) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
@@ -27,7 +28,9 @@ func (o *OpDropNotNull) Start(ctx context.Context, l Logger, conn db.DB, latestS
 		return nil, TableDoesNotExistError{Name: o.Table}
 	}
 
-	return table, nil
+	return &backfill.Task{
+		Table: table,
+	}, nil
 }
 
 func (o *OpDropNotNull) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_drop_not_null.go
+++ b/pkg/migrations/op_drop_not_null.go
@@ -28,9 +28,7 @@ func (o *OpDropNotNull) Start(ctx context.Context, l Logger, conn db.DB, latestS
 		return nil, TableDoesNotExistError{Name: o.Table}
 	}
 
-	return &backfill.Task{
-		Table: table,
-	}, nil
+	return backfill.NewTask(table), nil
 }
 
 func (o *OpDropNotNull) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_drop_table.go
+++ b/pkg/migrations/op_drop_table.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/xataio/pgroll/pkg/backfill"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
@@ -15,7 +16,7 @@ var (
 	_ Createable = (*OpDropTable)(nil)
 )
 
-func (o *OpDropTable) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpDropTable) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Name)

--- a/pkg/migrations/op_raw_sql.go
+++ b/pkg/migrations/op_raw_sql.go
@@ -5,6 +5,7 @@ package migrations
 import (
 	"context"
 
+	"github.com/xataio/pgroll/pkg/backfill"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
@@ -14,7 +15,7 @@ var (
 	_ Createable = (*OpRawSQL)(nil)
 )
 
-func (o *OpRawSQL) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpRawSQL) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	if o.OnComplete {

--- a/pkg/migrations/op_rename_column.go
+++ b/pkg/migrations/op_rename_column.go
@@ -5,13 +5,14 @@ package migrations
 import (
 	"context"
 
+	"github.com/xataio/pgroll/pkg/backfill"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
 
 var _ Operation = (*OpRenameColumn)(nil)
 
-func (o *OpRenameColumn) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpRenameColumn) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	// Rename the table in the in-memory schema.

--- a/pkg/migrations/op_rename_constraint.go
+++ b/pkg/migrations/op_rename_constraint.go
@@ -5,13 +5,14 @@ package migrations
 import (
 	"context"
 
+	"github.com/xataio/pgroll/pkg/backfill"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
 
 var _ Operation = (*OpRenameConstraint)(nil)
 
-func (o *OpRenameConstraint) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpRenameConstraint) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	// no-op

--- a/pkg/migrations/op_rename_table.go
+++ b/pkg/migrations/op_rename_table.go
@@ -5,13 +5,14 @@ package migrations
 import (
 	"context"
 
+	"github.com/xataio/pgroll/pkg/backfill"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
 
 var _ Operation = (*OpRenameTable)(nil)
 
-func (o *OpRenameTable) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpRenameTable) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	return nil, s.RenameTable(o.From, o.To)

--- a/pkg/migrations/op_set_check.go
+++ b/pkg/migrations/op_set_check.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/xataio/pgroll/pkg/backfill"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
@@ -20,7 +21,7 @@ type OpSetCheckConstraint struct {
 
 var _ Operation = (*OpSetCheckConstraint)(nil)
 
-func (o *OpSetCheckConstraint) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpSetCheckConstraint) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
@@ -33,7 +34,9 @@ func (o *OpSetCheckConstraint) Start(ctx context.Context, l Logger, conn db.DB, 
 		return nil, fmt.Errorf("failed to add check constraint: %w", err)
 	}
 
-	return table, nil
+	return &backfill.Task{
+		Table: table,
+	}, nil
 }
 
 func (o *OpSetCheckConstraint) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_set_check.go
+++ b/pkg/migrations/op_set_check.go
@@ -34,9 +34,7 @@ func (o *OpSetCheckConstraint) Start(ctx context.Context, l Logger, conn db.DB, 
 		return nil, fmt.Errorf("failed to add check constraint: %w", err)
 	}
 
-	return &backfill.Task{
-		Table: table,
-	}, nil
+	return backfill.NewTask(table), nil
 }
 
 func (o *OpSetCheckConstraint) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_set_comment.go
+++ b/pkg/migrations/op_set_comment.go
@@ -29,7 +29,7 @@ func (o *OpSetComment) Start(ctx context.Context, l Logger, conn db.DB, latestSc
 		return nil, TableDoesNotExistError{Name: o.Table}
 	}
 
-	return &backfill.Task{Table: tbl}, NewCommentColumnAction(conn, o.Table, TemporaryName(o.Column), o.Comment).Execute(ctx)
+	return backfill.NewTask(tbl), NewCommentColumnAction(conn, o.Table, TemporaryName(o.Column), o.Comment).Execute(ctx)
 }
 
 func (o *OpSetComment) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_set_comment.go
+++ b/pkg/migrations/op_set_comment.go
@@ -5,6 +5,7 @@ package migrations
 import (
 	"context"
 
+	"github.com/xataio/pgroll/pkg/backfill"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
@@ -20,7 +21,7 @@ type OpSetComment struct {
 
 var _ Operation = (*OpSetComment)(nil)
 
-func (o *OpSetComment) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpSetComment) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	tbl := s.GetTable(o.Table)
@@ -28,7 +29,7 @@ func (o *OpSetComment) Start(ctx context.Context, l Logger, conn db.DB, latestSc
 		return nil, TableDoesNotExistError{Name: o.Table}
 	}
 
-	return tbl, NewCommentColumnAction(conn, o.Table, TemporaryName(o.Column), o.Comment).Execute(ctx)
+	return &backfill.Task{Table: tbl}, NewCommentColumnAction(conn, o.Table, TemporaryName(o.Column), o.Comment).Execute(ctx)
 }
 
 func (o *OpSetComment) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_set_default.go
+++ b/pkg/migrations/op_set_default.go
@@ -44,9 +44,7 @@ func (o *OpSetDefault) Start(ctx context.Context, l Logger, conn db.DB, latestSc
 		return nil, err
 	}
 
-	return &backfill.Task{
-		Table: table,
-	}, nil
+	return backfill.NewTask(table), nil
 }
 
 func (o *OpSetDefault) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_set_default.go
+++ b/pkg/migrations/op_set_default.go
@@ -5,6 +5,7 @@ package migrations
 import (
 	"context"
 
+	"github.com/xataio/pgroll/pkg/backfill"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
@@ -19,7 +20,7 @@ type OpSetDefault struct {
 
 var _ Operation = (*OpSetDefault)(nil)
 
-func (o *OpSetDefault) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpSetDefault) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
@@ -43,7 +44,9 @@ func (o *OpSetDefault) Start(ctx context.Context, l Logger, conn db.DB, latestSc
 		return nil, err
 	}
 
-	return table, nil
+	return &backfill.Task{
+		Table: table,
+	}, nil
 }
 
 func (o *OpSetDefault) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_set_fk.go
+++ b/pkg/migrations/op_set_fk.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/xataio/pgroll/pkg/backfill"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
@@ -20,7 +21,7 @@ type OpSetForeignKey struct {
 
 var _ Operation = (*OpSetForeignKey)(nil)
 
-func (o *OpSetForeignKey) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpSetForeignKey) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
@@ -60,7 +61,7 @@ func (o *OpSetForeignKey) Start(ctx context.Context, l Logger, conn db.DB, lates
 		return nil, fmt.Errorf("failed to add foreign key constraint: %w", err)
 	}
 
-	return table, nil
+	return &backfill.Task{Table: table}, nil
 }
 
 func (o *OpSetForeignKey) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_set_fk.go
+++ b/pkg/migrations/op_set_fk.go
@@ -61,7 +61,7 @@ func (o *OpSetForeignKey) Start(ctx context.Context, l Logger, conn db.DB, lates
 		return nil, fmt.Errorf("failed to add foreign key constraint: %w", err)
 	}
 
-	return &backfill.Task{Table: table}, nil
+	return backfill.NewTask(table), nil
 }
 
 func (o *OpSetForeignKey) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_set_notnull.go
+++ b/pkg/migrations/op_set_notnull.go
@@ -49,9 +49,7 @@ func (o *OpSetNotNull) Start(ctx context.Context, l Logger, conn db.DB, latestSc
 		return nil, fmt.Errorf("failed to add not null constraint: %w", err)
 	}
 
-	return &backfill.Task{
-		Table: table,
-	}, nil
+	return backfill.NewTask(table), nil
 }
 
 func (o *OpSetNotNull) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_set_notnull.go
+++ b/pkg/migrations/op_set_notnull.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/lib/pq"
 
+	"github.com/xataio/pgroll/pkg/backfill"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
@@ -21,7 +22,7 @@ type OpSetNotNull struct {
 
 var _ Operation = (*OpSetNotNull)(nil)
 
-func (o *OpSetNotNull) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpSetNotNull) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
@@ -48,7 +49,9 @@ func (o *OpSetNotNull) Start(ctx context.Context, l Logger, conn db.DB, latestSc
 		return nil, fmt.Errorf("failed to add not null constraint: %w", err)
 	}
 
-	return table, nil
+	return &backfill.Task{
+		Table: table,
+	}, nil
 }
 
 func (o *OpSetNotNull) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/migrations/op_set_replica_identity.go
+++ b/pkg/migrations/op_set_replica_identity.go
@@ -10,13 +10,14 @@ import (
 
 	"github.com/lib/pq"
 
+	"github.com/xataio/pgroll/pkg/backfill"
 	"github.com/xataio/pgroll/pkg/db"
 	"github.com/xataio/pgroll/pkg/schema"
 )
 
 var _ Operation = (*OpSetReplicaIdentity)(nil)
 
-func (o *OpSetReplicaIdentity) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*schema.Table, error) {
+func (o *OpSetReplicaIdentity) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	// build the correct form of the `SET REPLICA IDENTITY` statement based on the`identity type

--- a/pkg/migrations/op_set_unique.go
+++ b/pkg/migrations/op_set_unique.go
@@ -32,9 +32,7 @@ func (o *OpSetUnique) Start(ctx context.Context, l Logger, conn db.DB, latestSch
 		return nil, ColumnDoesNotExistError{Table: o.Table, Name: o.Column}
 	}
 
-	return &backfill.Task{
-		Table: table,
-	}, NewCreateUniqueIndexConcurrentlyAction(conn, s.Name, o.Name, table.Name, column.Name).Execute(ctx)
+	return backfill.NewTask(table), NewCreateUniqueIndexConcurrentlyAction(conn, s.Name, o.Name, table.Name, column.Name).Execute(ctx)
 }
 
 func (o *OpSetUnique) Complete(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) error {

--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -353,7 +353,7 @@ func (m *Roll) ensureView(ctx context.Context, version, name string, table *sche
 func (m *Roll) performBackfills(ctx context.Context, job *backfill.Job, cfg *backfill.Config) error {
 	bf := backfill.New(m.pgConn, cfg)
 
-	bf.LoadTriggers(ctx, job)
+	bf.CreateTriggers(ctx, job)
 
 	for _, table := range job.Tables {
 		m.logger.LogBackfillStart(table.Name)


### PR DESCRIPTION
From now on `Start` functions of each operations return a `backfill.Task` instance. This struct contains information required by the backfill process. The tasks are collected in a single `backfill.Job`.
This aggregates all relevant information for the backfill process: list of tables to backfill and all the triggers to load.
