### PR TITLE
Support altering primary key columns that are not included in FK constraints

### DIFF
--- a/internal/testutils/error_codes.go
+++ b/internal/testutils/error_codes.go
@@ -3,11 +3,12 @@
 package testutils
 
 const (
-	CheckViolationErrorCode     string = "check_violation"
-	ExclusionViolationErrorCode string = "exclusion_violation"
-	FKViolationErrorCode        string = "foreign_key_violation"
-	NotNullViolationErrorCode   string = "not_null_violation"
-	UndefinedColumnErrorCode    string = "undefined_column"
-	UndefinedTableErrorCode     string = "undefined_table"
-	UniqueViolationErrorCode    string = "unique_violation"
+	CheckViolationErrorCode         string = "check_violation"
+	ExclusionViolationErrorCode     string = "exclusion_violation"
+	FKViolationErrorCode            string = "foreign_key_violation"
+	NotNullViolationErrorCode       string = "not_null_violation"
+	UndefinedColumnErrorCode        string = "undefined_column"
+	UndefinedTableErrorCode         string = "undefined_table"
+	UniqueViolationErrorCode        string = "unique_violation"
+	NumericValueOutOfRangeErrorCode string = "numeric_value_out_of_range"
 )

--- a/pkg/backfill/backfill.go
+++ b/pkg/backfill/backfill.go
@@ -165,13 +165,8 @@ func getRowCount(ctx context.Context, conn db.DB, tableName string) (int64, erro
 
 // getIdentityColumn will return a column suitable for use in a backfill operation.
 func getIdentityColumns(table *schema.Table) []string {
-	pks := table.GetPrimaryKey()
-	if len(pks) != 0 {
-		pkNames := make([]string, len(pks))
-		for i, pk := range pks {
-			pkNames[i] = pk.Name
-		}
-		return pkNames
+	if len(table.PrimaryKey) != 0 {
+		return table.PrimaryKey
 	}
 
 	// If there is no primary key, look for a unique not null column

--- a/pkg/migrations/op_alter_column_test.go
+++ b/pkg/migrations/op_alter_column_test.go
@@ -508,6 +508,175 @@ func TestAlterColumnMultipleSubOperations(t *testing.T) {
 	})
 }
 
+func TestAlterPrimaryKeyColumns(t *testing.T) {
+	t.Parallel()
+
+	ExecuteTests(t, TestCases{
+		{
+			name: "alter a single primary key column",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_create_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "people",
+							Columns: []migrations.Column{
+								{
+									Name: "id",
+									Type: "int",
+									Pk:   true,
+								},
+								{
+									Name:     "name",
+									Type:     "varchar(255)",
+									Nullable: true,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_alter_column",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:  "people",
+							Column: "id",
+							Type:   ptr("bigint"),
+							Up:     "CAST(id AS bigint)",
+							Down:   "SELECT CASE WHEN id < 2147483647 THEN CAST(id AS int) ELSE 0 END",
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
+				PrimaryKeyConstraintMustExist(t, db, schema, "people", "people_pkey")
+				ColumnMustBePK(t, db, schema, "people", "id")
+
+				bigint := "31474836471" // A value larger than int can hold
+				integer := "100"
+
+				// Inserting a row with integer id into the old schema should succeed
+				MustInsert(t, db, schema, "01_create_table", "people", map[string]string{
+					"id":   integer,
+					"name": "alice",
+				})
+				// Inserting a row with integer bigint id into the old schema should fail
+				MustNotInsert(t, db, schema, "01_create_table", "people", map[string]string{
+					"id":   bigint,
+					"name": "alice",
+				}, testutils.NumericValueOutOfRangeErrorCode)
+
+				// Inserting a row with bigint id into the new schema should succeed
+				MustInsert(t, db, schema, "02_alter_column", "people", map[string]string{
+					"id":   bigint,
+					"name": "alice",
+				})
+			},
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
+				PrimaryKeyConstraintMustExist(t, db, schema, "people", "people_pkey")
+				ColumnMustBePK(t, db, schema, "people", "id")
+			},
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+				PrimaryKeyConstraintMustExist(t, db, schema, "people", "people_pkey")
+				ColumnMustBePK(t, db, schema, "people", "id")
+
+				// Inserting a row with integer bigint into the new schema should succeed
+				MustInsert(t, db, schema, "02_alter_column", "people", map[string]string{
+					"id":   "31474836472",
+					"name": "bob",
+				})
+			},
+		},
+		{
+			name: "alter a composite primary key: one column changes type, the other is unchanged",
+			migrations: []migrations.Migration{
+				{
+					Name: "01_create_table",
+					Operations: migrations.Operations{
+						&migrations.OpCreateTable{
+							Name: "people",
+							Columns: []migrations.Column{
+								{
+									Name: "id1",
+									Type: "int",
+									Pk:   true,
+								},
+								{
+									Name: "id2",
+									Type: "int",
+									Pk:   true,
+								},
+								{
+									Name:     "name",
+									Type:     "varchar(255)",
+									Nullable: true,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "02_alter_column",
+					Operations: migrations.Operations{
+						&migrations.OpAlterColumn{
+							Table:  "people",
+							Column: "id1",
+							Type:   ptr("bigint"),
+							Up:     "CAST(id1 AS bigint)",
+							Down:   "SELECT CASE WHEN id1 < 2147483647 THEN CAST(id1 AS int) ELSE 0 END",
+						},
+					},
+				},
+			},
+			afterStart: func(t *testing.T, db *sql.DB, schema string) {
+				PrimaryKeyConstraintMustExist(t, db, schema, "people", "people_pkey")
+				ColumnMustBePK(t, db, schema, "people", "id1")
+				ColumnMustBePK(t, db, schema, "people", "id2")
+
+				bigint := "31474836471" // A value larger than int can hold
+				integer := "100"
+
+				// Inserting a row with integer id into the old schema should succeed
+				MustInsert(t, db, schema, "01_create_table", "people", map[string]string{
+					"id1":  integer,
+					"id2":  integer,
+					"name": "alice",
+				})
+				// Inserting a row with integer bigint id into the old schema should fail
+				MustNotInsert(t, db, schema, "01_create_table", "people", map[string]string{
+					"id1":  bigint,
+					"id2":  integer,
+					"name": "alice",
+				}, testutils.NumericValueOutOfRangeErrorCode)
+
+				// Inserting a row with bigint id into the new schema should succeed
+				MustInsert(t, db, schema, "02_alter_column", "people", map[string]string{
+					"id1":  bigint,
+					"id2":  integer,
+					"name": "alice",
+				})
+			},
+			afterRollback: func(t *testing.T, db *sql.DB, schema string) {
+				PrimaryKeyConstraintMustExist(t, db, schema, "people", "people_pkey")
+				ColumnMustBePK(t, db, schema, "people", "id1")
+				ColumnMustBePK(t, db, schema, "people", "id2")
+			},
+			afterComplete: func(t *testing.T, db *sql.DB, schema string) {
+				PrimaryKeyConstraintMustExist(t, db, schema, "people", "people_pkey")
+				ColumnMustBePK(t, db, schema, "people", "id1")
+				ColumnMustBePK(t, db, schema, "people", "id2")
+
+				// Inserting a row with integer bigint into the new schema should succeed
+				MustInsert(t, db, schema, "02_alter_column", "people", map[string]string{
+					"id1":  "31474836472",
+					"id2":  "72",
+					"name": "bob",
+				})
+			},
+		},
+	})
+}
+
 func TestAlterColumnValidation(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/migrations/rename.go
+++ b/pkg/migrations/rename.go
@@ -130,5 +130,16 @@ func (a *renameDuplicatedColumnAction) Execute(ctx context.Context) error {
 		}
 	}
 
+	if slices.Contains(a.table.PrimaryKey, a.to) {
+		err := NewAddPrimaryKeyAction(a.conn, a.table.Name, primaryKeyName(a.table.Name)).Execute(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to re-add primary key constraint: %w", err)
+		}
+	}
+
 	return nil
+}
+
+func primaryKeyName(tableName string) string {
+	return fmt.Sprintf("%s_pkey", tableName)
 }


### PR DESCRIPTION
In the past `pgroll` could not preserve primary key constraint on altered columns. Instead the primary key constraint was down-graded to a unique, not null constraint. Now the PK constraint is not removed during completing the migration.

Futhermore, if the table had rows, `pgroll` could not backfill rows. `pgroll` "updates" the primary keys of the backfilled table to trigger backfilling existing columns. Previously, finding the identity columns returned the duplicated column `__pgroll_new_id` instead of the correct `id`. In this case we need the current PK, so we can copy the correct values to the new column.

I opened follow-up issue to support altering mutiple columns of the same composite key in the same migration: https://github.com/xataio/pgroll/pull/930

Support for alter PK columns that are part of FK constraints is in a follow-up PR: https://github.com/xataio/pgroll/pull/935

Closes #888
