### PR TITLE
Return list of `DBAction` from `Start`

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -16,11 +16,11 @@ import (
 
 // Operation is an operation that can be applied to a schema
 type Operation interface {
-	// Start will apply the required changes to enable supporting the new schema
+	// Start will return the list of required changes to enable supporting the new schema
 	// version in the database (through a view)
 	// update the given views to expose the new schema version
 	// Returns the table that requires backfilling, if any.
-	Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error)
+	Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) ([]DBAction, *backfill.Task, error)
 
 	// Complete will update the database schema to match the current version
 	// after calling Start.
@@ -118,7 +118,7 @@ func (m *Migration) UpdateVirtualSchema(ctx context.Context, s *schema.Schema) e
 	// Run `Start` on each operation using the fake DB. Updates will be made to
 	// the in-memory schema `s` without touching the physical database.
 	for _, op := range m.Operations {
-		if _, err := op.Start(ctx, NewNoopLogger(), db, s); err != nil {
+		if _, _, err := op.Start(ctx, NewNoopLogger(), db, s); err != nil {
 			return err
 		}
 	}

--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -18,16 +18,16 @@ var (
 	_ Createable = (*OpAlterColumn)(nil)
 )
 
-func (o *OpAlterColumn) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpAlterColumn) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) ([]DBAction, *backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
 	if table == nil {
-		return nil, TableDoesNotExistError{Name: o.Table}
+		return nil, nil, TableDoesNotExistError{Name: o.Table}
 	}
 	column := table.GetColumn(o.Column)
 	if column == nil {
-		return nil, ColumnDoesNotExistError{Table: o.Table, Name: o.Column}
+		return nil, nil, ColumnDoesNotExistError{Table: o.Table, Name: o.Column}
 	}
 	ops := o.subOperations()
 
@@ -35,7 +35,7 @@ func (o *OpAlterColumn) Start(ctx context.Context, l Logger, conn db.DB, s *sche
 	d := duplicatorForOperations(ops, conn, table, column).
 		WithName(column.Name, TemporaryName(o.Column))
 	if err := d.Execute(ctx); err != nil {
-		return nil, fmt.Errorf("failed to duplicate column: %w", err)
+		return nil, nil, fmt.Errorf("failed to duplicate column: %w", err)
 	}
 
 	// Copy the columns from table columns, so we can use it later
@@ -79,16 +79,19 @@ func (o *OpAlterColumn) Start(ctx context.Context, l Logger, conn db.DB, s *sche
 		},
 	)
 	task := backfill.NewTask(table, triggers...)
+
+	dbActions := make([]DBAction, 0)
 	// perform any operation specific start steps
 	for _, op := range ops {
-		bf, err := op.Start(ctx, l, conn, s)
+		actions, bf, err := op.Start(ctx, l, conn, s)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		task.AddTriggers(bf)
+		dbActions = append(dbActions, actions...)
 	}
 
-	return task, nil
+	return dbActions, task, nil
 }
 
 func (o *OpAlterColumn) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {

--- a/pkg/migrations/op_alter_column.go
+++ b/pkg/migrations/op_alter_column.go
@@ -80,7 +80,7 @@ func (o *OpAlterColumn) Start(ctx context.Context, l Logger, conn db.DB, s *sche
 	)
 	task := backfill.NewTask(table, triggers...)
 
-	dbActions := make([]DBAction, 0)
+	var dbActions []DBAction
 	// perform any operation specific start steps
 	for _, op := range ops {
 		actions, bf, err := op.Start(ctx, l, conn, s)

--- a/pkg/migrations/op_change_type.go
+++ b/pkg/migrations/op_change_type.go
@@ -20,15 +20,15 @@ type OpChangeType struct {
 
 var _ Operation = (*OpChangeType)(nil)
 
-func (o *OpChangeType) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpChangeType) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) ([]DBAction, *backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
 	if table == nil {
-		return nil, TableDoesNotExistError{Name: o.Table}
+		return nil, nil, TableDoesNotExistError{Name: o.Table}
 	}
 
-	return backfill.NewTask(table), nil
+	return nil, backfill.NewTask(table), nil
 }
 
 func (o *OpChangeType) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {

--- a/pkg/migrations/op_drop_column.go
+++ b/pkg/migrations/op_drop_column.go
@@ -15,7 +15,7 @@ var (
 	_ Createable = (*OpDropColumn)(nil)
 )
 
-func (o *OpDropColumn) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpDropColumn) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) ([]DBAction, *backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	var task *backfill.Task
@@ -34,16 +34,16 @@ func (o *OpDropColumn) Start(ctx context.Context, l Logger, conn db.DB, s *schem
 
 	table := s.GetTable(o.Table)
 	if table == nil {
-		return nil, TableDoesNotExistError{Name: o.Table}
+		return nil, nil, TableDoesNotExistError{Name: o.Table}
 	}
 	column := table.GetColumn(o.Column)
 	if column == nil {
-		return nil, ColumnDoesNotExistError{Table: o.Table, Name: o.Column}
+		return nil, nil, ColumnDoesNotExistError{Table: o.Table, Name: o.Column}
 	}
 
 	s.GetTable(o.Table).RemoveColumn(o.Column)
 
-	return task, nil
+	return nil, task, nil
 }
 
 func (o *OpDropColumn) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {

--- a/pkg/migrations/op_drop_index.go
+++ b/pkg/migrations/op_drop_index.go
@@ -15,11 +15,11 @@ var (
 	_ Createable = (*OpDropIndex)(nil)
 )
 
-func (o *OpDropIndex) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpDropIndex) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) ([]DBAction, *backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	// no-op
-	return nil, nil
+	return nil, nil, nil
 }
 
 func (o *OpDropIndex) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {

--- a/pkg/migrations/op_drop_not_null.go
+++ b/pkg/migrations/op_drop_not_null.go
@@ -20,15 +20,15 @@ type OpDropNotNull struct {
 
 var _ Operation = (*OpDropNotNull)(nil)
 
-func (o *OpDropNotNull) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpDropNotNull) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) ([]DBAction, *backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	table := s.GetTable(o.Table)
 	if table == nil {
-		return nil, TableDoesNotExistError{Name: o.Table}
+		return nil, nil, TableDoesNotExistError{Name: o.Table}
 	}
 
-	return backfill.NewTask(table), nil
+	return nil, backfill.NewTask(table), nil
 }
 
 func (o *OpDropNotNull) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {

--- a/pkg/migrations/op_raw_sql.go
+++ b/pkg/migrations/op_raw_sql.go
@@ -15,14 +15,14 @@ var (
 	_ Createable = (*OpRawSQL)(nil)
 )
 
-func (o *OpRawSQL) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpRawSQL) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) ([]DBAction, *backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	if o.OnComplete {
-		return nil, nil
+		return nil, nil, nil
 	}
 
-	return nil, NewRawSQLAction(conn, o.Up).Execute(ctx)
+	return []DBAction{NewRawSQLAction(conn, o.Up)}, nil, nil
 }
 
 func (o *OpRawSQL) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {

--- a/pkg/migrations/op_rename_column.go
+++ b/pkg/migrations/op_rename_column.go
@@ -12,17 +12,17 @@ import (
 
 var _ Operation = (*OpRenameColumn)(nil)
 
-func (o *OpRenameColumn) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpRenameColumn) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) ([]DBAction, *backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	// Rename the table in the in-memory schema.
 	table := s.GetTable(o.Table)
 	if table == nil {
-		return nil, TableDoesNotExistError{Name: o.Table}
+		return nil, nil, TableDoesNotExistError{Name: o.Table}
 	}
 	column := table.GetColumn(o.From)
 	if column == nil {
-		return nil, ColumnDoesNotExistError{Table: o.Table, Name: o.From}
+		return nil, nil, ColumnDoesNotExistError{Table: o.Table, Name: o.From}
 	}
 	table.RenameColumn(o.From, o.To)
 
@@ -30,7 +30,7 @@ func (o *OpRenameColumn) Start(ctx context.Context, l Logger, conn db.DB, s *sch
 	// renamed column.
 	table.RenameConstraintColumns(o.From, o.To)
 
-	return nil, nil
+	return nil, nil, nil
 }
 
 func (o *OpRenameColumn) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {

--- a/pkg/migrations/op_rename_constraint.go
+++ b/pkg/migrations/op_rename_constraint.go
@@ -12,11 +12,11 @@ import (
 
 var _ Operation = (*OpRenameConstraint)(nil)
 
-func (o *OpRenameConstraint) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpRenameConstraint) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) ([]DBAction, *backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	// no-op
-	return nil, nil
+	return nil, nil, nil
 }
 
 func (o *OpRenameConstraint) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {

--- a/pkg/migrations/op_rename_table.go
+++ b/pkg/migrations/op_rename_table.go
@@ -12,10 +12,10 @@ import (
 
 var _ Operation = (*OpRenameTable)(nil)
 
-func (o *OpRenameTable) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpRenameTable) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) ([]DBAction, *backfill.Task, error) {
 	l.LogOperationStart(o)
 
-	return nil, s.RenameTable(o.From, o.To)
+	return nil, nil, s.RenameTable(o.From, o.To)
 }
 
 func (o *OpRenameTable) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {

--- a/pkg/migrations/op_set_comment.go
+++ b/pkg/migrations/op_set_comment.go
@@ -21,15 +21,15 @@ type OpSetComment struct {
 
 var _ Operation = (*OpSetComment)(nil)
 
-func (o *OpSetComment) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpSetComment) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) ([]DBAction, *backfill.Task, error) {
 	l.LogOperationStart(o)
 
 	tbl := s.GetTable(o.Table)
 	if tbl == nil {
-		return nil, TableDoesNotExistError{Name: o.Table}
+		return nil, nil, TableDoesNotExistError{Name: o.Table}
 	}
 
-	return backfill.NewTask(tbl), NewCommentColumnAction(conn, o.Table, TemporaryName(o.Column), o.Comment).Execute(ctx)
+	return []DBAction{NewCommentColumnAction(conn, o.Table, TemporaryName(o.Column), o.Comment)}, backfill.NewTask(tbl), nil
 }
 
 func (o *OpSetComment) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {

--- a/pkg/migrations/op_set_replica_identity.go
+++ b/pkg/migrations/op_set_replica_identity.go
@@ -14,10 +14,10 @@ import (
 
 var _ Operation = (*OpSetReplicaIdentity)(nil)
 
-func (o *OpSetReplicaIdentity) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) (*backfill.Task, error) {
+func (o *OpSetReplicaIdentity) Start(ctx context.Context, l Logger, conn db.DB, s *schema.Schema) ([]DBAction, *backfill.Task, error) {
 	l.LogOperationStart(o)
 
-	return nil, NewSetReplicaIdentityAction(conn, o.Table, o.Identity.Type, o.Identity.Index).Execute(ctx)
+	return []DBAction{NewSetReplicaIdentityAction(conn, o.Table, o.Identity.Type, o.Identity.Index)}, nil, nil
 }
 
 func (o *OpSetReplicaIdentity) Complete(l Logger, conn db.DB, s *schema.Schema) ([]DBAction, error) {

--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -101,7 +101,7 @@ func (m *Roll) StartDDLOperations(ctx context.Context, migration *migrations.Mig
 	// execute operations
 	job := backfill.NewJob(m.schema, versionSchemaName)
 	for _, op := range migration.Operations {
-		actions, task, err := op.Start(ctx, m.logger, m.pgConn, newSchema)
+		actions, backfillTask, err := op.Start(ctx, m.logger, m.pgConn, newSchema)
 		if err != nil {
 			return nil, fmt.Errorf("unable to collect actions for start %q migration: %w", migration.Name, err)
 		}
@@ -127,8 +127,8 @@ func (m *Roll) StartDDLOperations(ctx context.Context, migration *migrations.Mig
 				}
 			}
 		}
-		if task != nil {
-			job.AddTask(task)
+		if backfillTask != nil {
+			job.AddTask(backfillTask)
 		}
 	}
 

--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -101,15 +101,20 @@ func (m *Roll) StartDDLOperations(ctx context.Context, migration *migrations.Mig
 	// execute operations
 	job := backfill.NewJob(m.schema, versionSchemaName)
 	for _, op := range migration.Operations {
-		task, err := op.Start(ctx, m.logger, m.pgConn, newSchema)
+		actions, task, err := op.Start(ctx, m.logger, m.pgConn, newSchema)
 		if err != nil {
-			errRollback := m.Rollback(ctx)
-			if errRollback != nil {
-				return nil, errors.Join(
-					fmt.Errorf("unable to execute start operation of %q: %w", migration.Name, err),
-					fmt.Errorf("unable to roll back failed operation: %w", errRollback))
+			return nil, fmt.Errorf("unable to collect actions for start %q migration: %w", migration.Name, err)
+		}
+		for _, action := range actions {
+			if err := action.Execute(ctx); err != nil {
+				errRollback := m.Rollback(ctx)
+				if errRollback != nil {
+					return nil, errors.Join(
+						fmt.Errorf("unable to execute start operation of %q: %w", migration.Name, err),
+						fmt.Errorf("unable to roll back failed operation: %w", errRollback))
+				}
+				return nil, fmt.Errorf("failed to start %q migration, changes rolled back: %w", migration.Name, err)
 			}
-			return nil, fmt.Errorf("failed to start %q migration, changes rolled back: %w", migration.Name, err)
 		}
 		// refresh schema when the op is isolated and requires a refresh (for example raw sql)
 		// we don't want to refresh the schema if the operation is not isolated as it would


### PR DESCRIPTION
This PR returns adds a new return value to `Start` to return the list of `DBActions`. However, returning 3 values is too many, so in a follow-up PR I am combining the list of `DBActions` and `backfill.Task` into the same data structure. The name is pending, my ideas so far `StartStep` or `StartOperation`. If you have a better name, I am open to using them.

New data structure in a follow-up PR:
```golang
type StartOperation struct {
    Actions []DBAction
    Task *backfill.Task
}
```