### PR TITLE
Disable `pgformatter` in `make format`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,11 @@ clean:
 format:
 	# Format JSON schema
 	docker run --rm -v $$PWD/schema.json:/mnt/schema.json node:alpine npx prettier /mnt/schema.json --parser json --tab-width 2 --single-quote --trailing-comma all --no-semi --arrow-parens always --print-width 120 --write
+	#
 	# Format embedded SQL
-	docker run --rm -v $$PWD/pkg/state/init.sql:/data/init.sql backplane/pgformatter --inplace /data/init.sql
+	# Removed because backplane/pgformatter:latest is broken; only latest tag is available so no way to pin to an older version.
+	# docker run --rm -v $$PWD/pkg/state/init.sql:/data/init.sql backplane/pgformatter --inplace /data/init.sql
+	
 	# Run gofumpt
 	gofumpt -w .
 


### PR DESCRIPTION
Temporarily remove the `pgformatter` step from `make format` because the `backplane/pgformatter:latest` image is broken and there is no way to pin to an older version:

Can be reproduced locally:

```bash
docker rmi backplane/pgformatter:latest 
make format

Uncaught exception: Uncaught exception: Uncaught exception: Uncaught exception: Possible precedence problem between ! and string eq at /usr/local/lib/perl5/site_perl/5.42.0/pgFormatter/Beautify.pm line 510.
 at /usr/local/bin/pg_format line 19.
        main::__ANON__("Possible precedence problem between ! and string eq at /usr/l"...) called at /usr/local/lib/perl5/site_perl/5.42.0/pgFormatter/Beautify.pm line 510
        require pgFormatter/Beautify.pm called at /usr/local/lib/perl5/site_perl/5.42.0/pgFormatter/CLI.pm line 26
        pgFormatter::CLI::BEGIN() called at /usr/local/lib/perl5/site_perl/5.42.0/pgFormatter/CLI.pm line 26
        eval {...} called at /usr/local/lib/perl5/site_perl/5.42.0/pgFormatter/CLI.pm line 26
        require pgFormatter/CLI.pm called at /usr/local/bin/pg_format line 45
Compilation failed in require at /usr/local/lib/perl5/site_perl/5.42.0/pgFormatter/CLI.pm line 26.
 at /usr/local/bin/pg_format line 19.
        main::__ANON__("Uncaught exception: Possible precedence problem between ! and"...) called at /usr/local/lib/perl5/site_perl/5.42.0/pgFormatter/CLI.pm line 26
        pgFormatter::CLI::BEGIN() called at /usr/local/lib/perl5/site_perl/5.42.0/pgFormatter/CLI.pm line 26
        eval {...} called at /usr/local/lib/perl5/site_perl/5.42.0/pgFormatter/CLI.pm line 26
        require pgFormatter/CLI.pm called at /usr/local/bin/pg_format line 45
BEGIN failed--compilation aborted at /usr/local/lib/perl5/site_perl/5.42.0/pgFormatter/CLI.pm line 26.
 at /usr/local/bin/pg_format line 19.
        main::__ANON__("Uncaught exception: Uncaught exception: Possible precedence p"...) called at /usr/local/lib/perl5/site_perl/5.42.0/pgFormatter/CLI.pm line 26
        require pgFormatter/CLI.pm called at /usr/local/bin/pg_format line 45
Compilation failed in require at /usr/local/bin/pg_format line 45.
 at /usr/local/bin/pg_format line 19.
        main::__ANON__("Uncaught exception: Uncaught exception: Uncaught exception: P"...) called at /usr/local/bin/pg_format line 45
make: *** [format] Error 2
```