### PR TITLE
Improve error message on binary/state mismatch

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -72,7 +72,11 @@ func New(ctx context.Context, pgURL, stateSchema string, opts ...StateOpt) (*Sta
 
 	// If the state schema is newer than the pgroll version, return an error
 	if compat == VersionCompatVersionSchemaNewer {
-		return nil, ErrNewPgrollSchema
+		schemaVersion := "unknown"
+		if v, err := st.SchemaVersion(ctx); err == nil {
+			schemaVersion = v
+		}
+		return nil, fmt.Errorf("%w: binary: %s vs schema: %s", ErrNewPgrollSchema, st.pgrollVersion, schemaVersion)
 	}
 
 	// if the state schema is older than the pgroll version, re-initialize the


### PR DESCRIPTION
Improve the error message when the `pgroll` binary version is older than the state schema version by including both versions in the error message:

Before:
```
Error: pgroll binary version is older than pgroll schema version
```

After:
```
Error: pgroll binary version is older than pgroll schema version: binary: v0.14.0 vs schema: 0.14.1
```