### PR TITLE
Remove unnecessary param from `Start` function

### DIFF
--- a/pkg/backfill/backfill.go
+++ b/pkg/backfill/backfill.go
@@ -58,10 +58,13 @@ func NewJob(schemaName, latestSchema string) *Job {
 	}
 }
 
+<<<<<<< HEAD
 func (t *Task) AddTriggers(other *Task) {
 	t.triggers = append(t.triggers, other.triggers...)
 }
 
+=======
+>>>>>>> 204e7f6b (Add trigger configuration to `backfill.Task` && consolidate triggers per)
 func (j *Job) AddTask(t *Task) {
 	if t.table != nil {
 		j.Tables = append(j.Tables, t.table)
@@ -69,6 +72,7 @@ func (j *Job) AddTask(t *Task) {
 
 	for _, trigger := range t.triggers {
 		if tg, exists := j.triggers[trigger.Name]; exists {
+<<<<<<< HEAD
 			// If the trigger already exists, append the SQL to the existing trigger config
 			// The rewriting is necessary to ensure that the expression uses the NEW prefix with the physical column name
 			// For example, if the user sets the following expression in their second operation:
@@ -80,6 +84,11 @@ func (j *Job) AddTask(t *Task) {
 		} else {
 			// If the trigger does not exist, create a new trigger config
 			// No need to rewrite the SQL here, as it is the first time we are adding it.
+=======
+			tg.SQL = append(tg.SQL, rewriteTriggerSQL(trigger.SQL, findColumnName(tg.Columns, tg.PhysicalColumn), tg.PhysicalColumn))
+			j.triggers[trigger.Name] = tg
+		} else {
+>>>>>>> 204e7f6b (Add trigger configuration to `backfill.Task` && consolidate triggers per)
 			j.triggers[trigger.Name] = triggerConfig{
 				Name:                trigger.Name,
 				Direction:           trigger.Direction,
@@ -95,17 +104,23 @@ func (j *Job) AddTask(t *Task) {
 	}
 }
 
+<<<<<<< HEAD
 // rewriteTriggerSQL rewrites the SQL migrations expression provided by the user
 // in the up or down attribute of the operations config.
 // The column name are turned from user defined names the physical column name with NEW prefix.
 // This is only needed, If there is already an backfilling step in the trigger SQL.
+=======
+>>>>>>> 204e7f6b (Add trigger configuration to `backfill.Task` && consolidate triggers per)
 func rewriteTriggerSQL(sql string, from, to string) string {
 	return strings.ReplaceAll(sql, from, fmt.Sprintf("NEW.%s", pq.QuoteIdentifier(to)))
 }
 
+<<<<<<< HEAD
 // findColumnName returns the original, user defined column name from the map of columns
 // for the provided physical column name.
 // __pgroll_new_name -> name
+=======
+>>>>>>> 204e7f6b (Add trigger configuration to `backfill.Task` && consolidate triggers per)
 func findColumnName(columns map[string]*schema.Column, columnName string) string {
 	for name, col := range columns {
 		if col.Name == columnName {

--- a/pkg/backfill/backfill.go
+++ b/pkg/backfill/backfill.go
@@ -58,13 +58,10 @@ func NewJob(schemaName, latestSchema string) *Job {
 	}
 }
 
-<<<<<<< HEAD
 func (t *Task) AddTriggers(other *Task) {
 	t.triggers = append(t.triggers, other.triggers...)
 }
 
-=======
->>>>>>> 204e7f6b (Add trigger configuration to `backfill.Task` && consolidate triggers per)
 func (j *Job) AddTask(t *Task) {
 	if t.table != nil {
 		j.Tables = append(j.Tables, t.table)
@@ -72,7 +69,6 @@ func (j *Job) AddTask(t *Task) {
 
 	for _, trigger := range t.triggers {
 		if tg, exists := j.triggers[trigger.Name]; exists {
-<<<<<<< HEAD
 			// If the trigger already exists, append the SQL to the existing trigger config
 			// The rewriting is necessary to ensure that the expression uses the NEW prefix with the physical column name
 			// For example, if the user sets the following expression in their second operation:
@@ -84,11 +80,6 @@ func (j *Job) AddTask(t *Task) {
 		} else {
 			// If the trigger does not exist, create a new trigger config
 			// No need to rewrite the SQL here, as it is the first time we are adding it.
-=======
-			tg.SQL = append(tg.SQL, rewriteTriggerSQL(trigger.SQL, findColumnName(tg.Columns, tg.PhysicalColumn), tg.PhysicalColumn))
-			j.triggers[trigger.Name] = tg
-		} else {
->>>>>>> 204e7f6b (Add trigger configuration to `backfill.Task` && consolidate triggers per)
 			j.triggers[trigger.Name] = triggerConfig{
 				Name:                trigger.Name,
 				Direction:           trigger.Direction,
@@ -104,23 +95,17 @@ func (j *Job) AddTask(t *Task) {
 	}
 }
 
-<<<<<<< HEAD
 // rewriteTriggerSQL rewrites the SQL migrations expression provided by the user
 // in the up or down attribute of the operations config.
 // The column name are turned from user defined names the physical column name with NEW prefix.
 // This is only needed, If there is already an backfilling step in the trigger SQL.
-=======
->>>>>>> 204e7f6b (Add trigger configuration to `backfill.Task` && consolidate triggers per)
 func rewriteTriggerSQL(sql string, from, to string) string {
 	return strings.ReplaceAll(sql, from, fmt.Sprintf("NEW.%s", pq.QuoteIdentifier(to)))
 }
 
-<<<<<<< HEAD
 // findColumnName returns the original, user defined column name from the map of columns
 // for the provided physical column name.
 // __pgroll_new_name -> name
-=======
->>>>>>> 204e7f6b (Add trigger configuration to `backfill.Task` && consolidate triggers per)
 func findColumnName(columns map[string]*schema.Column, columnName string) string {
 	for name, col := range columns {
 		if col.Name == columnName {

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -20,7 +20,7 @@ type Operation interface {
 	// version in the database (through a view)
 	// update the given views to expose the new schema version
 	// Returns the table that requires backfilling, if any.
-	Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error)
+	Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error)
 
 	// Complete will update the database schema to match the current version
 	// after calling Start.
@@ -118,7 +118,7 @@ func (m *Migration) UpdateVirtualSchema(ctx context.Context, s *schema.Schema) e
 	// Run `Start` on each operation using the fake DB. Updates will be made to
 	// the in-memory schema `s` without touching the physical database.
 	for _, op := range m.Operations {
-		if _, err := op.Start(ctx, NewNoopLogger(), db, "", s); err != nil {
+		if _, err := op.Start(ctx, NewNoopLogger(), db, s); err != nil {
 			return err
 		}
 	}

--- a/pkg/migrations/op_add_column.go
+++ b/pkg/migrations/op_add_column.go
@@ -19,7 +19,7 @@ var (
 	_ Createable = (*OpAddColumn)(nil)
 )
 
-func (o *OpAddColumn) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpAddColumn) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)

--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -18,7 +18,7 @@ var (
 	_ Createable = (*OpAlterColumn)(nil)
 )
 
-func (o *OpAlterColumn) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpAlterColumn) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
@@ -81,7 +81,7 @@ func (o *OpAlterColumn) Start(ctx context.Context, l Logger, conn db.DB, latestS
 	task := backfill.NewTask(table, triggers...)
 	// perform any operation specific start steps
 	for _, op := range ops {
-		bf, err := op.Start(ctx, l, conn, latestSchema, s)
+		bf, err := op.Start(ctx, l, conn, s)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/migrations/op_change_type.go
+++ b/pkg/migrations/op_change_type.go
@@ -20,7 +20,7 @@ type OpChangeType struct {
 
 var _ Operation = (*OpChangeType)(nil)
 
-func (o *OpChangeType) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpChangeType) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)

--- a/pkg/migrations/op_create_constraint.go
+++ b/pkg/migrations/op_create_constraint.go
@@ -16,7 +16,7 @@ var (
 	_ Createable = (*OpCreateConstraint)(nil)
 )
 
-func (o *OpCreateConstraint) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpCreateConstraint) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)

--- a/pkg/migrations/op_create_index.go
+++ b/pkg/migrations/op_create_index.go
@@ -18,7 +18,7 @@ var (
 	_ Createable = (*OpCreateIndex)(nil)
 )
 
-func (o *OpCreateIndex) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpCreateIndex) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)

--- a/pkg/migrations/op_create_table.go
+++ b/pkg/migrations/op_create_table.go
@@ -18,7 +18,7 @@ var (
 	_ Createable = (*OpCreateTable)(nil)
 )
 
-func (o *OpCreateTable) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpCreateTable) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	// Generate SQL for the columns in the table

--- a/pkg/migrations/op_drop_column.go
+++ b/pkg/migrations/op_drop_column.go
@@ -15,7 +15,7 @@ var (
 	_ Createable = (*OpDropColumn)(nil)
 )
 
-func (o *OpDropColumn) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpDropColumn) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	var task *backfill.Task

--- a/pkg/migrations/op_drop_constraint.go
+++ b/pkg/migrations/op_drop_constraint.go
@@ -15,7 +15,7 @@ import (
 
 var _ Operation = (*OpDropConstraint)(nil)
 
-func (o *OpDropConstraint) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpDropConstraint) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)

--- a/pkg/migrations/op_drop_index.go
+++ b/pkg/migrations/op_drop_index.go
@@ -15,7 +15,7 @@ var (
 	_ Createable = (*OpDropIndex)(nil)
 )
 
-func (o *OpDropIndex) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpDropIndex) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	// no-op

--- a/pkg/migrations/op_drop_multicolumn_constraint.go
+++ b/pkg/migrations/op_drop_multicolumn_constraint.go
@@ -19,7 +19,7 @@ var (
 	_ Createable = (*OpDropMultiColumnConstraint)(nil)
 )
 
-func (o *OpDropMultiColumnConstraint) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpDropMultiColumnConstraint) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)

--- a/pkg/migrations/op_drop_not_null.go
+++ b/pkg/migrations/op_drop_not_null.go
@@ -20,7 +20,7 @@ type OpDropNotNull struct {
 
 var _ Operation = (*OpDropNotNull)(nil)
 
-func (o *OpDropNotNull) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpDropNotNull) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)

--- a/pkg/migrations/op_drop_table.go
+++ b/pkg/migrations/op_drop_table.go
@@ -16,7 +16,7 @@ var (
 	_ Createable = (*OpDropTable)(nil)
 )
 
-func (o *OpDropTable) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpDropTable) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Name)

--- a/pkg/migrations/op_raw_sql.go
+++ b/pkg/migrations/op_raw_sql.go
@@ -15,7 +15,7 @@ var (
 	_ Createable = (*OpRawSQL)(nil)
 )
 
-func (o *OpRawSQL) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpRawSQL) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	if o.OnComplete {

--- a/pkg/migrations/op_rename_column.go
+++ b/pkg/migrations/op_rename_column.go
@@ -12,7 +12,7 @@ import (
 
 var _ Operation = (*OpRenameColumn)(nil)
 
-func (o *OpRenameColumn) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpRenameColumn) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	// Rename the table in the in-memory schema.

--- a/pkg/migrations/op_rename_constraint.go
+++ b/pkg/migrations/op_rename_constraint.go
@@ -12,7 +12,7 @@ import (
 
 var _ Operation = (*OpRenameConstraint)(nil)
 
-func (o *OpRenameConstraint) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpRenameConstraint) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	// no-op

--- a/pkg/migrations/op_rename_table.go
+++ b/pkg/migrations/op_rename_table.go
@@ -12,7 +12,7 @@ import (
 
 var _ Operation = (*OpRenameTable)(nil)
 
-func (o *OpRenameTable) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpRenameTable) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	return nil, s.RenameTable(o.From, o.To)

--- a/pkg/migrations/op_set_check.go
+++ b/pkg/migrations/op_set_check.go
@@ -21,7 +21,7 @@ type OpSetCheckConstraint struct {
 
 var _ Operation = (*OpSetCheckConstraint)(nil)
 
-func (o *OpSetCheckConstraint) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpSetCheckConstraint) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)

--- a/pkg/migrations/op_set_comment.go
+++ b/pkg/migrations/op_set_comment.go
@@ -21,7 +21,7 @@ type OpSetComment struct {
 
 var _ Operation = (*OpSetComment)(nil)
 
-func (o *OpSetComment) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpSetComment) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	tbl := s.GetTable(o.Table)

--- a/pkg/migrations/op_set_default.go
+++ b/pkg/migrations/op_set_default.go
@@ -20,7 +20,7 @@ type OpSetDefault struct {
 
 var _ Operation = (*OpSetDefault)(nil)
 
-func (o *OpSetDefault) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpSetDefault) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)

