### PR TITLE
Rename `pgroll.internal` GUC to `pgroll.no_inferred_migrations`

### DIFF
--- a/pkg/roll/roll.go
+++ b/pkg/roll/roll.go
@@ -101,9 +101,9 @@ func setupConn(ctx context.Context, pgURL, schema string, options options) (*sql
 		return nil, err
 	}
 
-	_, err = conn.ExecContext(ctx, "SET pgroll.internal TO 'TRUE'")
+	_, err = conn.ExecContext(ctx, "SET pgroll.no_inferred_migrations TO 'TRUE'")
 	if err != nil {
-		return nil, fmt.Errorf("unable to set pgroll.internal to true: %w", err)
+		return nil, fmt.Errorf("unable to set pgroll.no_inferred_migrations to true: %w", err)
 	}
 
 	if options.lockTimeoutMs > 0 {

--- a/pkg/state/init.sql
+++ b/pkg/state/init.sql
@@ -370,7 +370,7 @@ DECLARE
     migration_id text;
 BEGIN
     -- Ignore schema changes made by pgroll
-    IF (pg_catalog.current_setting('pgroll.internal', TRUE) = 'TRUE') THEN
+    IF (pg_catalog.current_setting('pgroll.no_inferred_migrations', TRUE) = 'TRUE') THEN
         RETURN;
     END IF;
     IF tg_event = 'sql_drop' AND tg_tag = 'DROP SCHEMA' THEN

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -47,9 +47,9 @@ func New(ctx context.Context, pgURL, stateSchema string, opts ...StateOpt) (*Sta
 		return nil, err
 	}
 
-	_, err = conn.ExecContext(ctx, "SET pgroll.internal TO 'TRUE'")
+	_, err = conn.ExecContext(ctx, "SET pgroll.no_inferred_migrations TO 'TRUE'")
 	if err != nil {
-		return nil, fmt.Errorf("unable to set pgroll.internal to true: %w", err)
+		return nil, fmt.Errorf("unable to set pgroll.no_inferred_migrations to true: %w", err)
 	}
 
 	st := &State{


### PR DESCRIPTION
Rename the GUC that causes `pgroll` to ignore schema changes made by itself (ie don't create `inferred` migrations for them).

The new name better reflects its purpose, and allows us to document it externally as a way for other applications to have their own DDL ignored by `pgroll`.