### PR TITLE
Turn `Duplicator` into a `DBAction`

### DIFF
--- a/pkg/migrations/duplicate.go
+++ b/pkg/migrations/duplicate.go
@@ -14,9 +14,9 @@ import (
 	"github.com/xataio/pgroll/pkg/schema"
 )
 
-// Duplicator duplicates a column in a table, including all constraints and
+// duplicator duplicates a column in a table, including all constraints and
 // comments.
-type Duplicator struct {
+type duplicator struct {
 	stmtBuilder       *duplicatorStmtBuilder
 	conn              db.DB
 	columns           map[string]*columnToDuplicate
@@ -42,7 +42,7 @@ const (
 )
 
 // NewColumnDuplicator creates a new Duplicator for a column.
-func NewColumnDuplicator(conn db.DB, table *schema.Table, columns ...*schema.Column) *Duplicator {
+func NewColumnDuplicator(conn db.DB, table *schema.Table, columns ...*schema.Column) *duplicator {
 	cols := make(map[string]*columnToDuplicate, len(columns))
 	for _, column := range columns {
 		cols[column.Name] = &columnToDuplicate{
@@ -51,7 +51,7 @@ func NewColumnDuplicator(conn db.DB, table *schema.Table, columns ...*schema.Col
 			withType: column.Type,
 		}
 	}
-	return &Duplicator{
+	return &duplicator{
 		stmtBuilder: &duplicatorStmtBuilder{
 			table: table,
 		},
@@ -62,32 +62,32 @@ func NewColumnDuplicator(conn db.DB, table *schema.Table, columns ...*schema.Col
 }
 
 // WithType sets the type of the new column.
-func (d *Duplicator) WithType(columnName, t string) *Duplicator {
+func (d *duplicator) WithType(columnName, t string) *duplicator {
 	d.columns[columnName].withType = t
 	return d
 }
 
 // WithoutConstraint excludes a constraint from being duplicated.
-func (d *Duplicator) WithoutConstraint(c string) *Duplicator {
+func (d *duplicator) WithoutConstraint(c string) *duplicator {
 	d.withoutConstraint = append(d.withoutConstraint, c)
 	return d
 }
 
 // WithoutNotNull excludes the NOT NULL constraint from being duplicated.
-func (d *Duplicator) WithoutNotNull(columnName string) *Duplicator {
+func (d *duplicator) WithoutNotNull(columnName string) *duplicator {
 	d.columns[columnName].withoutNotNull = true
 	return d
 }
 
 // WithName sets the name of the new column.
-func (d *Duplicator) WithName(columnName, asName string) *Duplicator {
+func (d *duplicator) WithName(columnName, asName string) *duplicator {
 	d.columns[columnName].asName = asName
 	return d
 }
 
 // Duplicate duplicates a column in the table, including all constraints and
 // comments.
-func (d *Duplicator) Duplicate(ctx context.Context) error {
+func (d *duplicator) Execute(ctx context.Context) error {
 	colNames := make([]string, 0, len(d.columns))
 	for name, c := range d.columns {
 		colNames = append(colNames, name)

--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -34,7 +34,7 @@ func (o *OpAlterColumn) Start(ctx context.Context, l Logger, conn db.DB, latestS
 	// Duplicate the column on the underlying table.
 	d := duplicatorForOperations(ops, conn, table, column).
 		WithName(column.Name, TemporaryName(o.Column))
-	if err := d.Duplicate(ctx); err != nil {
+	if err := d.Execute(ctx); err != nil {
 		return nil, fmt.Errorf("failed to duplicate column: %w", err)
 	}
 
@@ -283,7 +283,7 @@ func (o *OpAlterColumn) subOperations() []Operation {
 }
 
 // duplicatorForOperations returns a Duplicator for the given operations
-func duplicatorForOperations(ops []Operation, conn db.DB, table *schema.Table, column *schema.Column) *Duplicator {
+func duplicatorForOperations(ops []Operation, conn db.DB, table *schema.Table, column *schema.Column) *duplicator {
 	d := NewColumnDuplicator(conn, table, column)
 
 	for _, op := range ops {

--- a/pkg/migrations/op_create_constraint.go
+++ b/pkg/migrations/op_create_constraint.go
@@ -37,7 +37,7 @@ func (o *OpCreateConstraint) Start(ctx context.Context, l Logger, conn db.DB, la
 	for _, colName := range o.Columns {
 		d = d.WithName(table.GetColumn(colName).Name, TemporaryName(colName))
 	}
-	if err := d.Duplicate(ctx); err != nil {
+	if err := d.Execute(ctx); err != nil {
 		return nil, fmt.Errorf("failed to duplicate columns for new constraint: %w", err)
 	}
 

--- a/pkg/migrations/op_drop_constraint.go
+++ b/pkg/migrations/op_drop_constraint.go
@@ -32,7 +32,7 @@ func (o *OpDropConstraint) Start(ctx context.Context, l Logger, conn db.DB, late
 
 	// Create a copy of the column on the underlying table.
 	d := NewColumnDuplicator(conn, table, column).WithoutConstraint(o.Name)
-	if err := d.Duplicate(ctx); err != nil {
+	if err := d.Execute(ctx); err != nil {
 		return nil, fmt.Errorf("failed to duplicate column: %w", err)
 	}
 

--- a/pkg/migrations/op_drop_multicolumn_constraint.go
+++ b/pkg/migrations/op_drop_multicolumn_constraint.go
@@ -44,7 +44,7 @@ func (o *OpDropMultiColumnConstraint) Start(ctx context.Context, l Logger, conn 
 	for _, colName := range constraintColumns {
 		d = d.WithName(table.GetColumn(colName).Name, TemporaryName(colName))
 	}
-	if err := d.Duplicate(ctx); err != nil {
+	if err := d.Execute(ctx); err != nil {
 		return nil, fmt.Errorf("failed to duplicate column: %w", err)
 	}
 


### PR DESCRIPTION
This PR renames `Duplicate` to `Execute`, so `Duplicator` can be used as a `DBAction`.

Relates to #742
