### PR TITLE
fix: handle error from `CreateTriggers` in `performBackfills`

### DIFF
--- a/pkg/roll/execute.go
+++ b/pkg/roll/execute.go
@@ -367,7 +367,9 @@ func (m *Roll) ensureView(ctx context.Context, version, name string, table *sche
 func (m *Roll) performBackfills(ctx context.Context, job *backfill.Job, cfg *backfill.Config) error {
 	bf := backfill.New(m.pgConn, cfg)
 
-	bf.CreateTriggers(ctx, job)
+	if err := bf.CreateTriggers(ctx, job); err != nil {
+		return fmt.Errorf("failed to create triggers: %w", err)
+	}
 
 	for _, table := range job.Tables {
 		m.logger.LogBackfillStart(table.Name)


### PR DESCRIPTION
Hey! This PR propagates errors from `CreateTriggers()` during backfill operations.

I had invalid SQL in the `up` expression (because of TODOs from `pgroll convert`) and got a confusing error along the lines of `unable to backfill table "Foo": pq: column "_pgroll_needs_backfill" does not exist`. This was triggered because the invalid SQL prevented the `_pgroll_needs_backfill` column from being created in `CreateTriggers`, but the error wasn't surfaced.

Thank you for this project!