--- a/pkg/migrations/op_set_fk.go
+++ b/pkg/migrations/op_set_fk.go
@@ -21,7 +21,7 @@ type OpSetForeignKey struct {
 
 var _ Operation = (*OpSetForeignKey)(nil)
 
-func (o *OpSetForeignKey) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpSetForeignKey) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)

--- a/pkg/migrations/op_set_notnull.go
+++ b/pkg/migrations/op_set_notnull.go
@@ -20,7 +20,7 @@ type OpSetNotNull struct {
 
 var _ Operation = (*OpSetNotNull)(nil)
 
-func (o *OpSetNotNull) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpSetNotNull) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)

--- a/pkg/migrations/op_set_replica_identity.go
+++ b/pkg/migrations/op_set_replica_identity.go
@@ -14,7 +14,7 @@ import (
 
 var _ Operation = (*OpSetReplicaIdentity)(nil)
 
-func (o *OpSetReplicaIdentity) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpSetReplicaIdentity) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	return nil, NewSetReplicaIdentityAction(conn, o.Table, o.Identity.Type, o.Identity.Index).Execute(ctx)

--- a/pkg/migrations/op_set_unique.go
+++ b/pkg/migrations/op_set_unique.go
@@ -20,7 +20,7 @@ type OpSetUnique struct {
 
 var _ Operation = (*OpSetUnique)(nil)
 
-func (o *OpSetUnique) Start(ctx context.Context, l Logger, conn db.DB, latestSchema string, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpSetUnique) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)

--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -101,7 +101,7 @@ func (m *Roll) StartDDLOperations(ctx context.Context, migration *migrations.Mig
 	// execute operations
 	job := backfill.NewJob(m.schema, versionSchemaName)
 	for _, op := range migration.Operations {
-		task, err := op.Start(ctx, m.logger, m.pgConn, versionSchemaName, newSchema)
+		task, err := op.Start(ctx, m.logger, m.pgConn, newSchema)
 		if err != nil {
 			errRollback := m.Rollback(ctx)
 			if errRollback != nil {


### PR DESCRIPTION
`latestSchema` is no longer needed in the `Start` function of operations.

Requires #931 