### PR TITLE
Ignore per-session temp schemas in inferred migrations

### DIFF
--- a/pkg/state/init.sql
+++ b/pkg/state/init.sql
@@ -58,6 +58,14 @@ BEGIN
     IF schemaname IS NULL THEN
         RETURN;
     END IF;
+    -- Ignore DDL on PostgreSQL's per-session temporary schemas. Applications
+    -- creating or dropping temp tables would otherwise accumulate inferred
+    -- migrations on pg_temp/pg_temp_<N> schemas indefinitely.
+    IF schemaname IN ('pg_temp', 'pg_toast_temp')
+        OR schemaname LIKE 'pg_temp_%'
+        OR schemaname LIKE 'pg_toast_temp_%' THEN
+        RETURN;
+    END IF;
     -- Ignore migrations done during a migration period
     IF placeholder.is_active_migration_period (schemaname) THEN
         RETURN;

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -332,6 +332,30 @@ func TestInferredMigrationsHaveExpectedNamesAndVersionSchema(t *testing.T) {
 	})
 }
 
+func TestTempSchemaDDLDoesNotProduceInferredMigrations(t *testing.T) {
+	t.Parallel()
+
+	testutils.WithStateAndConnectionToContainer(t, func(st *state.State, db *sql.DB) {
+		ctx := context.Background()
+
+		// Create and drop a temporary table. Postgres places these in a
+		// per-session pg_temp_<N> schema; the event trigger must ignore them.
+		_, err := db.ExecContext(ctx, "CREATE TEMP TABLE temp_foo(id int)")
+		require.NoError(t, err)
+
+		_, err = db.ExecContext(ctx, "DROP TABLE temp_foo")
+		require.NoError(t, err)
+
+		// No inferred migration rows should have been recorded for any schema.
+		var count int
+		err = db.QueryRowContext(ctx,
+			fmt.Sprintf("SELECT count(*) FROM %s.migrations WHERE migration_type = 'inferred'", st.Schema()),
+		).Scan(&count)
+		require.NoError(t, err)
+		assert.Equal(t, 0, count, "temp-schema DDL should not produce inferred migrations")
+	})
+}
+
 func TestInferredMigrationsInTransactionHaveDifferentTimestamps(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
The `pg_roll_handle_ddl` event trigger in `pkg/state/init.sql` records an inferred row in `pgroll.migrations` for any DDL that happens outside a pgroll-owned connection. It filters pgroll's own sessions via `pgroll.no_inferred_migrations`, but it doesn't exclude PostgreSQL temp schemas.

I have been running pgroll in prod for ~2 months and have 291 inferred rows on `pg_temp` schemas. It's not harmful by any stretch, but is messy.

This PR adds a name-prefix guard in `placeholder.raw_migration()` that filters temp tables and a test.