### PR TITLE
Remove the `--with-prefixes` flag from the `pull` command

### DIFF
--- a/cli-definition.json
+++ b/cli-definition.json
@@ -199,12 +199,6 @@
           "shorthand": "j",
           "description": "output each migration in JSON format instead of YAML",
           "default": "false"
-        },
-        {
-          "name": "with-prefixes",
-          "shorthand": "p",
-          "description": "prefix each migration filename with its position in the schema history",
-          "default": "false"
         }
       ],
       "subcommands": [],

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -13,10 +13,9 @@ import (
 
 func pullCmd() *cobra.Command {
 	opts := map[string]string{
-		"p": "prefix each migration filename with its position in the schema history",
 		"j": "output each migration in JSON format instead of YAML",
 	}
-	var withPrefixes, useJSON bool
+	var useJSON bool
 
 	pullCmd := &cobra.Command{
 		Use:       "pull <target directory>",
@@ -47,12 +46,8 @@ func pullCmd() *cobra.Command {
 			}
 
 			// Write the missing migrations to the target directory
-			for i, mig := range migs {
-				prefix := ""
-				if withPrefixes {
-					prefix = fmt.Sprintf("%04d", i+1) + "_"
-				}
-				filePath, err := writeMigrationToFile(mig, targetDir, prefix, useJSON)
+			for _, mig := range migs {
+				filePath, err := writeMigrationToFile(mig, targetDir, "", useJSON)
 				if err != nil {
 					return fmt.Errorf("failed to write migration %q: %w", filePath, err)
 				}
@@ -61,7 +56,6 @@ func pullCmd() *cobra.Command {
 		},
 	}
 
-	pullCmd.Flags().BoolVarP(&withPrefixes, "with-prefixes", "p", false, opts["p"])
 	pullCmd.Flags().BoolVarP(&useJSON, "json", "j", false, opts["j"])
 
 	return pullCmd

--- a/docs/cli/pull.mdx
+++ b/docs/cli/pull.mdx
@@ -25,22 +25,6 @@ $ ls migrations/
 ...
 ```
 
-The command takes an optional `--with-prefixes` flag which will write each filename prefixed with its position in the schema history:
-
-```
-$ ls migrations/
-
-0001_01_create_tables.yaml
-0002_02_create_another_table.yaml
-0003_03_add_column_to_products.yaml
-0004_04_rename_table.yaml
-0005_05_sql.yaml
-0006_06_add_column_to_sql_table.yaml
-...
-```
-
-The `--with-prefixes` flag ensures that files are sorted lexicographically by their time of application.
-
 Use the `--json` flag to pull migrations in JSON format rather than YAML.
 
 If the target directory given to `pgroll pull` does not exist, `pgroll pull` will create it.


### PR DESCRIPTION
Remove the `--with-prefixes` flag from the `pull` command.

The `--with-prefixes` flag was a workaround for inferred migrations not being named in such a way that they would appear in the correct order when pulled. As of https://github.com/xataio/pgroll/pull/899, inferred migrations are named correctly so that `pgroll pull` will put all migrations, including inferred migrations, in the correct order on disk.